### PR TITLE
Handling commas and exceeding values in `NotionalInput`

### DIFF
--- a/src/client/src/ui/spotTile/components/PriceButton.tsx
+++ b/src/client/src/ui/spotTile/components/PriceButton.tsx
@@ -22,6 +22,7 @@ export const TradeButton = styled.button<{ direction: Direction }>`
       ? `
   cursor: initial;
   opacity: 0.3;
+  pointer-events: none;
     `
       : `
   .spot-tile:hover & {

--- a/src/client/src/ui/spotTile/components/PriceButton.tsx
+++ b/src/client/src/ui/spotTile/components/PriceButton.tsx
@@ -7,7 +7,7 @@ const hoverColors = {
   [Direction.Sell]: 'red',
 }
 
-export const TradeButton = styled('button')<{ direction: Direction }>`
+export const TradeButton = styled.button<{ direction: Direction }>`
   background-color: ${({ theme }) => theme.core.lightBackground};
   border-radius: 3px;
   transition: background-color 0.2s ease;
@@ -16,14 +16,22 @@ export const TradeButton = styled('button')<{ direction: Direction }>`
   outline: none;
   padding: 0.75rem 1.5rem;
   margin-bottom: 2px;
-  .spot-tile:hover & {
-    background-color: ${({ theme }) => theme.core.darkBackground};
-  }
 
-  .spot-tile:hover &:hover {
-    background-color: ${({ theme, direction }) => theme.template[hoverColors[direction]].normal};
-    color: ${({ theme }) => theme.template.white.normal};
+  ${({ theme, direction, disabled }) =>
+    disabled
+      ? `
+  cursor: initial;
+  opacity: 0.3;
+    `
+      : `
+  .spot-tile:hover & {
+    background-color: ${theme.core.darkBackground};
   }
+  .spot-tile:hover &:hover {
+    background-color: ${theme.template[hoverColors[direction]].normal};
+    color: ${theme.template.white.normal};
+  }
+  `}
 `
 
 const Box = styled.div`

--- a/src/client/src/ui/spotTile/components/SpotTile.tsx
+++ b/src/client/src/ui/spotTile/components/SpotTile.tsx
@@ -43,7 +43,7 @@ export default class SpotTile extends PureComponent<Props> {
               currencyPairSymbol={currencyPair.base}
               updateNotional={updateNotional}
               setDisabledTradingState={setDisabledTradingState}
-              disabled={disabled}
+              isTradingDisabled={disabled}
             />
           </NotionalInputWrapper>
         </SpotTileStyle>

--- a/src/client/src/ui/spotTile/components/SpotTile.tsx
+++ b/src/client/src/ui/spotTile/components/SpotTile.tsx
@@ -21,6 +21,8 @@ export default class SpotTile extends PureComponent<Props> {
       executeTrade,
       canExecute,
       children,
+      setInErrorStatus,
+      inError,
     } = this.props
 
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
@@ -34,10 +36,16 @@ export default class SpotTile extends PureComponent<Props> {
             executeTrade={executeTrade}
             priceData={price}
             currencyPair={currencyPair}
-            disabled={canExecute}
+            disabled={!canExecute || inError}
           />
           <NotionalInputWrapper>
-            <NotionalInput notional={notional} currencyPairSymbol={currencyPair.base} updateNotional={updateNotional} />
+            <NotionalInput
+              notional={notional}
+              currencyPairSymbol={currencyPair.base}
+              updateNotional={updateNotional}
+              setInErrorStatus={setInErrorStatus}
+              inError={inError}
+            />
           </NotionalInputWrapper>
         </SpotTileStyle>
         {children}

--- a/src/client/src/ui/spotTile/components/SpotTile.tsx
+++ b/src/client/src/ui/spotTile/components/SpotTile.tsx
@@ -19,10 +19,9 @@ export default class SpotTile extends PureComponent<Props> {
       notional,
       updateNotional,
       executeTrade,
-      canExecute,
       children,
-      setInErrorStatus,
-      inError,
+      setDisabledTradingState,
+      disabled,
     } = this.props
 
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
@@ -36,15 +35,15 @@ export default class SpotTile extends PureComponent<Props> {
             executeTrade={executeTrade}
             priceData={price}
             currencyPair={currencyPair}
-            disabled={!canExecute || inError}
+            disabled={disabled}
           />
           <NotionalInputWrapper>
             <NotionalInput
               notional={notional}
               currencyPairSymbol={currencyPair.base}
               updateNotional={updateNotional}
-              setInErrorStatus={setInErrorStatus}
-              inError={inError}
+              setDisabledTradingState={setDisabledTradingState}
+              disabled={disabled}
             />
           </NotionalInputWrapper>
         </SpotTileStyle>

--- a/src/client/src/ui/spotTile/components/Tile.tsx
+++ b/src/client/src/ui/spotTile/components/Tile.tsx
@@ -17,13 +17,13 @@ interface Props {
 
 interface State {
   notional: string
-  inError: boolean
+  disabled: boolean
 }
 
 class Tile extends React.PureComponent<Props, State> {
   state = {
     notional: DEFAULT_NOTIONAL_VALUE,
-    inError: false, // should probably be a list of errors at some point
+    disabled: false,
   }
 
   tileComponents = {
@@ -33,7 +33,7 @@ class Tile extends React.PureComponent<Props, State> {
 
   updateNotional = (notional: string) => this.setState({ notional })
 
-  setInErrorStatus = (inError: boolean) => this.setState({ inError })
+  setDisabledTradingState = (disabled: boolean) => this.setState({ disabled })
 
   executeTrade = (direction: Direction, rawSpotRate: number) => {
     const { currencyPair, executeTrade } = this.props
@@ -62,8 +62,9 @@ class Tile extends React.PureComponent<Props, State> {
 
   render() {
     const { currencyPair, spotTileData, executionStatus, tileView } = this.props
-    const { notional, inError } = this.state
+    const { notional, disabled } = this.state
     const TileViewComponent = tileView ? this.tileComponents[tileView] : SpotTile
+
     return (
       <TileViewComponent
         currencyPair={currencyPair}
@@ -72,9 +73,8 @@ class Tile extends React.PureComponent<Props, State> {
         executionStatus={executionStatus}
         notional={notional}
         updateNotional={this.updateNotional}
-        setInErrorStatus={this.setInErrorStatus}
-        canExecute={this.canExecute}
-        inError={inError}
+        setDisabledTradingState={this.setDisabledTradingState}
+        disabled={disabled || !this.canExecute}
       >
         {this.props.children}
       </TileViewComponent>

--- a/src/client/src/ui/spotTile/components/Tile.tsx
+++ b/src/client/src/ui/spotTile/components/Tile.tsx
@@ -5,6 +5,7 @@ import SpotTile from './SpotTile'
 import numeral from 'numeral'
 import { AnalyticsTile } from './analyticsTile'
 import { TileViews } from '../../workspace/workspaceHeader'
+import { DEFAULT_NOTIONAL_VALUE } from './notional/NotionalInput'
 interface Props {
   currencyPair: CurrencyPair
   spotTileData: SpotTileData
@@ -19,7 +20,7 @@ interface State {
 
 class Tile extends React.PureComponent<Props, State> {
   state = {
-    notional: '1000000',
+    notional: DEFAULT_NOTIONAL_VALUE,
   }
   tileComponents = {
     [TileViews.Normal]: SpotTile,

--- a/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -48,7 +48,7 @@ class AnalyticsTile extends React.PureComponent<Props> {
                 currencyPairSymbol={currencyPair.base}
                 updateNotional={updateNotional}
                 setDisabledTradingState={setDisabledTradingState}
-                disabled={disabled}
+                isTradingDisabled={disabled}
               />
             </GraphNotionalWrapper>
             <AnalyticsPriceControl

--- a/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -29,6 +29,8 @@ class AnalyticsTile extends React.PureComponent<Props> {
       executeTrade,
       canExecute,
       children,
+      setInErrorStatus,
+      inError,
     } = this.props
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
     const date = spotDate && `SPT (${spotDate})`
@@ -46,13 +48,15 @@ class AnalyticsTile extends React.PureComponent<Props> {
                 notional={notional}
                 currencyPairSymbol={currencyPair.base}
                 updateNotional={updateNotional}
+                setInErrorStatus={setInErrorStatus}
+                inError={inError}
               />
             </GraphNotionalWrapper>
             <AnalyticsPriceControl
               executeTrade={executeTrade}
               priceData={price}
               currencyPair={currencyPair}
-              disabled={canExecute}
+              disabled={!canExecute || inError}
             />
           </AnalyticsTileContent>
         </AnalyticsTileStyle>

--- a/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/ui/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -27,10 +27,9 @@ class AnalyticsTile extends React.PureComponent<Props> {
       notional,
       updateNotional,
       executeTrade,
-      canExecute,
       children,
-      setInErrorStatus,
-      inError,
+      setDisabledTradingState,
+      disabled,
     } = this.props
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
     const date = spotDate && `SPT (${spotDate})`
@@ -48,15 +47,15 @@ class AnalyticsTile extends React.PureComponent<Props> {
                 notional={notional}
                 currencyPairSymbol={currencyPair.base}
                 updateNotional={updateNotional}
-                setInErrorStatus={setInErrorStatus}
-                inError={inError}
+                setDisabledTradingState={setDisabledTradingState}
+                disabled={disabled}
               />
             </GraphNotionalWrapper>
             <AnalyticsPriceControl
               executeTrade={executeTrade}
               priceData={price}
               currencyPair={currencyPair}
-              disabled={!canExecute || inError}
+              disabled={disabled}
             />
           </AnalyticsTileContent>
         </AnalyticsTileStyle>

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -69,7 +69,7 @@ interface Props {
   notional: string
   updateNotional: (notional: string) => void
   setDisabledTradingState: (disableTrading: boolean) => void
-  disabled: boolean
+  isTradingDisabled: boolean
 }
 
 interface State {
@@ -167,7 +167,7 @@ export default class NotionalInput extends PureComponent<Props, State> {
   }
 
   checkStatus = (value: string) => {
-    const { disabled } = this.props
+    const { isTradingDisabled } = this.props
     const { showMessage } = this.state
     const numericValue = convertNotionalShorthandToNumericValue(value)
     if (this.isInvalidTradingValue(value)) {
@@ -178,9 +178,10 @@ export default class NotionalInput extends PureComponent<Props, State> {
     } else if (numericValue >= MAX_NOTIONAL_VALUE) {
       // if entered value bigger than max, show message error.
       this.updateStatus(true, true)
-    } else if (showMessage || disabled) {
+    } else if (showMessage || isTradingDisabled) {
       // all value checks have passed
-      // if Buy/Sell buttons are disabled and/or error message is shown from previous check
+      // if Buy/Sell buttons are disabled (isTradingDisabled)
+      // and/or error message is shown from previous check
       // enable buttons and remove message error.
       this.updateStatus(false, false)
     }

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -20,7 +20,6 @@ const CurrencyPairSymbol = styled('span')`
   opacity: 0.59;
   font-size: 0.625rem;
   line-height: 1.2rem;
-  padding-right: 0.375rem;
 `
 
 const MessagePlaceholder = styled.div`
@@ -34,8 +33,8 @@ const MessagePlaceholder = styled.div`
 
 const InputWrapper = styled.div`
   display: grid;
-  grid-template-columns: 1auto 1auto;
-  grid-template-rows: 1auto 1auto;
+  grid-template-columns: 30px auto;
+  grid-template-rows: auto auto;
   grid-template-areas: 'Currency Input' '. Message';
 `
 

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -76,7 +76,7 @@ export default class NotionalInput extends PureComponent<Props> {
           defaultValue={formattedSize}
           onFocus={this.handleFocus}
           onChange={this.handleInputChange}
-          onBlur={this.handleBlur}
+          onBlur={this.handleUpdateCausedByEvent}
           onKeyPress={this.handleKeyPressNotionalInput}
           inputIsValid={inputIsValid}
         />
@@ -92,7 +92,7 @@ export default class NotionalInput extends PureComponent<Props> {
     const charCode = event.charCode
 
     if (event.key === ENTER) {
-      this.formatAndUpdateValue(event.currentTarget.value)
+      this.handleUpdateCausedByEvent(event)
     } else if (charCode === CHAR_CODE_DOT) {
       // only allow one dot
       if (event.currentTarget.value.match(/\./g)) {
@@ -124,7 +124,7 @@ export default class NotionalInput extends PureComponent<Props> {
     }
   }
 
-  handleBlur = (event: React.FormEvent<HTMLInputElement>) => {
+  handleUpdateCausedByEvent = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget
     this.formatAndUpdateValue(value !== '.' ? value : DEFAULT_NOTIONAL_VALUE)
   }

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -16,6 +16,7 @@ const RESET_NOTIONAL_VALUE = '0'
 export const DEFAULT_NOTIONAL_VALUE = '1000000'
 
 const CurrencyPairSymbol = styled('span')`
+  grid-area: Currency;
   opacity: 0.59;
   font-size: 0.625rem;
   line-height: 1.2rem;
@@ -23,27 +24,29 @@ const CurrencyPairSymbol = styled('span')`
 `
 
 const ErrorMessagePlaceholder = styled.div`
-  position: absolute;
-  right: 45px;
-  font-size: 0.625rem;
-  line-height: 1.2rem;
-  padding-right: 0.375rem;
-  text-transform: uppercase;
   ${({ theme }) => `color: ${theme.template.red.normal}`};
+  grid-area: Message;
+  font-size: 0.6rem;
+  line-height: normal;
+  padding-top: 2px;
+  margin-bottom: -1rem; /* Prevents the layout to change in Tile when this ErrorMessagePlaceholder is rendered */
 `
 
 const InputWrapper = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: 1auto 1auto;
+  grid-template-rows: 1auto 1auto;
+  grid-template-areas: 'Currency Input' '. Message';
 `
 
 export const Input = styled.input<{ inError: boolean }>`
+  grid-area: Input;
   background: none;
   text-align: center;
   outline: none;
   border: none;
   font-size: 0.75rem;
-  width: 85px;
-  transition: box-shadow 0.2s ease;
+  width: 80px;
   padding: 2px 0;
   ${({ inError, theme }) =>
     !inError
@@ -89,7 +92,7 @@ export default class NotionalInput extends PureComponent<Props> {
           onKeyPress={this.handleKeyPressNotionalInput}
           inError={inError}
         />
-        {inError && <ErrorMessagePlaceholder>* max exceeded</ErrorMessagePlaceholder>}
+        {inError && <ErrorMessagePlaceholder>Max exceeded</ErrorMessagePlaceholder>}
       </InputWrapper>
     )
   }

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -6,11 +6,11 @@ import { convertNotionalShorthandToNumericValue } from './utils'
 const NUMERAL_FORMAT = '0,000,000[.]00'
 const DOT = '.'
 const ENTER = 'Enter'
-const CHAR_CODE_DOT = 46
-const CHAR_CODE_0 = 48
-const CHAR_CODE_9 = 57
-const CHAR_CODE_UNIT_SEP = 31
-const SHORTCUT_CHAR_CODES = [75, 77, 107, 109]
+const CHAR_CODE_DOT = 46 // .
+const CHAR_CODE_0 = 48 // 0
+const CHAR_CODE_9 = 57 // 9
+const CHAR_CODE_UNIT_SEP = 31 // US (unit separator)
+const SHORTCUT_CHAR_CODES = [75, 77, 107, 109] // K, M, k, m
 const MAX_NOTIONAL_VALUE = 1000000000
 export const DEFAULT_NOTIONAL_VALUE = '1000000'
 const RESET_NOTIONAL_VALUE = DEFAULT_NOTIONAL_VALUE
@@ -29,7 +29,7 @@ const MessagePlaceholder = styled.div`
   font-size: 0.6rem;
   line-height: normal;
   padding-top: 2px;
-  margin-bottom: -1rem; /* Prevents the layout to change in Tile when this MessagePlaceholder is rendered */
+  margin-bottom: -1rem; /* Prevents the layout from changing in Tile when this MessagePlaceholder is rendered */
 `
 
 const InputWrapper = styled.div`
@@ -116,7 +116,7 @@ export default class NotionalInput extends PureComponent<Props, State> {
     if (event.key === ENTER) {
       this.handleUpdateCausedByEvent(event)
     } else if (charCode === CHAR_CODE_DOT) {
-      // only allow one dot unless the existing dot is in the
+      // only allow one dot unless the existing dot is in the current
       // text selection while replacing existing text.
       const { value, selectionStart, selectionEnd } = currentTarget
       const textWithoutSelection = value.replace(value.substring(selectionStart, selectionEnd), '')
@@ -152,7 +152,7 @@ export default class NotionalInput extends PureComponent<Props, State> {
     this.formatAndUpdateValue(valueToFormatAndUpdate, callback)
   }
 
-  isInvalidTradingValue = (value: string) => value === DOT || value === '0' || value === ''
+  isInvalidTradingValue = (value: string) => value === DOT || value === '0' || value === '' || value === 'Infinity'
 
   formatAndUpdateValue = (inputValue: string, callback?: (newValue: string) => void) => {
     const { updateNotional } = this.props

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -108,27 +108,30 @@ export default class NotionalInput extends PureComponent<Props> {
   }
 
   handleInputChange = (event: React.FormEvent<HTMLInputElement>) => {
-    // If user deletes all chars, set value back to DEFAULT_NOTIONAL_VALUE instead of empty string
-    let value = event.currentTarget.value.trim() || DEFAULT_NOTIONAL_VALUE
-    const numericValue = convertNotionalShorthandToNumericValue(value)
-    if (numericValue >= MAX_NOTIONAL_VALUE) {
-      value = DEFAULT_NOTIONAL_VALUE
-      this.triggerInputWarningMessage()
-    }
+    let value = event.currentTarget.value.trim()
 
-    if (!isNaN(numericValue)) {
-      // user may be trying to enter decimals. In that case, format and update only when completed.
-      const lastTwoChars = value.substr(-2)
-      if (lastTwoChars.indexOf(DOT) === -1) {
-        // propagate change back to dom node's value
-        this.formatAndUpdateValue(value)
+    // if empty string, no thing
+    if (value) {
+      const numericValue = convertNotionalShorthandToNumericValue(value)
+      if (numericValue >= MAX_NOTIONAL_VALUE) {
+        value = DEFAULT_NOTIONAL_VALUE
+        this.triggerInputWarningMessage()
+      }
+
+      if (!isNaN(numericValue)) {
+        // user may be trying to enter decimals. In that case, format and update only when completed.
+        const lastTwoChars = value.substr(-2)
+        if (lastTwoChars.indexOf(DOT) === -1) {
+          // propagate change back to dom node's value
+          this.formatAndUpdateValue(value)
+        }
       }
     }
   }
 
   handleUpdateCausedByEvent = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget
-    this.formatAndUpdateValue(value !== DOT ? value : DEFAULT_NOTIONAL_VALUE)
+    this.formatAndUpdateValue(value !== DOT && value !== '' ? value : DEFAULT_NOTIONAL_VALUE)
   }
 
   formatAndUpdateValue = (inputValue: string) => {

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -12,8 +12,9 @@ const CHAR_CODE_9 = 57
 const CHAR_CODE_UNIT_SEP = 31
 const SHORTCUT_CHAR_CODES = [75, 77, 107, 109]
 const MAX_NOTIONAL_VALUE = 1000000000
-const RESET_NOTIONAL_VALUE = '0'
 export const DEFAULT_NOTIONAL_VALUE = '1000000'
+const RESET_NOTIONAL_VALUE = DEFAULT_NOTIONAL_VALUE
+const RESET_MATCH_CASES = /(^$|[.,0])/g
 
 const CurrencyPairSymbol = styled('span')`
   grid-area: Currency;
@@ -143,7 +144,7 @@ export default class NotionalInput extends PureComponent<Props> {
 
   handleUpdateCausedByEvent = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget
-    this.formatAndUpdateValue(value !== DOT && value !== '' ? value : RESET_NOTIONAL_VALUE)
+    this.formatAndUpdateValue(!value.match(RESET_MATCH_CASES) ? value : RESET_NOTIONAL_VALUE)
   }
 
   formatAndUpdateValue = (inputValue: string) => {

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -4,6 +4,7 @@ import { styled } from 'rt-theme'
 import { convertNotionalShorthandToNumericValue } from './utils'
 
 const NUMERAL_FORMAT = '0,000,000[.]00'
+const DOT = '.'
 const ENTER = 'Enter'
 const CHAR_CODE_DOT = 46
 const CHAR_CODE_0 = 48
@@ -117,7 +118,7 @@ export default class NotionalInput extends PureComponent<Props> {
     if (!isNaN(numericValue)) {
       // user may be trying to enter decimals. In that case, format and update only when completed.
       const lastTwoChars = value.substr(-2)
-      if (lastTwoChars.indexOf('.') === -1) {
+      if (lastTwoChars.indexOf(DOT) === -1) {
         // propagate change back to dom node's value
         this.formatAndUpdateValue(value)
       }
@@ -126,7 +127,7 @@ export default class NotionalInput extends PureComponent<Props> {
 
   handleUpdateCausedByEvent = (event: React.FormEvent<HTMLInputElement>) => {
     const { value } = event.currentTarget
-    this.formatAndUpdateValue(value !== '.' ? value : DEFAULT_NOTIONAL_VALUE)
+    this.formatAndUpdateValue(value !== DOT ? value : DEFAULT_NOTIONAL_VALUE)
   }
 
   formatAndUpdateValue = (inputValue: string) => {

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -80,7 +80,8 @@ export default class NotionalInput extends PureComponent<Props, State> {
   private inputRef = React.createRef<HTMLInputElement>()
 
   state = {
-    showMessage: false, // TODO Add support for other errors and warnings.
+    // TODO Add support for other errors and warnings.
+    showMessage: convertNotionalShorthandToNumericValue(this.props.notional) >= MAX_NOTIONAL_VALUE,
   }
 
   render() {

--- a/src/client/src/ui/spotTile/components/notional/utils.ts
+++ b/src/client/src/ui/spotTile/components/notional/utils.ts
@@ -25,12 +25,6 @@ export function convertNotionalShorthandToNumericValue(value: string) {
   return newNotional
 }
 
-export function hasShorthandInput(value: string) {
-  const notionalShorthand = value.toUpperCase().replace(/,/g, '')
-  const matches = notionalShorthand.match(numberConvertRegex)
-  return matches && matches[2] !== undefined // found K or M
-}
-
 export function UtcFormatDate(date: Date, format: string = '%b %e, %H:%M:%S') {
   return utcFormat(format)(date)
 }

--- a/src/client/src/ui/spotTile/components/stories/AnalyticsTitle.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/AnalyticsTitle.stories.tsx
@@ -7,7 +7,7 @@ import { AnalyticsTile } from '../analyticsTile'
 
 const updateNotional = action('updateNotional')
 const executeTrade = action('executeTrade')
-const setInErrorStatus = action('setInErrorStatus')
+const setDisabledTradingState = action('setDisabledTradingState')
 
 stories.add('AnalyticsTile', () => (
   <Story>
@@ -25,9 +25,8 @@ stories.add('AnalyticsTile', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
-          setInErrorStatus={setInErrorStatus}
-          canExecute={true}
-          inError={false}
+          setDisabledTradingState={setDisabledTradingState}
+          disabled={false}
         />
       </div>
     </Centered>
@@ -50,9 +49,8 @@ stories.add('AnalyticsTile in error', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
-          setInErrorStatus={setInErrorStatus}
-          canExecute={true}
-          inError={true}
+          setDisabledTradingState={setDisabledTradingState}
+          disabled={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/stories/AnalyticsTitle.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/AnalyticsTitle.stories.tsx
@@ -3,11 +3,12 @@ import { stories, Story, Centered } from './Initialise.stories'
 import { action } from '@storybook/addon-actions'
 import { ServiceConnectionStatus } from 'rt-types'
 import { currencyPair, spotTileData } from '../test-resources/spotTileProps'
-
 import { AnalyticsTile } from '../analyticsTile'
 
 const updateNotional = action('updateNotional')
 const executeTrade = action('executeTrade')
+const setInErrorStatus = action('setInErrorStatus')
+
 stories.add('AnalyticsTile', () => (
   <Story>
     <Centered>
@@ -24,7 +25,34 @@ stories.add('AnalyticsTile', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
+          setInErrorStatus={setInErrorStatus}
           canExecute={true}
+          inError={false}
+        />
+      </div>
+    </Centered>
+  </Story>
+))
+
+stories.add('AnalyticsTile in error', () => (
+  <Story>
+    <Centered>
+      <div
+        style={{
+          width: '320px',
+          height: '150px',
+        }}
+      >
+        <AnalyticsTile
+          currencyPair={currencyPair}
+          spotTileData={spotTileData}
+          executeTrade={executeTrade}
+          executionStatus={ServiceConnectionStatus.CONNECTED}
+          notional="1,000,000"
+          updateNotional={updateNotional}
+          setInErrorStatus={setInErrorStatus}
+          canExecute={true}
+          inError={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
@@ -7,7 +7,29 @@ stories.add('Notional input', () => (
   <Story>
     <Centered>
       <div style={{ padding: '1.5rem' }}>
-        <NotionalInput notional="1,000,000" currencyPairSymbol="USD" updateNotional={action('Update notional')} />
+        <NotionalInput
+          notional="1,000,000"
+          currencyPairSymbol="USD"
+          updateNotional={action('Update notional')}
+          setInErrorStatus={action('setInErrorStatus')}
+          inError={false}
+        />
+      </div>
+    </Centered>
+  </Story>
+))
+
+stories.add('Notional input in error', () => (
+  <Story>
+    <Centered>
+      <div style={{ padding: '1.5rem' }}>
+        <NotionalInput
+          notional="1,000,000"
+          currencyPairSymbol="USD"
+          updateNotional={action('Update notional')}
+          setInErrorStatus={action('setInErrorStatus')}
+          inError={true}
+        />
       </div>
     </Centered>
   </Story>

--- a/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
@@ -12,7 +12,7 @@ stories.add('Notional input', () => (
           currencyPairSymbol="USD"
           updateNotional={action('Update notional')}
           setDisabledTradingState={action('setDisabledTradingState')}
-          disabled={false}
+          isTradingDisabled={false}
         />
       </div>
     </Centered>
@@ -28,7 +28,7 @@ stories.add('Notional input with trading disabled', () => (
           currencyPairSymbol="USD"
           updateNotional={action('Update notional')}
           setDisabledTradingState={action('setDisabledTradingState')}
-          disabled={true}
+          isTradingDisabled={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/NotionalInput.stories.tsx
@@ -11,15 +11,15 @@ stories.add('Notional input', () => (
           notional="1,000,000"
           currencyPairSymbol="USD"
           updateNotional={action('Update notional')}
-          setInErrorStatus={action('setInErrorStatus')}
-          inError={false}
+          setDisabledTradingState={action('setDisabledTradingState')}
+          disabled={false}
         />
       </div>
     </Centered>
   </Story>
 ))
 
-stories.add('Notional input in error', () => (
+stories.add('Notional input with trading disabled', () => (
   <Story>
     <Centered>
       <div style={{ padding: '1.5rem' }}>
@@ -27,8 +27,8 @@ stories.add('Notional input in error', () => (
           notional="1,000,000"
           currencyPairSymbol="USD"
           updateNotional={action('Update notional')}
-          setInErrorStatus={action('setInErrorStatus')}
-          inError={true}
+          setDisabledTradingState={action('setDisabledTradingState')}
+          disabled={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/stories/SpotTile.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/SpotTile.stories.tsx
@@ -7,7 +7,7 @@ import SpotTile from '../SpotTile'
 
 const executeTrade = action('executeTrade')
 const updateNotional = action('updateNotional')
-const setInErrorStatus = action('setInErrorStatus')
+const setDisabledTradingState = action('setDisabledTradingState')
 
 stories.add('SpotTile', () => (
   <Story>
@@ -25,9 +25,8 @@ stories.add('SpotTile', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
-          setInErrorStatus={setInErrorStatus}
-          canExecute={true}
-          inError={false}
+          setDisabledTradingState={setDisabledTradingState}
+          disabled={false}
         />
       </div>
     </Centered>
@@ -50,9 +49,8 @@ stories.add('SpotTile in error', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
-          setInErrorStatus={setInErrorStatus}
-          canExecute={true}
-          inError={true}
+          setDisabledTradingState={setDisabledTradingState}
+          disabled={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/stories/SpotTile.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/SpotTile.stories.tsx
@@ -7,6 +7,7 @@ import SpotTile from '../SpotTile'
 
 const executeTrade = action('executeTrade')
 const updateNotional = action('updateNotional')
+const setInErrorStatus = action('setInErrorStatus')
 
 stories.add('SpotTile', () => (
   <Story>
@@ -24,7 +25,34 @@ stories.add('SpotTile', () => (
           executionStatus={ServiceConnectionStatus.CONNECTED}
           notional="1,000,000"
           updateNotional={updateNotional}
+          setInErrorStatus={setInErrorStatus}
           canExecute={true}
+          inError={false}
+        />
+      </div>
+    </Centered>
+  </Story>
+))
+
+stories.add('SpotTile in error', () => (
+  <Story>
+    <Centered>
+      <div
+        style={{
+          width: '320px',
+          height: '150px',
+        }}
+      >
+        <SpotTile
+          currencyPair={currencyPair}
+          spotTileData={spotTileData}
+          executeTrade={executeTrade}
+          executionStatus={ServiceConnectionStatus.CONNECTED}
+          notional="1,000,000"
+          updateNotional={updateNotional}
+          setInErrorStatus={setInErrorStatus}
+          canExecute={true}
+          inError={true}
         />
       </div>
     </Centered>

--- a/src/client/src/ui/spotTile/components/types.ts
+++ b/src/client/src/ui/spotTile/components/types.ts
@@ -8,8 +8,7 @@ export interface Props {
   executeTrade: (direction: Direction, rawSpotRate: number) => void
   notional: string
   updateNotional: (notional: string) => void
-  setInErrorStatus: (inError: boolean) => void
-  canExecute: boolean
-  inError: boolean
+  setDisabledTradingState: (inError: boolean) => void
+  disabled: boolean
   chartData?: []
 }

--- a/src/client/src/ui/spotTile/components/types.ts
+++ b/src/client/src/ui/spotTile/components/types.ts
@@ -8,6 +8,8 @@ export interface Props {
   executeTrade: (direction: Direction, rawSpotRate: number) => void
   notional: string
   updateNotional: (notional: string) => void
+  setInErrorStatus: (inError: boolean) => void
   canExecute: boolean
+  inError: boolean
   chartData?: []
 }


### PR DESCRIPTION
:warning: We still need to validate a few things.

We now show commas in field when inputing number. Resets to DEFAULT_NOTIONAL_VALUE when input value exceeds MAX_NOTIONAL_VALUE.

When finished:
![Screen Shot 2019-03-13 at 6 11 56 PM](https://user-images.githubusercontent.com/1565793/54318143-b9ce0b80-45bb-11e9-91b9-e4bfc9ad4495.png)

When inputting (Before):
![Screen Shot 2019-03-13 at 6 12 12 PM](https://user-images.githubusercontent.com/1565793/54318113-a458e180-45bb-11e9-9df1-391d1f71d369.png)

When inputting (After):
![Screen Shot 2019-03-13 at 6 10 47 PM](https://user-images.githubusercontent.com/1565793/54318157-cbafae80-45bb-11e9-9da0-c6aa91e4ad30.png)

When the value exceeds `MAX_NOTIONAL_VALUE`, it is set back to `DEFAULT_NOTIONAL_VALUE` and a red line appear to indicate that the entry was invalid. It disappears after 2 seconds.

![Screen Shot 2019-03-13 at 6 11 22 PM (2)](https://user-images.githubusercontent.com/1565793/54318342-64dec500-45bc-11e9-9035-78a9851a2750.png)

We need to validate these points: 

- [x] `DEFAULT_NOTIONAL_VALUE` is currently hardcoded to `1000000`, maybe it should be `0` ?
- [x] the UI for the input error
- [x] we should probably also show a message or tooltip or the end user will not know what was the problem probably.
- [ ] we should probably also imprement increase/decrease of the number using up/down arrows? It should behave like a number type input field.

⚠️ I did not leave the entered value in the field when exceeding `MAX_NOTIONAL_VALUE` because you don't want the end user to Buy or Sell with an invalid value entered.




