### PR TITLE
Correct e2e script

### DIFF
--- a/deploy/e2e/e2e.sh
+++ b/deploy/e2e/e2e.sh
@@ -10,18 +10,17 @@ set -euo pipefail
 
 startTime=$(date)
 
-for file in ./{build,run}Containers; do
-  [ -r "$file" ] && exec "$file" $build_id;
-done
-unset file
+chmod 755 ./ensurePermissions
+./ensurePermissions
+
+./buildContainers $build_id
+./runContainers $build_id
 
 echo "Giving some time for services to start"
 sleep 10
 
-for file in ./{test,stop}Containers; do
-  [ -r "$file" ] && exec "$file" $build_id
-done
-unset file
+./testContainers $build_id
+./stopContainers $build_id
 
 echo " "
 echo "============="


### PR DESCRIPTION
Last modification to e2e script was making it stop after build.
This remove the `exec` and simply use multiple `chmod` instead. 
