### PR TITLE
minor improving logging of errors

### DIFF
--- a/src/client/src/components/currency-pairs.js
+++ b/src/client/src/components/currency-pairs.js
@@ -134,7 +134,7 @@ class CurrencyPairs extends React.Component {
                       this.updatePairs();
                     },
                     err => {
-                      _log.error(`Error on getSpotPriceStream stream stream ${err.message}`);
+                      _log.error('Error on getSpotPriceStream stream stream', err);
                     }
                   );
                 shouldStateUpdate = true;
@@ -159,7 +159,7 @@ class CurrencyPairs extends React.Component {
         shouldStateUpdate && this.updatePairs();
       },
       err => {
-        _log.error(`Error on getCurrencyPairUpdatesStream stream stream ${err.message}`);
+        _log.error('Error on getCurrencyPairUpdatesStream stream stream', err);
       })
     );
 

--- a/src/client/src/components/header.js
+++ b/src/client/src/components/header.js
@@ -37,7 +37,7 @@ class Header extends React.Component {
           this.setState({serviceLookup:services});
         },
         err => {
-          _log.error(`Error on service status stream ${err.message}`);
+          _log.error('Error on service status stream', err);
         }
       )
     );

--- a/src/client/src/system/logger.js
+++ b/src/client/src/system/logger.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Guard from './guard';
 
 var levels = {
@@ -41,16 +42,23 @@ class Logger {
     }
   }
 
-  warn(message) {
+  warn(message, err) {
     if (_currentLevel <= levels.warn) {
-      this._log('WARN', message);
+      this._logError('WARN', message, err);
     }
   }
 
-  error(message) {
+  error(message, err) {
     if (_currentLevel <= levels.error) {
-      this._log('ERROR', message);
+      this._logError('ERROR', message, err);
     }
+  }
+
+  _logError(level, message, err) {
+    let errorMessage = _.isError(err)
+      ? err.message
+      : err;
+    this._log(level, `${message}. Error:${errorMessage}`);
   }
 
   _log(level, message) {

--- a/src/client/src/system/observableExtentsions/retryPolicyExt.js
+++ b/src/client/src/system/observableExtentsions/retryPolicyExt.js
@@ -20,18 +20,15 @@ function retryWithPolicy<TValue>(retryPolicy, operationDescription:String, sched
             o.onNext(i);
           }
         },
-        ex => {
+        err => {
           retryCount++;
-          let errorMessage = _.isError(ex)
-            ? ex.message
-            : ex;
-          let shouldRetryResult:ShouldRetryResult = retryPolicy.shouldRetry(ex, retryCount);
+          let shouldRetryResult:ShouldRetryResult = retryPolicy.shouldRetry(err, retryCount);
           if (shouldRetryResult.shouldRetry) {
             if (shouldRetryResult.retryAfterMilliseconds === 0) {
-              _log.warn(`Retrying [${operationDescription}]. This is attempt [${operationDescription}]. Exception: [${errorMessage}]`);
+              _log.warn(`Retrying [${operationDescription}]. This is attempt [${operationDescription}]`, err);
               subscribe();
             } else {
-              _log.warn(`Retrying [${operationDescription}] after [${shouldRetryResult.retryAfterMilliseconds}]. This is attempt [${retryCount}]. Exception: [${errorMessage}]`);
+              _log.warn(`Retrying [${operationDescription}] after [${shouldRetryResult.retryAfterMilliseconds}]. This is attempt [${retryCount}]`, err);
               // throwing away the disposable as we do a dispose check before we onNext
               scheduler.scheduleFuture(
                 '',
@@ -42,8 +39,8 @@ function retryWithPolicy<TValue>(retryPolicy, operationDescription:String, sched
           }
           else {
             // don't retry
-            _log.error(`Not retrying [${operationDescription}]. Retry count [${retryCount}]. Will error. Exception: [${errorMessage}]`);
-            o.onError(ex);
+            _log.error(`Not retrying [${operationDescription}]. Retry count [${retryCount}]. Will error`, err);
+            o.onError(err);
           }
         },
         () => o.onCompleted()

--- a/src/client/src/system/service/connection.js
+++ b/src/client/src/system/service/connection.js
@@ -128,7 +128,7 @@ export default class Connection extends disposables.DisposableBase {
           subscription = sub;
         }, (error:autobahn.Error) => {
           // subscription failed, error is an instance of autobahn.Error
-          _log.error(`Error on topic ${topic}: ${error}`);
+          _log.error(`Error on topic ${topic}`, error);
           o.onError(error);
         });
         disposables.add(Rx.Disposable.create(() => {
@@ -139,11 +139,11 @@ export default class Connection extends disposables.DisposableBase {
                   _log.verbose(`Successfully unsubscribing from topic ${topic}`);
                 },
                 err => {
-                  _log.error(`Error unsubscribing from topic ${topic}: ${err.message}`);
+                  _log.error(`Error unsubscribing from topic ${topic}`, err);
                 }
               );
             } catch (err) {
-              _log.error(`Error thrown unsubscribing from topic ${topic}: ${err.message}`);
+              _log.error(`Error thrown unsubscribing from topic ${topic}`, err);
             }
           }
         }));
@@ -187,7 +187,7 @@ export default class Connection extends disposables.DisposableBase {
             if (!isDisposed) {
               o.onError(error);
             } else {
-              _log.error(`Ignoring error for remoteProcedure [${remoteProcedure}] as stream disposed.. Error was: [${error.message}]`);
+              _log.error(`Ignoring error for remoteProcedure [${remoteProcedure}] as stream disposed.`, error);
             }
           }
         );

--- a/src/client/src/system/service/serviceClient.js
+++ b/src/client/src/system/service/serviceClient.js
@@ -81,7 +81,7 @@ export default class ServiceClient extends disposables.DisposableBase {
         .publish()
         .refCount();
       let isConnectedStream = connectionStatus.where(isConnected => isConnected);
-      let errorOnDisconnectStream = connectionStatus.where(isConnected => !isConnected).take(1).selectMany(Rx.Observable.throw(new Error('Disconnected')));
+      let errorOnDisconnectStream = connectionStatus.where(isConnected => !isConnected).take(1).selectMany(Rx.Observable.throw(new Error('Underlying connection disconnected')));
       let serviceInstanceDictionaryStream = this._connection
         .subscribeToTopic('status')
         .where(s => s.Type === serviceType)
@@ -124,7 +124,7 @@ export default class ServiceClient extends disposables.DisposableBase {
         .getServiceWithMinLoad(waitForSuitableService)
         .subscribe(serviceInstanceStatus => {
             if (!serviceInstanceStatus.isConnected) {
-              o.onError(new Error('Disconnected'));
+              o.onError(new Error('Service instance is disconnected for request response operation'));
             } else if (!hasSubscribed) {
               hasSubscribed = true;
               _this._log.debug(`Will use service instance [${serviceInstanceStatus.serviceId}] for request/response operation [${operationName}]. IsConnected: [${serviceInstanceStatus.isConnected}]`);
@@ -182,7 +182,7 @@ export default class ServiceClient extends disposables.DisposableBase {
         .getServiceWithMinLoad()
         .subscribe(serviceInstanceStatus => {
             if (!serviceInstanceStatus.isConnected) {
-              o.onError(new Error('Disconnected'));
+              o.onError(new Error('Service instance is disconnected for stream operation'));
             } else if (!hasSubscribed) {
               hasSubscribed = true;
               _this._log.debug(`Will use service instance [${serviceInstanceStatus.serviceId}] for stream operation [${operationName}]. IsConnected: [${serviceInstanceStatus.isConnected}]`);

--- a/src/client/src/views/index-view.js
+++ b/src/client/src/views/index-view.js
@@ -53,7 +53,7 @@ class IndexView extends React.Component {
           });
         },
         err => {
-          _log.error(`Error on blotterService stream stream ${err.message}`);
+          _log.error('Error on blotterService stream stream', err);
         }
       )
     );
@@ -66,7 +66,7 @@ class IndexView extends React.Component {
           });
         },
         err => {
-          _log.error(`Error on analyticsService stream stream ${err.message}`);
+          _log.error('Error on analyticsService stream stream', err);
         }
       )
     );
@@ -90,7 +90,7 @@ class IndexView extends React.Component {
             }
           },
           err => {
-            _log.error(`Error on connection status stream ${err.message}`);
+            _log.error('Error on connection status stream', err);
           }
         )
     );
@@ -178,8 +178,8 @@ class IndexView extends React.Component {
         });
         payload.onACK(message);
       },
-      (error) => {
-        _log.error(error.message);
+      (err) => {
+        _log.error('Error on executeTrade stream', err);
       }
     );
   }


### PR DESCRIPTION
In short this adds overloads to `log.warn()` and `log.error()` to take an err. Internally they check if it's a string or an `Error` object and log the right thing.
