### PR TITLE
ARTP-277 Add scroll bar style via react-helmet style tag

### DIFF
--- a/src/client/src/shell/layouts/AppLayout.tsx
+++ b/src/client/src/shell/layouts/AppLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Helmet from 'react-helmet'
 import { styled } from 'rt-theme'
 
 import Header from '../components/app-header'
@@ -11,12 +12,30 @@ export interface Props {
   after?: React.ReactNode
 }
 
+const scrollbarCSS = `
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background-color: rgba(212, 221, 232, .4);
+  }
+  ::-webkit-scrollbar-corner {
+    background-color: rgba(0,0,0,0);
+  }
+`
+
 class AppLayout extends React.Component<Props> {
   render() {
     const { before, header, body, footer, after } = this.props
 
     return (
       <AppLayoutRoot>
+        <Helmet>
+          <style>{scrollbarCSS}</style>
+        </Helmet>
+
         {before}
 
         <Header>{header}</Header>
@@ -46,20 +65,6 @@ const AppLayoutRoot = styled.div`
 const Body = styled.div`
   display: flex;
   overflow: hidden;
-
-  ::-webkit-scrollbar {
-    min-width: 0.25rem;
-    min-height: 2rem;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    border-radius: 2px;
-    background-color: rgba(212, 221, 232, 0.4);
-  }
-
-  ::-webkit-scrollbar-corner {
-    background-color: rgba(127, 127, 127, 0);
-  }
 `
 
 export default AppLayout


### PR DESCRIPTION
The previous approach to styling scroll bars under `MainRoute` did not work. This is a simple fix, but the PR is open to suggestions.

It's important to keep in mind this style is not applicable to the `StyleguideRoute`. Therefore, we must find an appropriate place to add a global style — and do so without introducing side-effects outside of a component lifecycle. 

Specifically, we should not inject a global style on `import`, or even on component mount. We must mount and unmount globals when our component mounts and unmounts.