### PR TITLE
ARTP-394 Fixed JS error when shrinking the browser window height

### DIFF
--- a/src/client/src/ui/analytics/components/analyticsLineChart/styled.tsx
+++ b/src/client/src/ui/analytics/components/analyticsLineChart/styled.tsx
@@ -3,6 +3,9 @@ import { styled } from 'rt-theme'
 export const AnalyticsLineChartStyle = styled.div`
   width: 100%;
   height: 100%;
+  min-height: 35px; /* Required to avoid JS errors when resizing the height of the browser small enough such 
+                        that the height of the chart is computed as negative values. -D.S. ARTP-394 */
+  overflow-y: hidden;
   .recharts-cartesian-axis-ticks {
     color: #ffffff;
     width: 52px;


### PR DESCRIPTION
...such that the line chart shrinks to 0 (actually, its height was computed as a negative number).

https://weareadaptive.atlassian.net/browse/ARTP-394