### PR TITLE
Fix persistent OpenFin processes

### DIFF
--- a/src/client/public/config/openfin/local.app.json
+++ b/src/client/public/config/openfin/local.app.json
@@ -1,29 +1,30 @@
 {
-    "devtools_port": 9090,
-    "splashScreenImage": "http://localhost:3000/static/media/splash-screen.jpg",
-    "startup_app": {
-        "name": "Reactive Trader Cloud (LOCAL)",
-        "url": "http://localhost:3000/",
-        "uuid": "reactive-trader-cloud-local",
-        "applicationIcon": "http://localhost:3000/static/media/adaptive-mark-large.png",
-        "autoShow": true,
-        "defaultWidth": 1280,
-        "defaultHeight": 900,
-        "minWidth": 800,
-        "minHeight": 600,
-        "resizable": true,
-        "maximizable": true,
-        "frame": false
-    },
-    "runtime": {
-        "version": "9.61.34.22",
-        "futureVersion": "9.61.34.22",
-        "forceLatest": true
-    },
-    "shortcut": {
-        "company": "Adaptive Consulting",
-        "description": "Desktop Reactive Trader Cloud",
-        "icon": "http://localhost:3000/static/media/icon.ico",
-        "name": "Reactive Trader Cloud (LOCAL)"
-    }
+  "devtools_port": 9090,
+  "splashScreenImage": "http://localhost:3000/static/media/splash-screen.jpg",
+  "startup_app": {
+    "name": "Reactive Trader Cloud (LOCAL)",
+    "url": "http://localhost:3000/",
+    "uuid": "reactive-trader-cloud-local",
+    "applicationIcon": "http://localhost:3000/static/media/adaptive-mark-large.png",
+    "autoShow": true,
+    "defaultWidth": 1280,
+    "defaultHeight": 900,
+    "minWidth": 800,
+    "minHeight": 600,
+    "resizable": true,
+    "maximizable": true,
+    "frame": false,
+    "nonPersistent": true
+  },
+  "runtime": {
+    "version": "9.61.34.22",
+    "futureVersion": "9.61.34.22",
+    "forceLatest": true
+  },
+  "shortcut": {
+    "company": "Adaptive Consulting",
+    "description": "Desktop Reactive Trader Cloud",
+    "icon": "http://localhost:3000/static/media/icon.ico",
+    "name": "Reactive Trader Cloud (LOCAL)"
+  }
 }


### PR DESCRIPTION
When closing OpenFin, the OpenFin process would sometimes linger.

By setting the `nonPersist` flag to true, OpenFin should close when we close the application.

According to the OpenFin docs, `nonPersist` is:
"A flag to configure the application as non-persistent. Runtime exits when there are no persistent apps running."