### PR TITLE
[ARTP-218] Blotter pop out flashing content before styles loaded

### DIFF
--- a/src/client/src/rt-components/tear-off/Portal.tsx
+++ b/src/client/src/rt-components/tear-off/Portal.tsx
@@ -71,9 +71,7 @@ class NewPortal extends React.Component<PortalProps & { environment: Environment
       childHead.innerHTML = parentHead.innerHTML.replace(/\/static/g, window.location.href + 'static')
       this.externalWindow.document.title = title
 
-      setTimeout(() => {
-        this.externalWindow.document.body.appendChild(this.container)
-      }, 200)
+      setTimeout(() => this.externalWindow.document.body.appendChild(this.container), 200)
 
       this.forceUpdate()
 

--- a/src/client/src/rt-components/tear-off/Portal.tsx
+++ b/src/client/src/rt-components/tear-off/Portal.tsx
@@ -63,8 +63,6 @@ class NewPortal extends React.Component<PortalProps & { environment: Environment
     const { onBlock, title } = this.props
 
     if (this.externalWindow) {
-      this.externalWindow.document.title = title
-
       const parentHead = document.head
       const childHead = this.externalWindow.document.head
 

--- a/src/client/src/rt-components/tear-off/Portal.tsx
+++ b/src/client/src/rt-components/tear-off/Portal.tsx
@@ -69,8 +69,11 @@ class NewPortal extends React.Component<PortalProps & { environment: Environment
       const childHead = this.externalWindow.document.head
 
       childHead.innerHTML = parentHead.innerHTML.replace(/\/static/g, window.location.href + 'static')
+      this.externalWindow.document.title = title
 
-      this.externalWindow.document.body.appendChild(this.container)
+      setTimeout(() => {
+        this.externalWindow.document.body.appendChild(this.container)
+      }, 200)
 
       this.forceUpdate()
 

--- a/src/client/src/rt-components/tear-off/Portal.tsx
+++ b/src/client/src/rt-components/tear-off/Portal.tsx
@@ -68,7 +68,8 @@ class NewPortal extends React.Component<PortalProps & { environment: Environment
 
       childHead.innerHTML = parentHead.innerHTML.replace(/\/static/g, window.location.href + 'static')
       this.externalWindow.document.title = title
-
+      // Wait 200ms to allow external window's styles to load
+      // Prevents flash of unstyled content
       setTimeout(() => this.externalWindow.document.body.appendChild(this.container), 200)
 
       this.forceUpdate()


### PR DESCRIPTION
Bug: When popping out the blotter, the blotter grid's header titles were visible before the styles were fully loaded.

Cause: Styles not fully loaded before content is visible.

Fix: Delay adding the content to the pop out DOM to allow styles to load.