### PR TITLE
[ARTP-212] Remove rounded corners on torn off tiles

### DIFF
--- a/src/client/src/rt-components/index.ts
+++ b/src/client/src/rt-components/index.ts
@@ -1,5 +1,5 @@
 export { Environment, EnvironmentValue, withEnvironment } from './Environment'
-export { TearOff } from './tear-off'
+export { TearOff, TearOffContainer } from './tear-off'
 export { OpenFinChrome, OpenFinControls, OpenFinHeader } from './open-fin'
 export { Flex, flexStyle } from './flex'
 export { PopoutIcon, ExpandIcon, LogoIcon } from './icons'

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 import { RegionActions } from 'rt-actions'
+import { styled } from 'rt-theme'
 import Portal, { PortalProps } from './Portal'
+
+export const TearOffContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`
 
 type RenderCB = (popOut: () => void, tornOff: boolean) => JSX.Element
 
@@ -35,7 +41,7 @@ class TearOff extends React.PureComponent<TearOffProps, { tornOff: boolean }> {
     if (tornOff) {
       return (
         <Portal onUnload={() => this.popIn(id)} {...portalProps}>
-          {render(() => this.popOut(id), tornOff)}
+          <TearOffContainer>{render(() => this.popOut(id), tornOff)}</TearOffContainer>
         </Portal>
       )
     }

--- a/src/client/src/rt-components/tear-off/index.ts
+++ b/src/client/src/rt-components/tear-off/index.ts
@@ -1,1 +1,1 @@
-export { TearOffConnected as TearOff } from './TearOff'
+export { TearOffConnected as TearOff, TearOffContainer } from './TearOff'

--- a/src/client/src/ui/spotTile/components/styled.tsx
+++ b/src/client/src/ui/spotTile/components/styled.tsx
@@ -1,3 +1,4 @@
+import { TearOffContainer } from 'rt-components'
 import { styled } from 'rt-theme'
 
 export interface ColorProps {
@@ -25,6 +26,10 @@ export const TileBaseStyle = styled('div')`
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
+
+  ${TearOffContainer} & {
+    border-radius: 0px;
+  }
 `
 
 export const Icon = styled('i')`


### PR DESCRIPTION
Bug: When popped out, spot tiles still had rounded corners. This caused a gap where the background would be visible in each corner.

Cause: The original popout container was removed during theming

Fix: Creating a new styled component that wraps tear offs. The TearOffContainer allows us to account for tear off state in our styled components.