### PR TITLE
[ARTP-209] Unresponsive tile after notification

### DIFF
--- a/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
+++ b/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
@@ -17,7 +17,7 @@ const hasNotification = (tradeStatus: LastTradeExecutionStatus) => tradeStatus.h
 export default class NotificationContainer extends PureComponent<Props> {
   render() {
     return (
-      <Transition from={{ opacity: 0 }} enter={{ opacity: 1 }} leave={{ opacity: 0 }}>
+      <Transition from={{ opacity: 0 }} enter={{ opacity: 1 }} leave={{ opacity: 0, pointerEvents: 'none' }}>
         {this.renderNotifications()}
       </Transition>
     )


### PR DESCRIPTION
Bug: After a notification, a user would not be able to click a price button for about a second.

Cause: Due to animation, a notification component while unmounting is present until it is fully unmounted. This makes the tile look like it is ready to be clicked while the notification is actually still up, just not visible.

Fix: Added `pointer-events: none` on the leave property of the animation. This puts the CSS property on the notification component when unmounting, allowing the user to click-through the fading notification.