### PR TITLE
Proposal to prevent the FlexDiv styled-component to generate over 200 classes

### DIFF
--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as builder
+FROM node:11.10-alpine as builder
 WORKDIR '/app'
 COPY ./package*.json ./
 RUN npm install

--- a/src/client/Dockerfile.dev
+++ b/src/client/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:11.10-alpine
 WORKDIR '/app'
 COPY ./package*.json ./
 RUN npm install

--- a/src/client/src/ui/analytics/components/analyticsBarChart/styled.tsx
+++ b/src/client/src/ui/analytics/components/analyticsBarChart/styled.tsx
@@ -8,12 +8,16 @@ const FlexDiv = styled.div`
 export const BarChart = styled.div`
   display: flex;
 `
-export const PriceContainer = styled(FlexDiv)<{ distance: number }>`
+
+export const PriceContainer = styled(FlexDiv).attrs((props: { distance: number }) => ({
+  style: {
+    transform: `translate(${props.distance}%)`,
+  },
+}))<{ distance: number }>`
   width: 100%;
   font-size: 11px;
   transition: transform 0.5s;
   transition-timing-function: ${({ theme }) => theme.motion.easing};
-  transform: translate(${({ distance }) => distance}%);
 `
 
 export const Offset = styled.div`


### PR DESCRIPTION
Proposal to use `attrs` for the dynamic `transform` property on `FlexDiv` for performance.

![Screen Shot 2019-03-11 at 4 07 34 PM](https://user-images.githubusercontent.com/1565793/54159005-480e8a00-4422-11e9-835b-ba9d9c95e298.png)

Currently, every single `FlexDiv` in `PriceContainer` (in PnL) will generate its own new CSS class everytime the value of `distance` is updated. That's why we end up getting that warning (screenshot above).

If you hover the css class only that particular `FlexDiv` is highlighted in blue (on `develop`). So most likely each css class of each of these `FlexDiv` is only used for a few seconds.

![Screen Shot 2019-03-11 at 5 21 55 PM](https://user-images.githubusercontent.com/1565793/54159160-ba7f6a00-4422-11e9-89a1-aa1e8175de73.png)

With this update if you hover the css class you will see that all the `PriceContainer` are now highlighted in blue because they can now all use the same css class and styled-component doesn't need to generate a new unique css class every few seconds for every `PriceContainer`.

![Screen Shot 2019-03-11 at 5 19 09 PM](https://user-images.githubusercontent.com/1565793/54159245-f0bce980-4422-11e9-81d6-1c77b9acefb9.png)


