### PR TITLE
Fix IE 11

### DIFF
--- a/src/client/npm-shrinkwrap.json
+++ b/src/client/npm-shrinkwrap.json
@@ -3881,6 +3881,39 @@
       "integrity": "sha512-AVDVEmp0S9mbF1O8zekWbsOOmqnR08PZah5NRZJqSvJnFgiL0ep4Lwo4EymH8OieJR2QgQdR3q71TNW+wiVn4g==",
       "dev": true
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -63,6 +63,7 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-polyfill": "6.26.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "classnames": "2.2.3",

--- a/src/client/src/appBootstrapper.tsx
+++ b/src/client/src/appBootstrapper.tsx
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import { User } from './types'

--- a/src/client/src/ui/analytics/chartGradient.ts
+++ b/src/client/src/ui/analytics/chartGradient.ts
@@ -1,3 +1,5 @@
+import 'classlist-polyfill';
+
 /**
  * ChartGradient - a utility to draw linear gradients on area and stroke elements of a line chart
  *
@@ -43,7 +45,7 @@ export default class ChartGradient {
       defs = nvGroups.querySelector('defs')
     } else {
       // very ugly way to wait for dom. leaving as originaly but needs refactor
-      setTimeout(() => this.update(parentChart, domainMin, domainMax), 10) 
+      setTimeout(() => this.update(parentChart, domainMin, domainMax), 10)
     }
 
     if (!defs && nvGroups) {

--- a/src/client/webpack.config.js
+++ b/src/client/webpack.config.js
@@ -61,7 +61,6 @@ module.exports = function (env = {}) {
     name: 'client',
     target: 'web',
     entry: {
-      polyfill: ['babel-polyfill'],
       app: ['./src/appBootstrapper.tsx'],
       notification: ['./src/notificationBootstrapper.tsx'],
     },
@@ -142,7 +141,10 @@ module.exports = function (env = {}) {
       rules: [
         {
           test: /\.jsx?$/,
-          exclude: /node_modules/,
+          exclude: function(modulePath) {
+            return /node_modules/.test(modulePath)
+              && !/node_modules[\/\\]cbor/.test(modulePath);
+          },
           use: {
             loader: 'babel-loader',
             options: {

--- a/src/client/webpack.config.js
+++ b/src/client/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = function (env = {}) {
     name: 'client',
     target: 'web',
     entry: {
+      polyfill: ['babel-polyfill'],
       app: ['./src/appBootstrapper.tsx'],
       notification: ['./src/notificationBootstrapper.tsx'],
     },


### PR DESCRIPTION
The update of `autobahn` from version `0.9.9` to `17.5.2` pulled in a new dependency `hildjj/node-cbor`, which broke our compatibility with IE11. This pull request is meant to resolve that issue by introducing polyfills.

This pull request resolves #643.