### PR TITLE
Correct nsgate port redirection

### DIFF
--- a/deploy/docker/build/nsgate/template.writeFunctions.sh
+++ b/deploy/docker/build/nsgate/template.writeFunctions.sh
@@ -13,7 +13,7 @@ server {
     server_name $service-$namespace.__DOMAIN__;
 
     location / {
-        proxy_pass http://$service.$namespace;
+        proxy_pass http://$service.$namespace:$portNumber;
   }
 }
 EOF

--- a/deploy/kubernetes/templates/broker/svc.yml
+++ b/deploy/kubernetes/templates/broker/svc.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     name: "__SERVICE__"
     major: "__MAJOR__"
-    public: "true"
 spec:
   selector:
     name: "__SERVICE__"

--- a/deploy/kubernetes/templates/eventstore/svc.yml
+++ b/deploy/kubernetes/templates/eventstore/svc.yml
@@ -6,7 +6,6 @@ metadata:
   labels:
     name: "__SERVICE__"
     major: "__MAJOR__"
-    public: "true"
 spec:
   selector:
     name: "__SERVICE__"


### PR DESCRIPTION
NsGate was redirecting only port 80 for http.  
Now it redirect correctly the port number specified in the k8s-service manifest for http services.

Eventstore and Broker are also switch to private by default with this release. But a simple CLI command will permit to switch them to public.
