### PR TITLE
[ARTP-215] Style scrollbars

### DIFF
--- a/src/client/src/rt-theme/globals.ts
+++ b/src/client/src/rt-theme/globals.ts
@@ -55,4 +55,18 @@ export default injectGlobal`
     line-height: 1rem;
     text-rendering: geometricPrecision;
   }
+
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(212, 221, 232, .3);
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: rgba(0,0,0,0);
+  }
 `


### PR DESCRIPTION
Bug: Scrollbar styling is missing resulting in default styled scrollbars.

Cause: Scrollbar styling was removed.

Fix: Add in styling through `injectGlobal` provided by Emotion.js. While this works, it would be nice to come up with a more dynamic solution.