### PR TITLE
Update Event Store link for macOS setup

### DIFF
--- a/docs/setup/macos-setup.md
+++ b/docs/setup/macos-setup.md
@@ -21,7 +21,9 @@ $ dotnet restore
 
 #### Install Event Store
 
-Follow the instructions provided [here](https://geteventstore.com/downloads/)
+Follow the instructions provided [here](https://eventstore.org/downloads/)
+
+Or, [use the docker image](https://hub.docker.com/r/eventstore/eventstore/).
 
 
 #### Install Crossbar.io


### PR DESCRIPTION
The existing link does not resolve, I've updated it with Event Store's current downloads page.

Additionally it seems the docker image would be preferable as Event Store v4 is not currently available for macOS.