### PR TITLE
[ARTP 216] Fix for broken storybook views

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8804,12 +8804,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8824,19 +8826,18 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8953,8 +8954,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8966,7 +8966,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8981,6 +8980,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8995,7 +8995,6 @@
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9014,7 +9013,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9108,7 +9106,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9230,7 +9227,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/client/src/ui/spotTile/components/PriceMovement.tsx
+++ b/src/client/src/ui/spotTile/components/PriceMovement.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const MovementIcon = styled('i')<{ show: boolean; color: string }>`
   text-align: center;
-  color: ${({ theme, color }) => theme[color].base}}};
+  color: ${({ theme, color }) => theme[color].base};
   visibility: ${({ show }) => (show ? 'visible' : 'hidden')};
 `
 

--- a/src/client/src/ui/spotTile/components/SpotTile.stories.tsx
+++ b/src/client/src/ui/spotTile/components/SpotTile.stories.tsx
@@ -5,8 +5,8 @@ import { storiesOf } from '@storybook/react'
 
 import { action } from '@storybook/addon-actions'
 import { Flex } from 'rt-components'
-import { Story } from 'rt-storybook'
-import { styled } from 'rt-theme'
+import { Story as BaseStory } from 'rt-storybook'
+import { styled, ThemeProvider } from 'rt-theme'
 import { Direction } from 'rt-types'
 import { PriceMovementTypes } from '../model/priceMovementTypes'
 import NotionalInput from './notional'
@@ -23,6 +23,12 @@ const Centered = styled('div')`
   align-items: center;
   justify-content: center;
 `
+
+const Story: React.SFC = ({ children }) => (
+  <BaseStory>
+    <ThemeProvider theme={theme => theme.tile}>{children}</ThemeProvider>
+  </BaseStory>
+)
 
 const stories = storiesOf('Spot Tile', module)
 stories.addDecorator(withKnobs)

--- a/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
+++ b/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
@@ -34,7 +34,7 @@ export default class NotificationContainer extends PureComponent<Props> {
       )
     }
     if (!lastTradeExecutionStatus || !hasNotification(lastTradeExecutionStatus)) {
-      return () => null as SFC<void>
+      return (() => null) as SFC<object>
     }
     if (lastTradeExecutionStatus.hasError) {
       return (style: React.CSSProperties) => (
@@ -83,6 +83,6 @@ export default class NotificationContainer extends PureComponent<Props> {
         )
       }
     }
-    return () => null as SFC<void>
+    return (() => null) as SFC<object>
   }
 }

--- a/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
+++ b/src/client/src/ui/spotTile/components/notifications/NotificationContainer.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, SFC } from 'react'
+import React, { PureComponent } from 'react'
 import { Transition } from 'react-spring'
 import { CurrencyPair, TradeStatus } from 'rt-types'
 import { LastTradeExecutionStatus } from '../../model/spotTileData'
@@ -23,7 +23,7 @@ export default class NotificationContainer extends PureComponent<Props> {
     )
   }
 
-  private renderNotifications = () => {
+  private renderNotifications: () => ((style: React.CSSProperties) => JSX.Element | null) = () => {
     const { lastTradeExecutionStatus, currencyPair, onNotificationDismissed, isPriceStale } = this.props
     const symbols = `${currencyPair.base}/${currencyPair.terms}`
     if (isPriceStale) {
@@ -34,7 +34,7 @@ export default class NotificationContainer extends PureComponent<Props> {
       )
     }
     if (!lastTradeExecutionStatus || !hasNotification(lastTradeExecutionStatus)) {
-      return (() => null) as SFC<object>
+      return () => null
     }
     if (lastTradeExecutionStatus.hasError) {
       return (style: React.CSSProperties) => (
@@ -83,6 +83,6 @@ export default class NotificationContainer extends PureComponent<Props> {
         )
       }
     }
-    return (() => null) as SFC<object>
+    return () => null
   }
 }


### PR DESCRIPTION
Bug: Price button, price movement, and notional input broken in storybook.

Cause: In the migration to the new theming method, spot tile styling was not selected for.

Fix: Create a `Story` component with a `ThemeProvider` that selects for spot tile styles from the parent theme.