### PR TITLE
Improve price generation

### DIFF
--- a/src/server/Adaptive.ReactiveTrader.Server.Pricing/MeanReversionRandomWalkPriceGenerator.cs
+++ b/src/server/Adaptive.ReactiveTrader.Server.Pricing/MeanReversionRandomWalkPriceGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Adaptive.ReactiveTrader.Contract;
+
+namespace Adaptive.ReactiveTrader.Server.Pricing
+{
+    public sealed class MeanReversionRandomWalkPriceGenerator : IPriceGenerator
+    {
+        private static readonly Random Random = new Random();
+        private readonly decimal _halfSpreadPercentage;
+        private readonly decimal _initial;
+        private readonly int _precision;
+        private readonly decimal _reversion;
+        private readonly decimal _vol;
+
+        public MeanReversionRandomWalkPriceGenerator(string symbol, decimal initial, int precision, decimal reversionCoefficient = 0.005m, decimal volatility = 5m)
+        {
+            _initial = initial;
+            _precision = precision;
+            _reversion = reversionCoefficient;
+            var power = (decimal) Math.Pow(10, precision);
+            _vol = volatility*1m/power;
+            Symbol = symbol; 
+            _halfSpreadPercentage = Random.Next(2, 11)/power/_initial;
+        }
+
+        public string Symbol { get; }
+
+        public IEnumerable<SpotPriceDto> Sequence()
+        {
+            var previousMid = _initial;
+
+            while (true)
+            {
+                var random = (decimal) Random.NextNormal();
+                previousMid += _reversion*(_initial - previousMid) + random*_vol;
+
+                yield return new SpotPriceDto
+                {
+                    Symbol = Symbol,
+                    ValueDate = DateTime.UtcNow.AddDays(2).Date,
+                    Mid = Format(previousMid),
+                    Ask = Format(previousMid*(1 + _halfSpreadPercentage)),
+                    Bid = Format(previousMid*(1 - _halfSpreadPercentage)),
+                    CreationTimestamp = Stopwatch.GetTimestamp()
+                };
+            }
+        }
+
+        private decimal Format(decimal price)
+        {
+            var power = (decimal) Math.Pow(10, _precision);
+            var mid = (int) (price*power);
+            return mid/power;
+        }
+    }
+}

--- a/src/server/Adaptive.ReactiveTrader.Server.Pricing/MeanReversionRandomWalkPriceGenerator.cs
+++ b/src/server/Adaptive.ReactiveTrader.Server.Pricing/MeanReversionRandomWalkPriceGenerator.cs
@@ -14,7 +14,7 @@ namespace Adaptive.ReactiveTrader.Server.Pricing
         private readonly decimal _reversion;
         private readonly decimal _vol;
 
-        public MeanReversionRandomWalkPriceGenerator(string symbol, decimal initial, int precision, decimal reversionCoefficient = 0.005m, decimal volatility = 5m)
+        public MeanReversionRandomWalkPriceGenerator(string symbol, decimal initial, int precision, decimal reversionCoefficient = 0.001m, decimal volatility = 5m)
         {
             _initial = initial;
             _precision = precision;
@@ -22,7 +22,7 @@ namespace Adaptive.ReactiveTrader.Server.Pricing
             var power = (decimal) Math.Pow(10, precision);
             _vol = volatility*1m/power;
             Symbol = symbol; 
-            _halfSpreadPercentage = Random.Next(2, 11)/power/_initial;
+            _halfSpreadPercentage = Random.Next(2, 16)/power/_initial;
         }
 
         public string Symbol { get; }

--- a/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomExtensions.cs
+++ b/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomExtensions.cs
@@ -6,7 +6,13 @@ namespace Adaptive.ReactiveTrader.Server.Pricing
     {
         public static double NextNormal(this Random random)
         {
-            return Math.Sqrt(-2d*Math.Log(random.NextDouble()))*Math.Sin(2d*Math.PI*random.NextDouble());
+            var r1 = random.NextDouble();
+            while (r1 < double.Epsilon)
+            {
+                r1 = random.NextDouble();
+            }
+
+            return Math.Sqrt(-2d*Math.Log(r1))*Math.Sin(2d*Math.PI*random.NextDouble());
         }
     }
 }

--- a/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomExtensions.cs
+++ b/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Adaptive.ReactiveTrader.Server.Pricing
+{
+    public static class RandomExtensions
+    {
+        public static double NextNormal(this Random random)
+        {
+            return Math.Sqrt(-2d*Math.Log(random.NextDouble()))*Math.Sin(2d*Math.PI*random.NextDouble());
+        }
+    }
+}

--- a/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomWalkPriceGenerator.cs
+++ b/src/server/Adaptive.ReactiveTrader.Server.Pricing/RandomWalkPriceGenerator.cs
@@ -29,7 +29,7 @@ namespace Adaptive.ReactiveTrader.Server.Pricing
             while (true)
             {
                 var pow = (decimal) Math.Pow(10, _precision);
-                var newMid = previousMid + Random.Next(-5, 5)/pow;
+                var newMid = previousMid + Random.Next(-5, 6)/pow;
 
                 // check that the new Mid does not drift too far from sampleRate (3%)
                 if (Math.Abs(newMid - _initial)/_initial > .03m)


### PR DESCRIPTION
closes #229
- Bug: Random.Next(-5, 5) is not symmetric (min value is inclusive, max value is exclusive)
- Use mean reversion to stop prices diverging from initial value
- Use normal distribution to approximate prices moves

closes #230 
- Use % spread so that spreads can move (albeit not very often)

