### PR TITLE
Generalize environment handling

### DIFF
--- a/src/client/src/index.tsx
+++ b/src/client/src/index.tsx
@@ -5,12 +5,13 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom'
 // Side-effecting import for rt-theme/globals
 import 'rt-theme'
 
-import { MainRoute, NotificationRoute, StyleguideRoute } from './routes'
+import { MainRoute, NotificationRoute, OrderTicketRoute, StyleguideRoute } from './routes'
 
 ReactDOM.render(
   <BrowserRouter>
     <Switch>
       <Route path="/styleguide" component={StyleguideRoute} />
+      <Route path="/order-ticket" component={OrderTicketRoute} />
       <Route path="/notification" component={NotificationRoute} />
       <Route component={MainRoute} />
     </Switch>

--- a/src/client/src/routes/MainRoute.tsx
+++ b/src/client/src/routes/MainRoute.tsx
@@ -3,7 +3,7 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { timer } from 'rxjs'
 
 import { ConnectionActions } from 'rt-actions'
-import { Environment } from 'rt-components'
+import { createEnvironment, Environment } from 'rt-components'
 import { AutobahnConnectionProxy } from 'rt-system'
 import { ThemeName, ThemeStorage } from 'rt-theme'
 
@@ -21,13 +21,8 @@ const APPLICATION_DISCONNECT = 15 * 60 * 1000
 const config = getEnvVars(process.env.REACT_APP_ENV!)
 const LOG_NAME = 'Application Service: '
 
-export default class MainRoute extends React.Component {
-  openfin = new OpenFin()
-
-  environment = {
-    isDesktop: this.openfin.isPresent,
-    openfin: this.openfin.isPresent ? this.openfin : null,
-  }
+export class MainRoute extends React.Component {
+  environment = createEnvironment<OpenFin>(new OpenFin())
 
   store = configureStore(
     createApplicationServices({
@@ -36,7 +31,7 @@ export default class MainRoute extends React.Component {
         'com.weareadaptive.reactivetrader',
         +(config.overwriteServerEndpoint ? config.serverPort : location.port)!,
       ),
-      openfin: this.openfin,
+      openfin: this.environment.openfin,
       user: FakeUserRepository.currentUser,
     }),
   )
@@ -66,3 +61,5 @@ export default class MainRoute extends React.Component {
     )
   }
 }
+
+export default MainRoute

--- a/src/client/src/routes/OrderTicketRoute/OrderTicketRoute.tsx
+++ b/src/client/src/routes/OrderTicketRoute/OrderTicketRoute.tsx
@@ -1,0 +1,9 @@
+import React, { PureComponent } from 'react'
+
+export class OrderTicketRoute extends PureComponent {
+  render() {
+    return <div>OrderTicketRoute</div>
+  }
+}
+
+export default OrderTicketRoute

--- a/src/client/src/routes/OrderTicketRoute/index.ts
+++ b/src/client/src/routes/OrderTicketRoute/index.ts
@@ -1,0 +1,1 @@
+export { OrderTicketRoute } from './OrderTicketRoute'

--- a/src/client/src/routes/OrderTicketRoute/index.tsx
+++ b/src/client/src/routes/OrderTicketRoute/index.tsx
@@ -1,0 +1,22 @@
+import React, { PureComponent } from 'react'
+
+import { createEnvironment, Environment } from 'rt-components'
+import { ThemeName, ThemeStorage } from 'rt-theme'
+
+import PlainOrderTicketRoute from './OrderTicketRoute'
+
+import { OpenFin } from '../../shell/openFin'
+
+export class OrderTicketRoute extends PureComponent {
+  environment = createEnvironment(new OpenFin())
+
+  render() {
+    return (
+      <ThemeStorage.Provider storage={sessionStorage} default={ThemeName.Dark}>
+        <Environment.Provider value={this.environment}>
+          <PlainOrderTicketRoute />
+        </Environment.Provider>
+      </ThemeStorage.Provider>
+    )
+  }
+}

--- a/src/client/src/routes/index.ts
+++ b/src/client/src/routes/index.ts
@@ -1,3 +1,4 @@
-export { default as MainRoute } from './MainRoute'
+export { MainRoute } from './MainRoute'
 export { NotificationRoute } from './NotificationRoute'
 export { StyleguideRoute } from './StyleguideRoute'
+export { OrderTicketRoute } from './OrderTicketRoute'

--- a/src/client/src/rt-components/Environment/EnvironmentContext.tsx
+++ b/src/client/src/rt-components/Environment/EnvironmentContext.tsx
@@ -1,19 +1,39 @@
 import React from 'react'
 
-export interface EnvironmentValue {
-  isDesktop: Boolean
-  openfin?: Window
+export interface EnvironmentValue<Provider extends Window = Window> {
+  provider: Provider
+  openfin?: Provider | null
+  [key: string]: Provider | null
 }
 
 export interface Window {
+  type: string | 'desktop' | 'browser'
+  platform: string | 'openfin' | 'browser'
   maximize: () => void
   minimize: () => void
   close: () => void
   open: (url: string) => void
+  [key: string]: any
 }
 
-export const Environment = React.createContext<EnvironmentValue>({
-  isDesktop: false
-})
+export function createEnvironment<Provider extends Window>(provider: any): EnvironmentValue<Provider> {
+  return {
+    provider,
+    get [provider.platform]() {
+      return provider && provider.isPresent ? provider : null
+    },
+  }
+}
+
+export const Environment = React.createContext<EnvironmentValue<Window>>(
+  createEnvironment<Window>({
+    type: 'browser',
+    platform: 'browser',
+    maximize: () => {},
+    minimize: () => {},
+    close: () => {},
+    open: () => {},
+  }),
+)
 
 export default Environment

--- a/src/client/src/rt-components/Environment/EnvironmentContext.tsx
+++ b/src/client/src/rt-components/Environment/EnvironmentContext.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-export interface EnvironmentValue<Provider extends Window = Window> {
+export interface EnvironmentValue<Provider extends WindowProvider = WindowProvider> {
   provider: Provider
   openfin?: Provider | null
   [key: string]: Provider | null
 }
 
-export interface Window {
+export interface WindowProvider {
   type: string | 'desktop' | 'browser'
   platform: string | 'openfin' | 'browser'
   maximize: () => void
@@ -16,7 +16,7 @@ export interface Window {
   [key: string]: any
 }
 
-export function createEnvironment<Provider extends Window>(provider: any): EnvironmentValue<Provider> {
+export function createEnvironment<Provider extends WindowProvider>(provider: any): EnvironmentValue<Provider> {
   return {
     provider,
     get [provider.platform]() {
@@ -25,8 +25,8 @@ export function createEnvironment<Provider extends Window>(provider: any): Envir
   }
 }
 
-export const Environment = React.createContext<EnvironmentValue<Window>>(
-  createEnvironment<Window>({
+export const Environment = React.createContext<EnvironmentValue<WindowProvider>>(
+  createEnvironment<WindowProvider>({
     type: 'browser',
     platform: 'browser',
     maximize: () => {},

--- a/src/client/src/rt-components/Environment/index.tsx
+++ b/src/client/src/rt-components/Environment/index.tsx
@@ -1,2 +1,2 @@
-export { Environment, EnvironmentValue } from './EnvironmentContext'
+export { createEnvironment, Environment, EnvironmentValue } from './EnvironmentContext'
 export { withEnvironment } from './withEnvironment'

--- a/src/client/src/rt-components/index.ts
+++ b/src/client/src/rt-components/index.ts
@@ -1,4 +1,4 @@
-export { Environment, EnvironmentValue, withEnvironment } from './Environment'
+export { createEnvironment, Environment, EnvironmentValue, withEnvironment } from './Environment'
 export { TearOff } from './tear-off'
 export { OpenFinChrome, OpenFinControls, OpenFinHeader } from './open-fin'
 export { Flex, flexStyle } from './flex'

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const RouteWrapperBase: React.SFC<Props> = ({ environment, children }) => (
   <RouteStyle>
-    {environment.isDesktop ? (
+    {environment.provider.platform === 'openfin' ? (
       <OpenFinChrome>
         <OpenFinHeader close={closeOpenFinWindow} />
         {children}

--- a/src/client/src/rt-components/tear-off/Portal.tsx
+++ b/src/client/src/rt-components/tear-off/Portal.tsx
@@ -29,7 +29,7 @@ class NewPortal extends React.Component<PortalProps & { environment: Environment
   async componentDidMount() {
     const { environment, config, desktopConfig, browserConfig } = this.props
 
-    if (environment.isDesktop) {
+    if (environment.provider.type === 'desktop') {
       const win = await openDesktopWindow({ ...config, ...desktopConfig })
       win.addEventListener('closed', this.release)
       this.externalWindow = win.getNativeWindow()

--- a/src/client/src/shell/openFin/index.ts
+++ b/src/client/src/shell/openFin/index.ts
@@ -1,1 +1,1 @@
-export { default as OpenFin } from './openFin'
+export { OpenFin } from './openFin'

--- a/src/client/src/shell/openFin/openFin.ts
+++ b/src/client/src/shell/openFin/openFin.ts
@@ -4,7 +4,10 @@ const LOG_NAME = 'OpenFin: '
 
 const REQUEST_LIMIT_CHECK_TOPIC = 'request-limit-check'
 
-export default class OpenFin {
+export class OpenFin {
+  type = 'desktop'
+  platform = 'openfin'
+
   private limitCheckSubscriber: string | null = null
   private limitCheckId: number = 1
 

--- a/src/client/src/ui/spotTile/components/TileControls.tsx
+++ b/src/client/src/ui/spotTile/components/TileControls.tsx
@@ -51,7 +51,7 @@ const TileControls: React.SFC<Props & { environment: EnvironmentValue }> = ({
         <PopoutIcon width={0.8125} height={0.75} />
       </TopRightButton>
     )}
-    {environment.isDesktop && (
+    {environment.provider.type === 'desktop' && (
       <BottomRightButton onClick={displayCurrencyChart}>
         <i className="fas fa-chart-bar" />
       </BottomRightButton>


### PR DESCRIPTION
This is a proposal to generalize the environment we share across applications within Reactive Trader. As Reactive Trader grows to include application environments beyond OpenFin or the browser we'll want consistency in how we think and communicate with that underlying environment.

This change consolidates the definition of the environment and window provider. It alters the interface to be invariant to changes in platform specifics.

The underlying gist of a window provider is that we adopt browser conventions where ever possible. This happily minimizes the room for debate and possible surface area as we grow the feature set for each applications requirements.
 