### PR TITLE
Popout nginx issue fix

### DIFF
--- a/src/client/src/bootstrapper.js
+++ b/src/client/src/bootstrapper.js
@@ -131,7 +131,7 @@ class Bootstrapper {
   }
 }
 
-let runBootstrapper = location.pathname === '/';
+let runBootstrapper = location.pathname === '/' && location.hash.length === 0;
 // if we're not the root we (perhaps a popup) we never re-run the bootstrap logic
 if(runBootstrapper) {
   new Bootstrapper().run();

--- a/src/client/src/ui/regions/views/popout/popoutRegionView.jsx
+++ b/src/client/src/ui/regions/views/popout/popoutRegionView.jsx
@@ -39,7 +39,7 @@ export default class PopoutRegionView extends ViewBase {
         : 400;
       let popupAttributes = {
         key: modelRegistration.key,
-        url:'/popout',
+        url:'/#/popout',
         title:'',
         onClosing: () => this._popoutClosed(this.props.modelId, modelRegistration.model),
         options: {


### PR DESCRIPTION
The JS client needs a way to differentiate a popout page from the full app page. In a popout the full JS bootstrapper doesn't run, hence the need to differentiate. 
 
Previously popouts were pointing to url `/popout` and the JS didn't load the bootstrapper at this URL, however nginx failed with a 404 as it tried to serve a non existent resource. 

The fix is to point popouts to `/#/popout` which is still a root url (keeping nginx happy) yet distinct enough for the JS to differentiate. 