### PR TITLE
Notification simplification

### DIFF
--- a/src/client/src/system/openFin/openFin.ts
+++ b/src/client/src/system/openFin/openFin.ts
@@ -1,7 +1,7 @@
 /// <reference path="./OpenFin.d.ts"/>
 import { Observable, Subject, Subscription } from 'rxjs/Rx'
 import * as _ from 'lodash'
-import {CurrencyPair, Trade} from '../../types'
+import { CurrencyPair, Trade } from '../../types'
 import PositionsMapper from '../../services/mappers/positionsMapper'
 import logger from '../logger'
 import * as numeral from 'numeral'

--- a/src/client/src/system/openFin/openFin.ts
+++ b/src/client/src/system/openFin/openFin.ts
@@ -1,7 +1,7 @@
 /// <reference path="./OpenFin.d.ts"/>
 import { Observable, Subject, Subscription } from 'rxjs/Rx'
 import * as _ from 'lodash'
-import { Trade } from '../../types'
+import {CurrencyPair, Trade} from '../../types'
 import PositionsMapper from '../../services/mappers/positionsMapper'
 import logger from '../logger'
 import * as numeral from 'numeral'
@@ -202,10 +202,10 @@ export default class OpenFin {
     })
   }
 
-  openTradeNotification(trade) {
+  openTradeNotification(trade:Trade, currencyPair: CurrencyPair) {
     if (!this.isRunningInOpenFin) return
 
-    const tradeNotification = formatTradeNotification(trade)
+    const tradeNotification = formatTradeNotification(trade, currencyPair)
     new fin.desktop.Notification({
       url: '/notification.html',
       message: tradeNotification,
@@ -231,9 +231,9 @@ export default class OpenFin {
     fin.desktop.InterApplicationBus.publish('price-update', price)
   }
 
-  sendAllBlotterData(uuid, blotterData) {
+  sendAllBlotterData(uuid, blotterData: Trade[], currencyPairs:CurrencyPair[]) {
     const parsed = Object.keys(blotterData)
-      .map((x) => formatTradeNotification(blotterData[x]))
+      .map((x) => formatTradeNotification(blotterData[x], currencyPairs[blotterData[x].symbol]))
 
     fin.desktop.InterApplicationBus.send(uuid, 'blotter-data', parsed)
   }
@@ -248,7 +248,7 @@ export default class OpenFin {
   }
 }
 
-function formatTradeNotification(trade: Trade) {
+function formatTradeNotification(trade: Trade, currencyPair: CurrencyPair) {
   return {
     symbol: trade.symbol,
     spotRate: trade.spotRate,
@@ -258,6 +258,7 @@ function formatTradeNotification(trade: Trade) {
     tradeDate: moment(trade.tradeDate).format(),
     status: trade.status,
     dealtCurrency: trade.dealtCurrency,
+    termsCurrency: currencyPair.terms,
     valueDate: moment(trade.valueDate).format('DD MMM')
   }
 }

--- a/src/client/src/types/notification.ts
+++ b/src/client/src/types/notification.ts
@@ -10,6 +10,7 @@ export interface Notification {
   status: string
   spotRate: number
   dealtCurrency: string
+  termsCurrency:string
   formattedValueDate: string
   message?: string
 }

--- a/src/client/src/types/trade.ts
+++ b/src/client/src/types/trade.ts
@@ -4,6 +4,7 @@ export interface Trade {
   symbol: string,
   notional: number,
   dealtCurrency: string,
+  termsCurrency?: string,
   direction: any,
   spotRate: number,
   tradeDate: Date,

--- a/src/client/src/ui/blotter/epics.ts
+++ b/src/client/src/ui/blotter/epics.ts
@@ -1,8 +1,11 @@
 import { ACTION_TYPES as REF_ACTION_TYPES } from '../../redux/actions/referenceDataActions'
 import { createNewTradesAction } from './actions'
+import { CurrencyPair, Trade } from '../../types'
 
 const subscribeOpenFinToBlotterData = (openFin, store) => () => {
-  const cb = (msg, uuid) => openFin.sendAllBlotterData(uuid, store.getState().blotterService.trades)
+  const trades: Trade[] = store.getState().blotterService.trades
+  const currencyPairs: CurrencyPair[] = store.getState().blotterService.currencyPairs
+  const cb = (msg, uuid) => openFin.sendAllBlotterData(uuid, trades, currencyPairs)
   openFin.addSubscription('fetch-blotter', cb)
 }
 

--- a/src/client/src/ui/notification/TradeNotification.tsx
+++ b/src/client/src/ui/notification/TradeNotification.tsx
@@ -37,7 +37,7 @@ export default class TradeNotification extends React.Component<TradeNotification
           <ul className={tradeSummaryClasses}>
             <li className="notification__summary-item notification__summary-item--direction">{direction}</li>
             <li className="notification__summary-item notification__summary-item--notional">{trade.dealtCurrency} {trade.notional}</li>
-            <li className="notification__summary-item notification__summary-item--currency">vs {/*{trade.termsCurrency}*/}</li>
+            <li className="notification__summary-item notification__summary-item--currency">vs {trade.termsCurrency}</li>
           </ul>
           <div className="notification__details-items-container">
             <ul className="notification__details-items">

--- a/src/client/src/ui/notification/TradeNotificationContainer.tsx
+++ b/src/client/src/ui/notification/TradeNotificationContainer.tsx
@@ -24,13 +24,13 @@ class TradeNotification extends React.Component<TradeNotificationContainerProps,
   }
 
   public showOpenFinNotificationsForNewTrades(previousTrades, payloadTrades) {
-    _.forEach(payloadTrades, (trade) => {
+    _.forEach(payloadTrades, (trade:Trade) => {
       // ignore existing trades, unless it was pending
       if (previousTrades[trade.tradeId] && previousTrades[trade.tradeId].status !== TradeStatus.Pending) return
 
       // display a notification if the trade has a final status (Done or Rejected)
       if ((trade.status === TradeStatus.Done || trade.status === TradeStatus.Rejected)) {
-        this.context.openFin.openTradeNotification(trade)
+        this.context.openFin.openTradeNotification(trade, this.props.currencyPairs[trade.symbol])
       }
     })
   }

--- a/src/client/src/ui/notification/notificationUtils.ts
+++ b/src/client/src/ui/notification/notificationUtils.ts
@@ -15,6 +15,7 @@ export function buildNotification(trade:Trade = null, error) {
     notional: numeral(trade.notional).format('0,000,000[.]00'),
     status: trade.status,
     dealtCurrency: trade.dealtCurrency,
+    termsCurrency: trade.termsCurrency,
     spotRate: trade.spotRate,
     formattedValueDate: `SP. ${timeFormat('%b %e')(trade.valueDate)}`,
     tradeId: trade.tradeId,

--- a/src/client/src/ui/spotTile/SpotTile.tsx
+++ b/src/client/src/ui/spotTile/SpotTile.tsx
@@ -108,7 +108,6 @@ export default class SpotTile extends React.Component<SpotTileProps, {}> {
     if (notification.notificationType === NotificationType.Trade) {
       return (
         <TradeNotification
-          className="spot-tile__trade-summary"
           notification={notification}
           currencyPair={this.props.currencyPair}
           onDismissedClicked={() => this.props.onNotificationDismissedClick()}/>

--- a/src/client/src/ui/spotTile/__tests__/tradeNotification.spec.jsx
+++ b/src/client/src/ui/spotTile/__tests__/tradeNotification.spec.jsx
@@ -19,7 +19,6 @@ describe.only('TradeNotification', () => {
       tradeId: 'ABC',
     }
     const component = <TradeNotification
-          className='spot-tile__trade-summary'
           notification={notification}
           onDismissedClicked={mockOnDismissedClicked}/>
 
@@ -48,7 +47,6 @@ describe.only('TradeNotification', () => {
         tradeId: 'ABC',
       }
       const component = <TradeNotification
-            className='spot-tile__trade-summary'
             notification={notification}
             onDismissedClicked={() => {}}/>
 

--- a/src/client/src/ui/spotTile/epics.ts
+++ b/src/client/src/ui/spotTile/epics.ts
@@ -8,7 +8,7 @@ import { SpotPrice } from '../../types/spotPrice'
 import * as _ from 'lodash'
 import { currencyChartOpened, dismissNotification, executeTrade, tradeExecuted, updateTiles } from './actions';
 
-const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 6000
+const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 600000
 
 interface SpotPrices {
   [symbol: string]: SpotPrice

--- a/src/client/src/ui/spotTile/epics.ts
+++ b/src/client/src/ui/spotTile/epics.ts
@@ -8,7 +8,7 @@ import { SpotPrice } from '../../types/spotPrice'
 import * as _ from 'lodash'
 import { currencyChartOpened, dismissNotification, executeTrade, tradeExecuted, updateTiles } from './actions';
 
-const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 600000
+const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 6000
 
 interface SpotPrices {
   [symbol: string]: SpotPrice

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
@@ -5,8 +5,7 @@ import { CurrencyPair, TradeStatus } from '../../../types'
 import { Notification } from '../../../types/notification'
 
 interface TradeNotificationProps {
-  className: string,
-  currencyPair: CurrencyPair,
+  currencyPair: CurrencyPair
   notification: Notification,
   onDismissedClicked: () => void
 }
@@ -15,38 +14,30 @@ class TradeNotification extends React.Component<TradeNotificationProps, {}>{
   props: TradeNotificationProps
 
   renderError() {
-    const classNames = classnames(
-      'trade-notification',
-      'trade-notification--error',
-      this.props.className,
-    )
     return (
-    <div className={classNames}>
-      {this.props.notification.hasError}.
+    <div >
+      {this.props.notification.hasError}
       The execution status is unknown. Please contact your sales rep.
-        <a
-          href="#"
+        <div
           className="trade-notification__button--dismiss"
           onClick={this.props.onDismissedClicked}>
           Done
-        </a>
+        </div>
     </div>)
   }
 
   render() {
-    const { notification, onDismissedClicked, className } = this.props
+    const { notification, onDismissedClicked } = this.props
 
     if (notification.hasError) {
       return this.renderError()
     }
 
-    const classNames = classnames(
-      'trade-notification',
-      className,
+    const containerClassName = classnames(
       { 'trade-notification--rejected': notification.status === TradeStatus.Rejected },
     )
     return (
-      <div className={classNames}>
+      <div className={containerClassName}>
         <span className="trade-notification__trade-status">
           {notification.status}
           </span>
@@ -64,49 +55,34 @@ class TradeNotification extends React.Component<TradeNotificationProps, {}>{
             className="trade-notification__summary-item trade-notification__summary-item--currency">
             <span
               className="trade-notification__label--versus">vs </span>
-              {/*{notification.termsCurrency}*/}
+              { this.props.currencyPair.terms }
           </li>
         </ul>
         <div className="trade-notification__details-items-container">
-          <ul className="trade-notification__details-items trade-notification__details-items--rate">
-            <li
-              className="trade-notification__details-item trade-notification__details-item--label">
-              Rate
-            </li>
-            <li
-              className="trade-notification__details-item trade-notification__details-item--value">
-              {notification.spotRate}
-            </li>
-          </ul>
-          <ul className="trade-notification__details-items trade-notification__details-items--date">
-            <li
-              className="trade-notification__details-item trade-notification__details-item--label">
-              Date
-            </li>
-            <li
-              className="trade-notification__details-item trade-notification__details-item--value">
-              {notification.formattedValueDate}
-            </li>
-          </ul>
-          <ul
-             // tslint:disable-next-line:max-line-length
-            className="trade-notification__details-items trade-notification__details-items--trade-id">
-            <li className="trade-notification__details-item trade-notification__details-item--label">
-              Trade ID
-            </li>
-            <li
-              className="trade-notification__details-item trade-notification__details-item--value">
-              {notification.tradeId}
-            </li>
-          </ul>
+          { this.createNotificationPropertyDisplay('Rate', notification.spotRate)}
+          { this.createNotificationPropertyDisplay('Date', notification.formattedValueDate)}
+          { this.createNotificationPropertyDisplay('Trade ID', notification.tradeId)}
         </div>
-        <a
-          href="#"
-          className="trade-notification__button--dismiss"
+        <div className="trade-notification__button--dismiss trade-notification__button--dismiss-icon"
           onClick={onDismissedClicked}>
-          <i className="trade-notification__button--dismiss-icon fa fa-share" ></i>
-        </a>
+          <i className="fa fa-share" ></i>
+        </div>
       </div>
+    )
+  }
+
+  private createNotificationPropertyDisplay = (label: string, value: string|number) => {
+    return (
+      <ul className="trade-notification__details-items trade-notification__details-items--date">
+        <li
+          className="trade-notification__details-item trade-notification__details-item--label">
+          {label}
+        </li>
+        <li
+          className="trade-notification__details-item trade-notification__details-item--value">
+          {value}
+        </li>
+      </ul>
     )
   }
 }

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
@@ -59,30 +59,26 @@ class TradeNotification extends React.Component<TradeNotificationProps, {}>{
           </li>
         </ul>
         <div className="trade-notification__details-items-container">
-          { this.createNotificationPropertyDisplay('Rate', notification.spotRate)}
-          { this.createNotificationPropertyDisplay('Date', notification.formattedValueDate)}
-          { this.createNotificationPropertyDisplay('Trade ID', notification.tradeId)}
+          { this.createItemDetailElement('Rate', notification.spotRate)}
+          { this.createItemDetailElement('Date', notification.formattedValueDate)}
+          { this.createItemDetailElement('Trade ID', notification.tradeId)}
         </div>
-        <div className="trade-notification__button--dismiss trade-notification__button--dismiss-icon"
-          onClick={onDismissedClicked}>
-          <i className="fa fa-share" ></i>
-        </div>
+        <i className="trade-notification__button--dismiss trade-notification__button--dismiss-icon fa fa-share"
+           onClick={onDismissedClicked}/>
       </div>
     )
   }
 
-  private createNotificationPropertyDisplay = (label: string, value: string|number) => {
+  private createItemDetailElement = (label: string, value: string|number) => {
     return (
-      <ul className="trade-notification__details-items trade-notification__details-items--date">
-        <li
-          className="trade-notification__details-item trade-notification__details-item--label">
+      <div className="trade-notification__details-item">
+        <div className="trade-notification__details-item--label">
           {label}
-        </li>
-        <li
-          className="trade-notification__details-item trade-notification__details-item--value">
+        </div>
+        <div className="trade-notification__details-item--value">
           {value}
-        </li>
-      </ul>
+        </div>
+      </div>
     )
   }
 }

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotification.tsx
@@ -15,11 +15,9 @@ class TradeNotification extends React.Component<TradeNotificationProps, {}>{
 
   renderError() {
     return (
-    <div >
-      {this.props.notification.hasError}
+    <div className="trade-notification">
       The execution status is unknown. Please contact your sales rep.
-        <div
-          className="trade-notification__button--dismiss"
+        <div className="trade-notification__button-dismiss"
           onClick={this.props.onDismissedClicked}>
           Done
         </div>
@@ -34,36 +32,30 @@ class TradeNotification extends React.Component<TradeNotificationProps, {}>{
     }
 
     const containerClassName = classnames(
-      { 'trade-notification--rejected': notification.status === TradeStatus.Rejected },
+      'trade-notification',
+      { 'trade-notification--rejected': notification.status === TradeStatus.Rejected }
     )
     return (
       <div className={containerClassName}>
         <span className="trade-notification__trade-status">
           {notification.status}
-          </span>
-        <ul className="trade-notification__summary-items">
-          <li
-            // tslint:disable-next-line:max-line-length
-            className="trade-notification__summary-item trade-notification__summary-item--direction">
-            {notification.direction}
-          </li>
-          <li
-            className="trade-notification__summary-item trade-notification__summary-item--notional">
-            {notification.dealtCurrency} {notification.notional}
-          </li>
-          <li
-            className="trade-notification__summary-item trade-notification__summary-item--currency">
-            <span
-              className="trade-notification__label--versus">vs </span>
-              { this.props.currencyPair.terms }
-          </li>
-        </ul>
+        </span>
+        <div className="trade-notification__summary-item--direction">
+          {notification.direction}
+        </div>
+        <div className="trade-notification__summary-item--notional">
+          {notification.dealtCurrency} {notification.notional}
+        </div>
+        <div className="trade-notification__summary-item--currency">
+          <span className="trade-notification__label--versus">vs </span>
+          { this.props.currencyPair.terms }
+        </div>
         <div className="trade-notification__details-items-container">
           { this.createItemDetailElement('Rate', notification.spotRate)}
           { this.createItemDetailElement('Date', notification.formattedValueDate)}
           { this.createItemDetailElement('Trade ID', notification.tradeId)}
         </div>
-        <i className="trade-notification__button--dismiss trade-notification__button--dismiss-icon fa fa-share"
+        <i className="trade-notification__dismiss-icon fa fa-share"
            onClick={onDismissedClicked}/>
       </div>
     )

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
@@ -73,40 +73,30 @@
 
 .trade-notification__details-items-container {
   display: flex;
+  justify-content: space-between;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding-top: 10px;
-  position: absolute;
+  padding: 10px 0 0 0 ;
+  margin-top: 18px;
   width: 100%;
-  bottom: 6px;
 }
 
-.trade-notification__details-items {
-  margin: 0;
-  padding: 0;
-  list-style: none;
+.trade-notification__details-item {
+  flex: 1 1 33%;
+
+  .trade-notification__details-item--label {
+    color: #c2c5c9;
+    text-transform: uppercase;
+    font-size: 12px;
+    font-family: BrandonMedium;
+  }
+
+  .trade-notification__details-item--value {
+    color: white;
+    font-size: 16px;
+    font-family: BrandonRegular;
+  }
 }
 
-.trade-notification__details-item--label {
-  color: #c2c5c9;
-  text-transform: uppercase;
-  font-size: 12px;
-  font-family: BrandonMedium;
-}
 
-.trade-notification__details-item--value {
-  color: white;
-  font-size: 16px;
-  font-family: BrandonRegular;
-}
 
-.trade-notification__details-items--rate {
-  flex: 0.8;
-}
 
-.trade-notification__details-items--date {
-  flex: 1;
-}
-
-.trade-notification__details-items--trade-id {
-  flex: 0.9
-}

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
@@ -53,11 +53,10 @@
 }
 
 .trade-notification__button--dismiss {
-  text-decoration: none;
   position: absolute;
   bottom: -5px;
   right: 0;
-  color: inherit;
+  cursor: pointer;
 }
 
 .trade-notification__button--dismiss-icon {
@@ -69,7 +68,6 @@
   position: absolute;
   top: 0;
   right: 40px;
-  color: inherit;
   font-family: BrandonRegular;
 }
 

--- a/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
+++ b/src/client/src/ui/spotTile/tradeNotification/TradeNotificationStyles.scss
@@ -1,5 +1,9 @@
 @import "../variables.scss";
 
+.trade-notification {
+  padding-top: 4px;
+}
+
 .trade-notification--rejected,
 .trade-notification--error {
   .trade-notification__trade-status {
@@ -9,21 +13,19 @@
 }
 
 .trade-notification--rejected {
-  .trade-notification__trade-status {
-    display: block;
-  }
   .trade-notification__summary-item {
     text-decoration: line-through;
   }
 }
 
-.trade-notification__summary-item {
-  line-height: 16px;
+@mixin trade-notification__summary-item {
+  line-height: 1.1;
+  color: #c2c5c9;
+  font-family: BrandonMedium;
 }
 
 .trade-notification__summary-item--direction {
-  color: #c2c5c9;
-  font-family: BrandonMedium;
+  @include trade-notification__summary-item;
   font-size: 12px;
   text-transform: uppercase;
 }
@@ -33,16 +35,15 @@
 }
 
 .trade-notification__summary-item--currency {
-  color: #c2c5c9;
+  @include trade-notification__summary-item;
   font-size: 14px;
 }
 
 .trade-notification__summary-item--notional {
+  @include trade-notification__summary-item;
   color: #f8ab02;
   font-size: 24px;
-  line-height: 24px;
   font-family: BrandonRegular;
-  display: inline-block;
 }
 
 .trade-notification__summary-items {
@@ -52,14 +53,18 @@
   padding: 0;
 }
 
-.trade-notification__button--dismiss {
+@mixin trade-notification__dismiss {
   position: absolute;
   bottom: -5px;
   right: 0;
   cursor: pointer;
 }
+.trade-notification__button-dismiss {
+  @include trade-notification__dismiss();
+}
 
-.trade-notification__button--dismiss-icon {
+.trade-notification__dismiss-icon {
+  @include trade-notification__dismiss();
   transform: rotate(45deg);
 }
 

--- a/src/client/stories/spotTile/index.ts
+++ b/src/client/stories/spotTile/index.ts
@@ -96,7 +96,6 @@ export const getTradeNotificationProps = (status: string,
                                           hasError: boolean,
                                           action: any) => {
   return {
-    className: 'spot-tile__trade-summary',
     notification: {
       hasError,
       status: TradeStatus[status],


### PR DESCRIPTION
Simplified the structure of the TradeNotification view
reinstated the 'termsCurrency' property on OpenFin notification

todo: review and remove duplication between the Notification and Trade types, they seem to be used almost interchangeably