### PR TITLE
remove unnecessary openfin config

### DIFF
--- a/src/client/config/openfin/demo.app.json
+++ b/src/client/config/openfin/demo.app.json
@@ -13,11 +13,7 @@
         "minHeight": 600,
         "resizable": true,
         "maximizable": true,
-        "frame": false,
-        "cornerRounding": {
-            "width": 0,
-            "height": 0
-        }
+        "frame": false
     },
     "runtime": {
         "arguments": "",

--- a/src/client/config/openfin/dev.app.json
+++ b/src/client/config/openfin/dev.app.json
@@ -13,11 +13,7 @@
         "minHeight": 600,
         "resizable": true,
         "maximizable": true,
-        "frame": false,
-        "cornerRounding": {
-            "width": 0,
-            "height": 0
-        }
+        "frame": false
     },
     "runtime": {
         "arguments": "",

--- a/src/client/config/openfin/local.app.json
+++ b/src/client/config/openfin/local.app.json
@@ -13,11 +13,7 @@
         "minHeight": 600,
         "resizable": true,
         "maximizable": true,
-        "frame": false,
-        "cornerRounding": {
-            "width": 0,
-            "height": 0
-        }
+        "frame": false
     },
     "runtime": {
         "arguments": "",


### PR DESCRIPTION
Align config with reactive trader js config.
0 is also the default value for corner rounding...

Fixes #339