### PR TITLE
[ARTP-192] Blotter filter popups stuck when torn off

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8783,8 +8783,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8805,14 +8804,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8827,20 +8824,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8957,8 +8951,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8970,7 +8963,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8985,7 +8977,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8993,14 +8984,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9019,7 +9008,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9100,8 +9088,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9113,7 +9100,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9199,8 +9185,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9236,7 +9221,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9256,7 +9240,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9300,14 +9283,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/client/src/ui/blotter/components/Blotter.tsx
+++ b/src/client/src/ui/blotter/components/Blotter.tsx
@@ -48,6 +48,8 @@ const icons = {
 export default class Blotter extends React.Component<BlotterProps, BlotterState> {
   private gridApi: GridApi | null = null
 
+  private gridDoc = React.createRef<HTMLDivElement>()
+
   state = {
     displayedRows: 0
   }
@@ -61,7 +63,7 @@ export default class Blotter extends React.Component<BlotterProps, BlotterState>
         <BlotterStyle>
           <React.Fragment>
             <BlotterHeader canPopout={canPopout} onPopoutClick={onPopoutClick} gridApi={this.gridApi} />
-            <BlotterGrid>
+            <BlotterGrid innerRef={this.gridDoc}>
               <AgGridReact
                 columnDefs={columnDefinitions}
                 defaultColDef={DEFAULT_COLUMN_DEFINITION}
@@ -78,6 +80,7 @@ export default class Blotter extends React.Component<BlotterProps, BlotterState>
                 onModelUpdated={this.onModelUpdated}
                 onGridReady={this.onGridReady}
                 icons={icons}
+                getDocument={() => this.gridDoc.current.ownerDocument}
               />
             </BlotterGrid>
             <BlotterStatus>{`Displaying rows ${displayedRows} of ${rows.length}`}</BlotterStatus>


### PR DESCRIPTION
Bug: In a tear off, clicking on a blotter header filter will cause the popup to become stuck

Cause: Removed reference to ag-grid's owner document

Fix: Letting ag-grid hold a reference to the document