### PR TITLE
Fix default client build script

### DIFF
--- a/src/client/package.json
+++ b/src/client/package.json
@@ -27,7 +27,7 @@
     "start:openfin:local": "npm-run-all -p openfin start:local",
     "start:openfin:cloud": "npm-run-all -p openfin start:cloud",
     "start:react-app": "react-app-rewired start --scripts-version react-scripts-ts",
-    "build": "npm run build:local",
+    "build": "npm run build:react-app",
     "build:local": "cross-env REACT_APP_ENV=local npm run build:react-app",
     "build:cloud": "cross-env REACT_APP_ENV=demo npm run build:react-app",
     "build:react-app": "cross-env NODE_ENV=development react-app-rewired build --scripts-version react-scripts-ts",


### PR DESCRIPTION
Removes a specified environment from default build script.

Compare with `build:local` or `build:cloud` which specify an environment — and therefore a particular host for the backend.