### PR TITLE
[Documentation] Fixed documentation link and details.

### DIFF
--- a/docs/deployment/rtc-deployment-cli.md
+++ b/docs/deployment/rtc-deployment-cli.md
@@ -60,7 +60,7 @@
 - requirements:
     - [setup docker][docker-setup]
     - [setup and start bash][bash-setup]
-    - [authenticate with gcloud][gcloud-init]
+    - *(Optional)* [authenticate with gcloud][gcloud-init]
 - run **./deploy/kubernetes/user-cluster <CLUSTER_NAME>** in *bash*
     ```
     $ ./deploy/kubernetes/use-cluster cluster
@@ -85,7 +85,7 @@
 - requirements:
     - [setup docker][docker-setup]
     - [setup and start bash][bash-setup]
-    - [authenticate with gcloud][gcloud-init]
+    - *(Optional)* [authenticate with gcloud][gcloud-init]
     - [select cluster][use-cluster]
 - run **./deploy/kubernetes/list_environments** in *bash*
     ```

--- a/docs/deployment/rtc-deployment-cli.md
+++ b/docs/deployment/rtc-deployment-cli.md
@@ -60,7 +60,7 @@
 - requirements:
     - [setup docker][docker-setup]
     - [setup and start bash][bash-setup]
-    - *(Optional)* [authenticate with gcloud][gcloud-init]
+    - [authenticate with gcloud][gcloud-init]
 - run **./deploy/kubernetes/user-cluster <CLUSTER_NAME>** in *bash*
     ```
     $ ./deploy/kubernetes/use-cluster cluster
@@ -85,7 +85,7 @@
 - requirements:
     - [setup docker][docker-setup]
     - [setup and start bash][bash-setup]
-    - *(Optional)* [authenticate with gcloud][gcloud-init]
+    - [authenticate with gcloud][gcloud-init]
     - [select cluster][use-cluster]
 - run **./deploy/kubernetes/list_environments** in *bash*
     ```

--- a/docs/deployment/rtc-deployment.md
+++ b/docs/deployment/rtc-deployment.md
@@ -19,5 +19,5 @@
     ```
 
 [environment-name]: ./environment-name.md
-[build-id]: ./build_id.md
+[build-id]: ./build-id.md
 [bash-setup]: ./bash-setup.md


### PR DESCRIPTION
- Fixed link to build-id.md page which was pointing to the non-existent build_id.md
- Removed (Optional) in "authenticate with gcloud" as authentication with gcloud is needed to be able to use the cluster and list the environments.