### PR TITLE
fix: removed nonPersistent from openfin configs

### DIFF
--- a/src/client/public/config/openfin/demo.json
+++ b/src/client/public/config/openfin/demo.json
@@ -13,8 +13,7 @@
     "minHeight": 600,
     "resizable": true,
     "maximizable": true,
-    "frame": false,
-    "nonPersistent": true
+    "frame": false
   },
   "runtime": {
     "arguments": "--force-device-scale-factor=1",

--- a/src/client/public/config/openfin/dev.json
+++ b/src/client/public/config/openfin/dev.json
@@ -13,8 +13,7 @@
     "minHeight": 600,
     "resizable": true,
     "maximizable": true,
-    "frame": false,
-    "nonPersistent": true
+    "frame": false
   },
   "runtime": {
     "arguments": "--force-device-scale-factor=1",

--- a/src/client/public/config/openfin/local.json
+++ b/src/client/public/config/openfin/local.json
@@ -14,7 +14,6 @@
         "resizable": true,
         "maximizable": true,
         "frame": false,
-        "nonPersistent": true,
         "contextMenu": true,
         "accelerator": {
             "devtools": true,

--- a/src/client/public/config/openfin/orderticket.json
+++ b/src/client/public/config/openfin/orderticket.json
@@ -15,7 +15,6 @@
         "resizable": false,
         "maximizable": false,
         "frame": false,
-        "nonPersistent": true,
         "contextMenu": true,
         "alwaysOnTop": false,
         "accelerator": {


### PR DESCRIPTION
**Issue**
RT closing when other connected external windows exited (e.g Excel, ChartIQ, Limit Checker)

**Solution**
Remove the nonPersistant:true property from the OpenFin config