### PR TITLE
Lower content-length threshold for gzip

### DIFF
--- a/deploy/docker/build/web/nginx/prod.nginx.conf
+++ b/deploy/docker/build/web/nginx/prod.nginx.conf
@@ -65,9 +65,10 @@ http {
             gzip_proxied any;
             gzip_http_version 1.1;
             gzip_comp_level 4;
-            # We are aligning minimum content-length with the size of an MTU of IPV4 
-            gzip_min_length 65536;
-            gzip_types text/plain text/css application/json application/javascript font/woff font/woff2 font/opentype image/svg+xml;
+            # We are aligning minimum content-length with the size of an MTU of IPV4
+            # (size of IPV4 MTU) - (size of the IPV4 header) = (2^16) - (20000) = 45536
+            gzip_min_length 45536;
+            gzip_types text/plain text/html text/css application/json application/javascript font/woff font/woff2 font/opentype image/svg+xml;
         }
 
         # # redirection to broker


### PR DESCRIPTION
This lowers the threshold for gzip to match the size of the datagram of an IPV4 MTU — given by:
```
(size of IPV4 MTU) - (size of the IPV4 header) = (2^16) - (20000) = 45536
```
But, check me on my maths here.