### PR TITLE
Client resize freeze fix

### DIFF
--- a/src/client/src/services/serviceContainer.js
+++ b/src/client/src/services/serviceContainer.js
@@ -120,7 +120,7 @@ export default class ServiceContainer {
 
   _createServiceStatusStream() : Rx.Observable<model.ServiceStatusLookup>{
     // merge then scan all our underlying service status streams into a single
-    // data structure (ServiceStatusLookup) we canquery for the current status.
+    // data structure (ServiceStatusLookup) we can query for the current status.
     return Rx.Observable
       .merge(
         this._pricingService.serviceStatusStream,

--- a/src/client/src/views/index-view.js
+++ b/src/client/src/views/index-view.js
@@ -94,16 +94,6 @@ class IndexView extends React.Component {
           }
         )
     );
-
-    this._disposables.add(
-      serviceContainer.serviceStatusStream.subscribe((services:serviceModel.ServiceStatusLookup) => {
-          this.setState({services});
-        },
-        err => {
-          _log.error(`Error on service status stream ${err.message}`);
-        }
-      )
-    );
   }
 
   componentWillUnmount() {
@@ -199,7 +189,7 @@ class IndexView extends React.Component {
     return (
       <div>
         <Modal/>
-        <Header status={this.state.connected} services={services}/>
+        <Header status={this.state.connected} />
         <CurrencyPairs onExecute={(payload) => this.addTrade(payload)} />
         <Analytics history={this.state.history} positions={this.state.positions}/>
         <Blotter trades={this.state.trades} />


### PR DESCRIPTION
client performance: moving status updates from index-view to the header.

Note, I think header shouldn't accept any props, should just be a 'smart component', will discuss and do further changes. Just getting this fix in to unblock ppl. 
