### PR TITLE
use web font matching designs

### DIFF
--- a/src/client/src/index.html
+++ b/src/client/src/index.html
@@ -4,6 +4,7 @@
   <title>Reactive Trader Cloud</title>
   <meta charset="utf-8">
   <link rel="shortcut icon" type="image/x-icon" href="images/favicon.ico"/>
+  <link href='https://fonts.googleapis.com/css?family=Rubik:300' rel='stylesheet' type='text/css'>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
 </head>
 <body>

--- a/src/client/src/ui/spotTile/views/priceButton.scss
+++ b/src/client/src/ui/spotTile/views/priceButton.scss
@@ -22,7 +22,7 @@
 }
 
 .price-button__pip {
-  font-size: 48px;
+  font-size: 44px;
   padding-left: 5px;
   padding-right: 5px;
   color: white;

--- a/src/client/src/ui/spotTile/views/spotTile.scss
+++ b/src/client/src/ui/spotTile/views/spotTile.scss
@@ -6,6 +6,7 @@
   height: 155px;
   color: $spot-tile-secondary-color;
   background-color: #293543;
+  font-family: 'Rubik', sans-serif;
   &:hover {
     background-color: #294464;
   }


### PR DESCRIPTION
Part of #106 

This font is the closest matching one to the visual designs we have out of the available Google web fonts. It's very subtly different - only the '0's are a bit thinner and the end of '3's are a tiny bit longer.

The proprietary design font probably doesn't conform to the FOSS style of this project anyway.

Rubik (Google web font):
![image](https://cloud.githubusercontent.com/assets/1429601/14527083/7716099a-023f-11e6-8850-52fcb6a39de9.png)
