### PR TITLE
[ARTP-169] - Up Node version to LTS

### DIFF
--- a/deploy/config
+++ b/deploy/config
@@ -41,9 +41,9 @@ eventstoreContainer_minor="0"
 eventstoreContainer="weareadaptive/eventstore:$eventstoreContainer_major.$eventstoreContainer_minor"
 
 # node
-vNode="8.11.3-alpine"
+vNode="8.11.3"
 nodeContainer_major="8"
-nodeContainer_minor="11.3-alpine"
+nodeContainer_minor="11.3"
 nodeContainer="node:$nodeContainer_major.$nodeContainer_minor"
 
 # nginx

--- a/deploy/config
+++ b/deploy/config
@@ -41,10 +41,10 @@ eventstoreContainer_minor="0"
 eventstoreContainer="weareadaptive/eventstore:$eventstoreContainer_major.$eventstoreContainer_minor"
 
 # node
-vNode="8.11.3"
+vNode="8"
 nodeContainer_major="8"
-nodeContainer_minor="11.3"
-nodeContainer="node:$nodeContainer_major.$nodeContainer_minor"
+nodeContainer_minor=""
+nodeContainer="node:$nodeContainer_major"
 
 # nginx
 vNginx="1.12.0"

--- a/deploy/config
+++ b/deploy/config
@@ -41,10 +41,10 @@ eventstoreContainer_minor="0"
 eventstoreContainer="weareadaptive/eventstore:$eventstoreContainer_major.$eventstoreContainer_minor"
 
 # node
-vNode="6.2.1"
-nodeContainer_major="6"
-nodeContainer_minor="2"
-nodeContainer="weareadaptive/node:$nodeContainer_major.$nodeContainer_minor"
+vNode="8.11.3-alpine"
+nodeContainer_major="8"
+nodeContainer_minor="11.3-alpine"
+nodeContainer="node:$nodeContainer_major.$nodeContainer_minor"
 
 # nginx
 vNginx="1.12.0"

--- a/deploy/docker/build/web/npminstall/Dockerfile
+++ b/deploy/docker/build/web/npminstall/Dockerfile
@@ -3,11 +3,11 @@ MAINTAINER  weareadaptive <thibault@weareadaptive.com>
 
 COPY        client/package.json client/package.json
 
+WORKDIR     /client
+
 RUN         npm install
 
 COPY        client /client
-
-WORKDIR     /client
 
 ENTRYPOINT  ["npm", "run", "build"]
 # ENTRYPOINT  npm install && npm test && npm run deploy:prod

--- a/deploy/docker/build/web/npminstall/Dockerfile
+++ b/deploy/docker/build/web/npminstall/Dockerfile
@@ -1,8 +1,13 @@
 FROM        __NODE_CONTAINER__
 MAINTAINER  weareadaptive <thibault@weareadaptive.com>
 
+COPY        client/package.json client/package.json
+
+RUN         npm install
+
 COPY        client /client
 
 WORKDIR     /client
-ENTRYPOINT  npm install && npm run build
+
+ENTRYPOINT  ["npm", "run", "build"]
 # ENTRYPOINT  npm install && npm test && npm run deploy:prod

--- a/deploy/docker/prepare
+++ b/deploy/docker/prepare
@@ -6,7 +6,8 @@ set -euo pipefail
 # CONFIGURATION
 # =============
 possible_commands="build push"
-rtc="servers broker web populatedEventstore"
+#rtc="servers broker web populatedEventstore"
+rtc="web"
 possible_groups="rtc gcloud dotnet nginx node testtools crossbar eventstore nsgate minikubegate ${rtc}"
 
 # USAGE

--- a/deploy/docker/prepare
+++ b/deploy/docker/prepare
@@ -6,8 +6,7 @@ set -euo pipefail
 # CONFIGURATION
 # =============
 possible_commands="build push"
-#rtc="servers broker web populatedEventstore"
-rtc="web"
+rtc="servers broker web populatedEventstore"
 possible_groups="rtc gcloud dotnet nginx node testtools crossbar eventstore nsgate minikubegate ${rtc}"
 
 # USAGE

--- a/src/client/.dockerignore
+++ b/src/client/.dockerignore
@@ -1,0 +1,3 @@
+
+node_modules
+npm-debug.log


### PR DESCRIPTION
- Upgraded node version to LTS 8.11.3.
- Separated the npm install layer to quickly build the client.
- Added docker ignore file.

**Note:** To use node LTS alpine it will be needed to install python in the container. Alpine has been avoided in this task.