### PR TITLE
Bug/scrollbars

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8823,12 +8823,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8843,17 +8845,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8970,7 +8975,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8982,6 +8988,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8996,6 +9003,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9003,12 +9011,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9027,6 +9037,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9107,7 +9118,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9119,6 +9131,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9240,6 +9253,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/client/src/rt-components/resizer/Resizer.tsx
+++ b/src/client/src/rt-components/resizer/Resizer.tsx
@@ -33,6 +33,8 @@ const Bar = styled.div`
     opacity: 0.3;
     transition: all 200ms ease-in-out;
   }
+
+  user-select: none;
 `
 
 interface Props {

--- a/src/client/src/rt-theme/globals.ts
+++ b/src/client/src/rt-theme/globals.ts
@@ -73,4 +73,9 @@ export default injectGlobal`
   button:focus {
     outline: none;
   }
+  
+  /* Undo ress.css overflow-y rule */
+  html {
+    overflow-y: initial;
+  } 
 `

--- a/src/client/src/rt-theme/globals.ts
+++ b/src/client/src/rt-theme/globals.ts
@@ -1,5 +1,3 @@
-import { injectGlobal } from 'rt-theme'
-
 /**
  * Resetting CSS
  *
@@ -48,6 +46,9 @@ import 'typeface-montserrat'
  * line-height explicit in our styles will allow us to
  * achieve a consistent vertical rhythm.
  */
+
+import { injectGlobal } from './emotion'
+
 export default injectGlobal`
   :root, body {
     font-family: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;

--- a/src/client/src/rt-theme/index.ts
+++ b/src/client/src/rt-theme/index.ts
@@ -1,6 +1,6 @@
-export { flush, hydrate, cx, merge, getRegisteredStyles, injectGlobal, keyframes, css, sheet, caches } from './emotion'
-
 import './globals'
+
+export { flush, hydrate, cx, merge, getRegisteredStyles, injectGlobal, keyframes, css, sheet, caches } from './emotion'
 
 export { colors, CorePalette, CorePaletteMap, ColorPalette, ColorPaletteMaps } from './colors'
 export { Theme } from './createTheme'

--- a/src/client/src/shell/GlobalScrollbarStyle.tsx
+++ b/src/client/src/shell/GlobalScrollbarStyle.tsx
@@ -1,55 +1,65 @@
+import { injectGlobal } from 'emotion'
 import { memoize } from 'lodash'
 import { rgba } from 'polished'
-import React from 'react'
+import React, { Component } from 'react'
 import Helmet from 'react-helmet'
 import { ThemeConsumer } from 'rt-theme'
 
 export const css = memoize(
   color => `
-  body, #root {
-    overflow: hidden;
-  }
-
-  body ::-webkit-scrollbar {
-    width: 16px;
-    height: 16px;
-  }
-
-  body ::-webkit-scrollbar-thumb {
-    border-radius: 22px;
-    background-color: rgba(212, 221, 232, .4);
-    
-
-    height: 16px;
-    border: 4.5px solid rgba(0, 0, 0, 0);
-    background-clip: padding-box;
-    background-color: ${color};
-  }
-  
-  body ::-webkit-scrollbar-corner {
-    background-color: rgba(0,0,0,0);
-  }
-
-  body .ag-body ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-
-  body .ag-body ::-webkit-scrollbar-thumb {
-    border-width: 2px;
-  }
+    body ::-webkit-scrollbar-thumb {
+      background-color: ${color};
+    }
 `,
   color => color,
 )
 
-export const GlobalScrollbarStyle = () => (
-  <ThemeConsumer>
-    {theme => (
-      <Helmet>
-        <style>{css(rgba(theme.secondary[3], 0.2))}</style>
-      </Helmet>
-    )}
-  </ThemeConsumer>
-)
+export class GlobalScrollbarStyle extends Component {
+  componentDidMount() {
+    // tslint:disable-next-line:no-unused-expression
+    injectGlobal`
+      body, #root {
+        overflow: hidden;
+      }
 
-export default GlobalScrollbarStyle
+      body ::-webkit-scrollbar {
+        width: 16px;
+        height: 16px;
+      }
+
+      body ::-webkit-scrollbar-thumb {
+        border-radius: 22px;
+        background-color: rgba(212, 221, 232, .4);
+        
+
+        height: 16px;
+        border: 4.5px solid rgba(0, 0, 0, 0);
+        background-clip: padding-box;
+      }
+      
+      body ::-webkit-scrollbar-corner {
+        background-color: rgba(0,0,0,0);
+      }
+
+      body .ag-body ::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+      }
+
+      body .ag-body ::-webkit-scrollbar-thumb {
+        border-width: 2px;
+      }
+    `
+  }
+  render() {
+    return (
+      <ThemeConsumer>
+        {theme => (
+          <Helmet>
+            <style>{css(rgba(theme.secondary[3], 0.2))}</style>
+          </Helmet>
+        )}
+      </ThemeConsumer>
+    )
+  }
+}


### PR DESCRIPTION
By using `injectGlobal` instead of `Helmet` to provide the base styling of scrollbars, scrollbar styling will occur earlier. This will prevent unstyled scrollbars from showing.