### PR TITLE
#610 Client subscribes twice to every currency pair

### DIFF
--- a/src/client/src/services/pricingService.ts
+++ b/src/client/src/services/pricingService.ts
@@ -6,36 +6,42 @@ import '../system/observableExtensions/retryPolicyExt'
 const log = logger.create('PricingService')
 
 export default class PricingService extends ServiceBase {
+  cachedObservablesBySymbol = {}
+
   getSpotPriceStream(request) {
-    const getPriceUpdatesOperationName = 'getPriceUpdates'
-    return Observable.create(
-      (o) => {
-        log.debug(`Subscribing to spot price stream for [${request.symbol}]`)
-        let lastPrice = null
-        return this.serviceClient
-          .createStreamOperation(getPriceUpdatesOperationName, request)
-          // we retry the price stream forever, if it errors (likely connection down) we pump a non tradable price
-          .retryWithPolicy(
-            RetryPolicy.indefiniteEvery2Seconds,
-            getPriceUpdatesOperationName,
-            Scheduler.async,
-            (err, willRetry) => {
-              if (willRetry && lastPrice !== null) {
-                // TODO: remove is stale price fully supported
-              }
-            },
-          )
-          .map(item => keysToLower(item))
-          .subscribe(
-            (price) => {
-              lastPrice = price
-              o.next(price)
-            },
-            (err) => { o.error(err) },
-            () => { o.complete() },
-          )
-      },
-    )
+    const { symbol } = request
+    if (!this.cachedObservablesBySymbol[symbol]) {
+      const getPriceUpdatesOperationName = 'getPriceUpdates'
+      this.cachedObservablesBySymbol[symbol] = Observable.create(
+        (o) => {
+          log.debug(`Subscribing to spot price stream for [${request.symbol}]`)
+          let lastPrice = null
+          return this.serviceClient
+            .createStreamOperation(getPriceUpdatesOperationName, request)
+            // we retry the price stream forever, if it errors (likely connection down) we pump a non tradable price
+            .retryWithPolicy(
+              RetryPolicy.indefiniteEvery2Seconds,
+              getPriceUpdatesOperationName,
+              Scheduler.async,
+              (err, willRetry) => {
+                if (willRetry && lastPrice !== null) {
+                  // TODO: remove is stale price fully supported
+                }
+              },
+            )
+            .map(item => keysToLower(item))
+            .subscribe(
+              (price) => {
+                lastPrice = price
+                o.next(price)
+              },
+              (err) => { o.error(err) },
+              () => { o.complete() },
+            )
+        },
+      ).share()
+    }
+    return this.cachedObservablesBySymbol[symbol]
   }
 }
 

--- a/src/client/src/services/pricingService.ts
+++ b/src/client/src/services/pricingService.ts
@@ -4,42 +4,46 @@ import { logger, RetryPolicy } from '../system'
 import '../system/observableExtensions/retryPolicyExt'
 
 const log = logger.create('PricingService')
+const getPriceUpdatesOperationName = 'getPriceUpdates'
 
 export default class PricingService extends ServiceBase {
   cachedObservablesBySymbol = {}
 
+  private createSpotPriceStream(request) {
+    return Observable.create(
+      (o) => {
+        log.debug(`Subscribing to spot price stream for [${request.symbol}]`)
+        let lastPrice = null
+        return this.serviceClient
+          .createStreamOperation(getPriceUpdatesOperationName, request)
+          // we retry the price stream forever, if it errors (likely connection down) we pump a non tradable price
+          .retryWithPolicy(
+            RetryPolicy.indefiniteEvery2Seconds,
+            getPriceUpdatesOperationName,
+            Scheduler.async,
+            (err, willRetry) => {
+              if (willRetry && lastPrice !== null) {
+                // TODO: remove is stale price fully supported
+              }
+            },
+          )
+          .map(item => keysToLower(item))
+          .subscribe(
+            (price) => {
+              lastPrice = price
+              o.next(price)
+            },
+            (err) => { o.error(err) },
+            () => { o.complete() },
+          )
+      },
+    ).share()
+  }
+
   getSpotPriceStream(request) {
     const { symbol } = request
     if (!this.cachedObservablesBySymbol[symbol]) {
-      const getPriceUpdatesOperationName = 'getPriceUpdates'
-      this.cachedObservablesBySymbol[symbol] = Observable.create(
-        (o) => {
-          log.debug(`Subscribing to spot price stream for [${request.symbol}]`)
-          let lastPrice = null
-          return this.serviceClient
-            .createStreamOperation(getPriceUpdatesOperationName, request)
-            // we retry the price stream forever, if it errors (likely connection down) we pump a non tradable price
-            .retryWithPolicy(
-              RetryPolicy.indefiniteEvery2Seconds,
-              getPriceUpdatesOperationName,
-              Scheduler.async,
-              (err, willRetry) => {
-                if (willRetry && lastPrice !== null) {
-                  // TODO: remove is stale price fully supported
-                }
-              },
-            )
-            .map(item => keysToLower(item))
-            .subscribe(
-              (price) => {
-                lastPrice = price
-                o.next(price)
-              },
-              (err) => { o.error(err) },
-              () => { o.complete() },
-            )
-        },
-      ).share()
+      this.cachedObservablesBySymbol[symbol] = this.createSpotPriceStream(request)
     }
     return this.cachedObservablesBySymbol[symbol]
   }


### PR DESCRIPTION
Fixes #610
To avoid duplicating the observable for the same pair we create a subject so it can multicast and is also cached.

We can see the difference of number of duplicate frames in the websockets. Before we have plenty of duplicate frames for the prices, after the change, there are no duplicates.

Before:
![ws prices before](https://user-images.githubusercontent.com/35812387/35448883-682dee90-02b3-11e8-9b37-f4f60423e846.PNG)

After:
![ws prices after](https://user-images.githubusercontent.com/35812387/35448888-6d13fae4-02b3-11e8-8761-a16e24fcc7a8.PNG)

