### PR TITLE
ARTP-573 / Tests and snapshots for Tile components

### DIFF
--- a/src/client/__tests__/helpers/index.tsx
+++ b/src/client/__tests__/helpers/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { ThemeProvider } from 'styled-components'
+import { themes } from '../../src/rt-theme'
+
+const lightTheme = themes.light
+const darkTheme = themes.dark
+
+export function renderWithTheme(component: JSX.Element, theme?: 'light' | 'dark') {
+  return renderer.create(
+    <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>{component}</ThemeProvider>,
+  )
+}

--- a/src/client/src/ui/spotTile/components/Tile/Tile.test.tsx
+++ b/src/client/src/ui/spotTile/components/Tile/Tile.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react'
+import { renderWithTheme } from '../../../../../__tests__/helpers'
+import Tile, { TileProps, TileState } from './Tile'
+import { currencyPair } from '../test-resources/spotTileProps'
+import { ServiceConnectionStatus } from 'rt-types'
+import { TileViews } from '../../../../ui/workspace/workspaceHeader'
+import { DerivedStateFromUserInput } from './TileBusinessLogic'
+import { TradingMode } from '../types'
+import { PriceMovementTypes } from '../../../../ui/spotTile/model/priceMovementTypes'
+
+const prevState: TileState = {
+  canExecute: true,
+  inputDisabled: false,
+  inputValidationMessage: null,
+  notional: '1,000,000',
+  tradingDisabled: false,
+}
+
+const defaultParams: DerivedStateFromUserInput = {
+  actions: {
+    setTradingMode: (tradingMode: TradingMode) => {},
+  },
+  prevState,
+  notionalUpdate: {
+    type: 'blur',
+    value: '1,000,000',
+  },
+  spotTileData: {
+    currencyChartIsOpening: false,
+    historicPrices: [],
+    isTradeExecutionInFlight: false,
+    lastTradeExecutionStatus: null,
+    price: {
+      ask: 1.48364,
+      bid: 1.4835,
+      creationTimestamp: 694779224112175,
+      mid: 1.48357,
+      priceMovementType: 'Down' as PriceMovementTypes,
+      symbol: 'EURCAD',
+      valueDate: '2019-04-07T00:00:00Z',
+    },
+    rfqPrice: null,
+    rfqState: 'none',
+    rfqTimeout: null,
+  },
+}
+
+const defaultTileProps: TileProps = {
+  children: jest.fn(),
+  currencyPair,
+  executeTrade: () => {},
+  setTradingMode: () => {},
+  executionStatus: 'CONNECTED' as ServiceConnectionStatus,
+  rfq: {
+    cancel: () => {},
+    expired: () => {},
+    reject: () => {},
+    request: () => {},
+    requote: () => {},
+    reset: () => {},
+  },
+  spotTileData: defaultParams.spotTileData,
+  tileView: 'Normal' as TileViews,
+}
+
+test('Snapshot, state derived from props, defaults, RFQ none, should be able to excute', () => {
+  const component = renderWithTheme(<Tile {...defaultTileProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, DISCONNECTED', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    executionStatus: 'DISCONNECTED' as ServiceConnectionStatus,
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, in trade', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    spotTileData: {
+      ...defaultTileProps.spotTileData,
+      isTradeExecutionInFlight: true,
+    },
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, RFQ requested', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    spotTileData: {
+      ...defaultTileProps.spotTileData,
+      rfqState: 'requested',
+    },
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, RFQ received', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    spotTileData: {
+      ...defaultTileProps.spotTileData,
+      rfqState: 'received',
+      rfqPrice: {
+        ask: 1.48364,
+        bid: 1.4835,
+        creationTimestamp: 694779224112175,
+        mid: 1.48357,
+        priceMovementType: 'Down' as PriceMovementTypes,
+        symbol: 'EURCAD',
+        valueDate: '2019-04-07T00:00:00Z',
+      },
+    },
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, RFQ canRequest', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    spotTileData: {
+      ...defaultTileProps.spotTileData,
+      rfqState: 'canRequest',
+    },
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('Snapshot, state derived from props, RFQ expired', () => {
+  const nextProps: TileProps = {
+    ...defaultTileProps,
+    spotTileData: {
+      ...defaultTileProps.spotTileData,
+      rfqState: 'expired',
+      rfqPrice: {
+        ask: 1.48364,
+        bid: 1.4835,
+        creationTimestamp: 694779224112175,
+        mid: 1.48357,
+        priceMovementType: 'Down' as PriceMovementTypes,
+        symbol: 'EURCAD',
+        valueDate: '2019-04-07T00:00:00Z',
+      },
+    },
+  }
+  const component = renderWithTheme(<Tile {...nextProps} />)
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/client/src/ui/spotTile/components/Tile/Tile.tsx
+++ b/src/client/src/ui/spotTile/components/Tile/Tile.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import { CurrencyPair, Direction, ServiceConnectionStatus } from 'rt-types'
-import { ExecuteTradeRequest, SpotTileData, createTradeRequest, TradeRequest } from '../model/index'
-import SpotTile from './SpotTile'
-import { AnalyticsTile } from './analyticsTile'
-import { TileViews } from '../../workspace/workspaceHeader'
-import { TileSwitchChildrenProps, TradingMode, RfqActions } from './types'
-import { ValidationMessage, NotionalUpdate } from './notional/NotionalInput'
+import {
+  ExecuteTradeRequest,
+  SpotTileData,
+  createTradeRequest,
+  TradeRequest,
+} from '../../model/index'
+import SpotTile from '../SpotTile'
+import { AnalyticsTile } from '../analyticsTile/index'
+import { TileViews } from '../../../workspace/workspaceHeader/index'
+import { TileSwitchChildrenProps, TradingMode, RfqActions } from '../types'
+import { ValidationMessage, NotionalUpdate } from '../notional/NotionalInput'
 import {
   getDefaultNotionalValue,
   getDerivedStateFromProps,
@@ -14,7 +19,7 @@ import {
   resetNotional,
   isValueInRfqRange,
 } from './TileBusinessLogic'
-import { getConstsFromRfqState } from '../model/spotTileUtils'
+import { getConstsFromRfqState } from '../../model/spotTileUtils'
 
 export interface TileProps {
   currencyPair: CurrencyPair

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
@@ -11,6 +11,168 @@ import { TileState } from './Tile'
 import { TradingMode } from '../types'
 import { PriceMovementTypes } from '../../../../ui/spotTile/model/priceMovementTypes'
 
+// edit mode, should not format on the fly
+// https://regex101.com/r/MrSCRE/3
+// Leave commented values to easily compare
+const shouldNotFormatOnTheFly = [
+  // '000',
+  // '00',
+  // ',',
+  '',
+  '.',
+  '0',
+  '0.1',
+  '0.4',
+  // '2.82',
+  // '12.87',
+  '4.5',
+  '5.',
+  '.6',
+  '12.',
+  // '34.56',
+  '34,876.',
+  '34,876.8',
+  // '34,876.89',
+  // '6.78',
+  // '103,234,876',
+  // '100,000,000',
+  // '123456',
+  // '123 456',
+  '0.0',
+  ',000,000',
+  '00,000,000',
+  // '0.00',
+  // '.98765',
+  // '.05',
+  // '.11',
+  // '0.11',
+  // 'Infinity',
+  // 'NaN',
+]
+// should format on the fly
+const shouldFormatOnTheFly = [
+  '000',
+  '00',
+  ',',
+  // '',
+  // '.',
+  // '0',
+  // '0.1',
+  // '0.4',
+  '2.82',
+  '12.87',
+  // '4.5',
+  // '5.',
+  // '.6',
+  // '12.',
+  '34.56',
+  // '34,876.',
+  // '34,876.8',
+  '34,876.89',
+  '6.78',
+  '103,234,876',
+  '100,000,000',
+  '123456',
+  '123 456',
+  // '0.0',
+  // ',000,000',
+  // '00,000,000',
+  '0.00',
+  '.98765',
+  '.05',
+  '.11',
+  '0.11',
+  'Infinity',
+  'NaN',
+]
+
+test('isEditMode should be true', () => {
+  shouldNotFormatOnTheFly.forEach(v => {
+    console.log('shouldNotFormatOnTheFly', v)
+    expect(isEditMode(v)).toBe(true)
+  })
+})
+
+test('isEditMode should be false', () => {
+  shouldFormatOnTheFly.forEach(v => {
+    console.log('shouldFormatOnTheFly', v)
+    expect(isEditMode(v)).toBe(false)
+  })
+})
+
+// invalid trading values, should disable trading (Buy/Sell buttons)
+// https://regex101.com/r/OWDRCO/2
+// Leave commented values to easily compare
+const invalidTradingValues = [
+  '.',
+  ',',
+  '0',
+  '0.0',
+  // '0.2',
+  // '0.1',
+  // '0.01',
+  // '0.98',
+  '0.00',
+  // '0.01',
+  // '34,134.',
+  // '34,134.7',
+  // '34,134.65',
+  '000,000',
+  '01,000',
+  // '1.1',
+  // '1',
+  // '1.98',
+  ',000',
+  // '12,123,123',
+  'Infinity',
+  'NaN',
+  '0',
+  // '.76',
+  '',
+]
+// valid trading values, should enable trading (Buy/Sell buttons)
+const validTradingValues = [
+  // '.',
+  // ',',
+  // '0',
+  // '0.0',
+  '0.2',
+  '0.1',
+  '0.01',
+  '0.98',
+  // '0.00',
+  '0.01',
+  '34,134.',
+  '34,134.7',
+  '34,134.65',
+  // '000,000',
+  // '01,000',
+  '1.1',
+  '1',
+  '1.98',
+  // ',000',
+  '12,123,123',
+  // 'Infinity',
+  // 'NaN',
+  // '0',
+  '.76',
+  // ''
+]
+
+test('isInvalidTradingValue should true', () => {
+  invalidTradingValues.forEach(v => {
+    console.log('invalidTradingValues', v)
+    expect(isInvalidTradingValue(v)).toBe(true)
+  })
+})
+
+test('isInvalidTradingValue should false', () => {
+  validTradingValues.forEach(v => {
+    console.log('validTradingValues', v)
+    expect(isInvalidTradingValue(v)).toBe(false)
+  })
+})
+
 test('getNumericNotional', () => {
   const numericValue = getNumericNotional('1,000,000')
   expect(numericValue).toBe(1000000)
@@ -57,91 +219,6 @@ test('isValueOverRfqRange', () => {
 
   const isOverRange5 = isValueOverRfqRange('1,000,000,001')
   expect(isOverRange5).toBe(true)
-})
-
-test('isInvalidTradingValue', () => {
-  const isInvalid = isInvalidTradingValue('1')
-  expect(isInvalid).toBe(false)
-
-  const isInvalid2 = isInvalidTradingValue('0')
-  expect(isInvalid2).toBe(true)
-
-  const isInvalid3 = isInvalidTradingValue('.')
-  expect(isInvalid3).toBe(true)
-
-  const isInvalid4 = isInvalidTradingValue('0.0')
-  expect(isInvalid4).toBe(true)
-
-  const isInvalid5 = isInvalidTradingValue('0.00')
-  expect(isInvalid5).toBe(true)
-
-  const isInvalid6 = isInvalidTradingValue('')
-  expect(isInvalid6).toBe(true)
-
-  const isInvalid7 = isInvalidTradingValue('NaN')
-  expect(isInvalid7).toBe(true)
-
-  const isInvalid8 = isInvalidTradingValue('Infinity')
-  expect(isInvalid8).toBe(true)
-
-  const isInvalid9 = isInvalidTradingValue(',')
-  expect(isInvalid9).toBe(true)
-
-  const isInvalid10 = isInvalidTradingValue('.0')
-  expect(isInvalid10).toBe(true)
-
-  const isInvalid11 = isInvalidTradingValue('0.01')
-  expect(isInvalid11).toBe(false)
-
-  const isInvalid12 = isInvalidTradingValue('0.1')
-  expect(isInvalid12).toBe(false)
-
-  const isInvalid13 = isInvalidTradingValue('10,009.01')
-  expect(isInvalid13).toBe(false)
-})
-
-test('isEditMode', () => {
-  const inEditMode = isEditMode('1')
-  expect(inEditMode).toBe(false)
-
-  const inEditMode2 = isEditMode('000,000')
-  expect(inEditMode2).toBe(true)
-
-  const inEditMode3 = isEditMode(',000,000')
-  expect(inEditMode3).toBe(true)
-
-  const inEditMode4 = isEditMode(',98')
-  expect(inEditMode4).toBe(true)
-
-  const inEditMode5 = isEditMode('0.00')
-  expect(inEditMode5).toBe(false)
-
-  const inEditMode6 = isEditMode('')
-  expect(inEditMode6).toBe(true)
-
-  const inEditMode7 = isEditMode('NaN')
-  expect(inEditMode7).toBe(false)
-
-  const inEditMode8 = isEditMode('Infinity')
-  expect(inEditMode8).toBe(false)
-
-  const inEditMode9 = isEditMode(',')
-  expect(inEditMode9).toBe(false)
-
-  const inEditMode10 = isEditMode('0.')
-  expect(inEditMode10).toBe(true)
-
-  const inEditMode11 = isEditMode('0.01')
-  expect(inEditMode11).toBe(false)
-
-  const inEditMode12 = isEditMode('0.1')
-  expect(inEditMode12).toBe(true)
-
-  const inEditMode13 = isEditMode('10,009.01')
-  expect(inEditMode13).toBe(false)
-
-  const inEditMode14 = isEditMode('0.0')
-  expect(inEditMode14).toBe(true)
 })
 
 const prevState: TileState = {
@@ -204,34 +281,4 @@ test('state derived from user interaction on change', () => {
     tradingDisabled: false,
   }
   expect(newState).toEqual(expected)
-
-  const newParams2 = {
-    ...defaultParams,
-    notionalUpdate: {
-      type: 'change',
-      value: ',000,000',
-    },
-  }
-  const newState2 = getDerivedStateFromUserInput(newParams2)
-  const expected2 = {
-    ...defaultNewState,
-    notional: ',000,000',
-    tradingDisabled: true,
-  }
-  expect(newState2).toEqual(expected2)
-
-  const newParams3 = {
-    ...defaultParams,
-    notionalUpdate: {
-      type: 'change',
-      value: ',000,000',
-    },
-  }
-  const newState3 = getDerivedStateFromUserInput(newParams3)
-  const expected3 = {
-    ...defaultNewState,
-    notional: ',000,000',
-    tradingDisabled: true,
-  }
-  expect(newState3).toEqual(expected3)
 })

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
@@ -4,7 +4,12 @@ import {
   isValueOverRfqRange,
   isInvalidTradingValue,
   isEditMode,
+  DerivedStateFromUserInput,
+  getDerivedStateFromUserInput,
 } from './TileBusinessLogic'
+import { TileState } from './Tile'
+import { TradingMode } from '../types'
+import { PriceMovementTypes } from '../../../../ui/spotTile/model/priceMovementTypes'
 
 test('getNumericNotional', () => {
   const numericValue = getNumericNotional('1,000,000')
@@ -137,4 +142,96 @@ test('isEditMode', () => {
 
   const inEditMode14 = isEditMode('0.0')
   expect(inEditMode14).toBe(true)
+})
+
+const prevState: TileState = {
+  canExecute: false,
+  inputDisabled: false,
+  inputValidationMessage: null,
+  notional: '1,000,000',
+  tradingDisabled: false,
+}
+
+const defaultParams: DerivedStateFromUserInput = {
+  actions: {
+    setTradingMode: (tradingMode: TradingMode) => {},
+  },
+  prevState,
+  notionalUpdate: {
+    type: 'blur',
+    value: '1,000,000',
+  },
+  spotTileData: {
+    currencyChartIsOpening: false,
+    historicPrices: [],
+    isTradeExecutionInFlight: false,
+    lastTradeExecutionStatus: null,
+    price: {
+      ask: 1.48364,
+      bid: 1.4835,
+      creationTimestamp: 694779224112175,
+      mid: 1.48357,
+      priceMovementType: 'Down' as PriceMovementTypes,
+      symbol: 'EURCAD',
+      valueDate: '2019-04-07T00:00:00Z',
+    },
+    rfqPrice: null,
+    rfqState: 'none',
+    rfqTimeout: null,
+  },
+}
+
+const defaultNewState: TileState = {
+  canExecute: false,
+  inputDisabled: false,
+  inputValidationMessage: null,
+  notional: '1,000,000',
+  tradingDisabled: false,
+}
+
+test('state derived from user interaction on change', () => {
+  const newParams = {
+    ...defaultParams,
+    notionalUpdate: {
+      type: 'change',
+      value: '1,000',
+    },
+  }
+  const newState = getDerivedStateFromUserInput(newParams)
+  const expected = {
+    ...defaultNewState,
+    notional: '1,000',
+    tradingDisabled: false,
+  }
+  expect(newState).toEqual(expected)
+
+  const newParams2 = {
+    ...defaultParams,
+    notionalUpdate: {
+      type: 'change',
+      value: ',000,000',
+    },
+  }
+  const newState2 = getDerivedStateFromUserInput(newParams2)
+  const expected2 = {
+    ...defaultNewState,
+    notional: ',000,000',
+    tradingDisabled: true,
+  }
+  expect(newState2).toEqual(expected2)
+
+  const newParams3 = {
+    ...defaultParams,
+    notionalUpdate: {
+      type: 'change',
+      value: ',000,000',
+    },
+  }
+  const newState3 = getDerivedStateFromUserInput(newParams3)
+  const expected3 = {
+    ...defaultNewState,
+    notional: ',000,000',
+    tradingDisabled: true,
+  }
+  expect(newState3).toEqual(expected3)
 })

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
@@ -12,9 +12,9 @@ import {
 } from './TileBusinessLogic'
 import { TileProps, TileState } from './Tile'
 import { TradingMode } from '../types'
-import { PriceMovementTypes } from '../../../../ui/spotTile/model/priceMovementTypes'
+import { PriceMovementTypes } from '../../model/priceMovementTypes'
 import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
-import { TileViews } from '../../../../ui/workspace/workspaceHeader'
+import { TileViews } from '../../../workspace/workspaceHeader/index'
 
 // edit mode, should not format on the fly
 // https://regex101.com/r/MrSCRE/3
@@ -360,7 +360,7 @@ test('state derived from user interaction on blur when isInvalidTradingValue is 
 })
 
 const defaultTileProps: TileProps = {
-  children: null,
+  children: jest.fn(),
   currencyPair,
   executeTrade: () => {},
   setTradingMode: () => {},
@@ -421,12 +421,13 @@ test('state derived from props, RFQ requested', () => {
     ...defaultTileProps,
     spotTileData: {
       ...defaultTileProps.spotTileData,
-      rfqState: 'canRequest',
+      rfqState: 'requested',
     },
   }
   const newState: TileState = getDerivedStateFromProps(nextProps, prevState)
   const expected = {
     ...prevState,
+    inputDisabled: true,
     canExecute: false,
   }
   expect(newState).toEqual(expected)

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
@@ -17,7 +17,7 @@ import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
 import { TileViews } from '../../../workspace/workspaceHeader/index'
 
 // edit mode, should not format on the fly
-// https://regex101.com/r/MrSCRE/3
+// https://regex101.com/r/MrSCRE/4
 // Leave commented values to easily compare
 const shouldNotFormatOnTheFly = [
   // '000',
@@ -53,6 +53,7 @@ const shouldNotFormatOnTheFly = [
   // '0.11',
   // 'Infinity',
   // 'NaN',
+  // '01234'
 ]
 // should format on the fly
 const shouldFormatOnTheFly = [
@@ -89,6 +90,7 @@ const shouldFormatOnTheFly = [
   '0.11',
   'Infinity',
   'NaN',
+  '01234',
 ]
 
 test('isEditMode should be true', () => {

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.test.ts
@@ -1,0 +1,140 @@
+import {
+  getNumericNotional,
+  isValueInRfqRange,
+  isValueOverRfqRange,
+  isInvalidTradingValue,
+  isEditMode,
+} from './TileBusinessLogic'
+
+test('getNumericNotional', () => {
+  const numericValue = getNumericNotional('1,000,000')
+  expect(numericValue).toBe(1000000)
+
+  const numericValue2 = getNumericNotional('1,000.00')
+  expect(numericValue2).toBe(1000)
+
+  const numericValue3 = getNumericNotional('7800')
+  expect(numericValue3).toBe(7800)
+
+  const numericValue4 = getNumericNotional(1200 as any)
+  expect(numericValue4).toBe(1200)
+})
+
+test('isValueInRfqRange', () => {
+  const isInRange = isValueInRfqRange('1,000,000')
+  expect(isInRange).toBe(false)
+
+  const isInRange2 = isValueInRfqRange('10,000,000')
+  expect(isInRange2).toBe(true)
+
+  const isInRange3 = isValueInRfqRange('999,999,999.99')
+  expect(isInRange3).toBe(true)
+
+  const isInRange4 = isValueInRfqRange('1,000,000,000')
+  expect(isInRange4).toBe(true)
+
+  const isInRange5 = isValueInRfqRange('1,000,000,001')
+  expect(isInRange5).toBe(false)
+})
+
+test('isValueOverRfqRange', () => {
+  const isOverRange = isValueOverRfqRange('1,000,000')
+  expect(isOverRange).toBe(false)
+
+  const isOverRange2 = isValueOverRfqRange('10,000,000')
+  expect(isOverRange2).toBe(false)
+
+  const isOverRange3 = isValueOverRfqRange('999,999,999.99')
+  expect(isOverRange3).toBe(false)
+
+  const isOverRange4 = isValueOverRfqRange('1,000,000,000')
+  expect(isOverRange4).toBe(false)
+
+  const isOverRange5 = isValueOverRfqRange('1,000,000,001')
+  expect(isOverRange5).toBe(true)
+})
+
+test('isInvalidTradingValue', () => {
+  const isInvalid = isInvalidTradingValue('1')
+  expect(isInvalid).toBe(false)
+
+  const isInvalid2 = isInvalidTradingValue('0')
+  expect(isInvalid2).toBe(true)
+
+  const isInvalid3 = isInvalidTradingValue('.')
+  expect(isInvalid3).toBe(true)
+
+  const isInvalid4 = isInvalidTradingValue('0.0')
+  expect(isInvalid4).toBe(true)
+
+  const isInvalid5 = isInvalidTradingValue('0.00')
+  expect(isInvalid5).toBe(true)
+
+  const isInvalid6 = isInvalidTradingValue('')
+  expect(isInvalid6).toBe(true)
+
+  const isInvalid7 = isInvalidTradingValue('NaN')
+  expect(isInvalid7).toBe(true)
+
+  const isInvalid8 = isInvalidTradingValue('Infinity')
+  expect(isInvalid8).toBe(true)
+
+  const isInvalid9 = isInvalidTradingValue(',')
+  expect(isInvalid9).toBe(true)
+
+  const isInvalid10 = isInvalidTradingValue('.0')
+  expect(isInvalid10).toBe(true)
+
+  const isInvalid11 = isInvalidTradingValue('0.01')
+  expect(isInvalid11).toBe(false)
+
+  const isInvalid12 = isInvalidTradingValue('0.1')
+  expect(isInvalid12).toBe(false)
+
+  const isInvalid13 = isInvalidTradingValue('10,009.01')
+  expect(isInvalid13).toBe(false)
+})
+
+test('isEditMode', () => {
+  const inEditMode = isEditMode('1')
+  expect(inEditMode).toBe(false)
+
+  const inEditMode2 = isEditMode('000,000')
+  expect(inEditMode2).toBe(true)
+
+  const inEditMode3 = isEditMode(',000,000')
+  expect(inEditMode3).toBe(true)
+
+  const inEditMode4 = isEditMode(',98')
+  expect(inEditMode4).toBe(true)
+
+  const inEditMode5 = isEditMode('0.00')
+  expect(inEditMode5).toBe(false)
+
+  const inEditMode6 = isEditMode('')
+  expect(inEditMode6).toBe(true)
+
+  const inEditMode7 = isEditMode('NaN')
+  expect(inEditMode7).toBe(false)
+
+  const inEditMode8 = isEditMode('Infinity')
+  expect(inEditMode8).toBe(false)
+
+  const inEditMode9 = isEditMode(',')
+  expect(inEditMode9).toBe(false)
+
+  const inEditMode10 = isEditMode('0.')
+  expect(inEditMode10).toBe(true)
+
+  const inEditMode11 = isEditMode('0.01')
+  expect(inEditMode11).toBe(false)
+
+  const inEditMode12 = isEditMode('0.1')
+  expect(inEditMode12).toBe(true)
+
+  const inEditMode13 = isEditMode('10,009.01')
+  expect(inEditMode13).toBe(false)
+
+  const inEditMode14 = isEditMode('0.0')
+  expect(inEditMode14).toBe(true)
+})

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -1,10 +1,10 @@
 import numeral from 'numeral'
-import { convertNotionalShorthandToNumericValue } from './notional/utils'
+import { convertNotionalShorthandToNumericValue } from '../notional/utils'
 import { ServiceConnectionStatus, CurrencyPair } from 'rt-types'
 import { TileProps, TileState } from './Tile'
-import { NotionalUpdate } from './notional/NotionalInput'
-import { SpotTileData } from '../model/spotTileData'
-import { getConstsFromRfqState } from '../model/spotTileUtils'
+import { NotionalUpdate } from '../notional/NotionalInput'
+import { SpotTileData } from '../../model/spotTileData'
+import { getConstsFromRfqState } from '../../model/spotTileUtils'
 
 // Constants
 export const NUMERAL_FORMAT = '0,000,000[.]00'

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -15,12 +15,13 @@ const MIN_RFQ_VALUE = 10000000
 const RESET_NOTIONAL_VALUE = DEFAULT_NOTIONAL_VALUE
 
 // Utils
+export const getFormattedValue = (value: number | string) => numeral(value).format(NUMERAL_FORMAT)
 export const getDefaultNotionalValue = (currencyPair: CurrencyPair) =>
   // This is to simply to have one Tile showing RFQ prompt on page load
   // check JIRA ticket ARTP-532
   currencyPair.symbol === 'NZDUSD'
-    ? numeral(MIN_RFQ_VALUE).format(NUMERAL_FORMAT)
-    : numeral(DEFAULT_NOTIONAL_VALUE).format(NUMERAL_FORMAT)
+    ? getFormattedValue(MIN_RFQ_VALUE)
+    : getFormattedValue(DEFAULT_NOTIONAL_VALUE)
 
 export const getNumericNotional = (notional: string) =>
   numeral(notional).value() || DEFAULT_NOTIONAL_VALUE
@@ -117,7 +118,7 @@ export const getDerivedStateFromUserInput = ({
     // user may be trying to enter decimals or
     // user may be deleting previous entry (empty string, etc)
     // in those cases, format and update only when completed.
-    notional: !isEditMode(value) ? numeral(value).format(NUMERAL_FORMAT) : value,
+    notional: !isEditMode(value) ? getFormattedValue(value) : value,
     inputValidationMessage: null,
     tradingDisabled: false,
   }
@@ -132,7 +133,7 @@ export const getDerivedStateFromUserInput = ({
     }
     return {
       ...defaultNextState,
-      notional: numeral(RESET_NOTIONAL_VALUE).format(NUMERAL_FORMAT),
+      notional: getFormattedValue(RESET_NOTIONAL_VALUE),
     }
   } else if (type === 'blur' && isEditMode(value)) {
     // onBlur if in editMore, format value
@@ -142,7 +143,7 @@ export const getDerivedStateFromUserInput = ({
     }
     return {
       ...defaultNextState,
-      notional: numeral(value).format(NUMERAL_FORMAT),
+      notional: getFormattedValue(value),
     }
   } else if (isInvalidTradingValue(value)) {
     // onChange if invalid trading value, update value

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -54,7 +54,7 @@ export const getDerivedStateFromProps = (nextProps: TileProps, prevState: TileSt
     executionStatus,
   } = nextProps
 
-  const { inputValidationMessage } = prevState
+  const { tradingDisabled } = prevState
 
   const isInTrade = !Boolean(
     executionStatus === ServiceConnectionStatus.CONNECTED && !isTradeExecutionInFlight && price,
@@ -64,8 +64,7 @@ export const getDerivedStateFromProps = (nextProps: TileProps, prevState: TileSt
     rfqState,
   )
 
-  const canExecute =
-    !isInTrade && !isRfqStateCanRequest && !isRfqStateRequested && !inputValidationMessage
+  const canExecute = !isInTrade && !isRfqStateCanRequest && !isRfqStateRequested && !tradingDisabled
 
   const inputDisabled = isInTrade || isRfqStateRequested || isRfqStateReceived
 

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -10,6 +10,7 @@ import { getConstsFromRfqState } from '../../model/spotTileUtils'
 export const NUMERAL_FORMAT = '0,000,000[.]00'
 const DEFAULT_NOTIONAL_VALUE = 1000000
 const MAX_NOTIONAL_VALUE = 1000000000
+const MAX_PROCESSING_VALUE = 999999999999999999999
 const MIN_RFQ_VALUE = 10000000
 const RESET_NOTIONAL_VALUE = DEFAULT_NOTIONAL_VALUE
 
@@ -74,7 +75,7 @@ export const getDerivedStateFromProps = (nextProps: TileProps, prevState: TileSt
   }
 }
 
-interface DerivedStateFromUserInput {
+export interface DerivedStateFromUserInput {
   prevState: TileState
   spotTileData: SpotTileData
   notionalUpdate: NotionalUpdate
@@ -83,7 +84,7 @@ interface DerivedStateFromUserInput {
   }
 }
 
-interface DerivedStateFromNotionalReset {
+export interface DerivedStateFromNotionalReset {
   prevState: TileState
   spotTileData: SpotTileData
   actions: {
@@ -100,6 +101,12 @@ export const getDerivedStateFromUserInput = ({
   actions,
 }: DerivedStateFromUserInput): TileState => {
   const { type, value } = notionalUpdate
+
+  // We block user input when value exceeds MAX_PROCESSING_VALUE
+  if (convertNotionalShorthandToNumericValue(value) > MAX_PROCESSING_VALUE) {
+    return prevState
+  }
+
   const {
     price: { symbol },
     rfqState,

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -29,16 +29,21 @@ export const isValueInRfqRange = (notional: string) => {
   return numericValue >= MIN_RFQ_VALUE && numericValue <= MAX_NOTIONAL_VALUE
 }
 
-const isValueOverRfqRange = (notional: string) => {
+export const isValueOverRfqRange = (notional: string) => {
   const numericValue = convertNotionalShorthandToNumericValue(notional)
   return numericValue > MAX_NOTIONAL_VALUE
 }
 
-const invalidTradingValuesRegex = /^(\.|,|0|.0|0.|0.0|$|Infinity|NaN)$/
-const isInvalidTradingValue = (value: string) => value.match(invalidTradingValuesRegex)
+// With these values, user should not be able to trade
+const invalidTradingValuesRegex = /^(\.|,|0|.0|0.|0.0|0.00|$|Infinity|NaN)$/
+// const invalidTradingValuesRegex = /(?!\d?\.\d{2,})^(,|$|0|\.|0\.(\d{1})?|Infinity|NaN)/
+export const isInvalidTradingValue = (value: string) =>
+  Boolean(value.match(invalidTradingValuesRegex))
 
-const editModeRegex = /(?!.*(0\.)).*^(,|$|0)/
-export const isEditMode = (value: string) => value.match(editModeRegex)
+// In edit mode, the notional input should not format
+// check https://regex101.com/r/MrSCRE/2a to view this regex in action
+const editModeRegex = /(?!^,$|^00$|^000$|^(.*)?\.\d{2,}$)^(,|$|0|\.|(.*)\.(\d{1})?)/
+export const isEditMode = (value: string) => Boolean(value.match(editModeRegex))
 
 // State management derived from props
 export const getDerivedStateFromProps = (nextProps: TileProps, prevState: TileState) => {
@@ -109,7 +114,7 @@ export const getDerivedStateFromUserInput = ({
 
   const { isRfqStateNone } = getConstsFromRfqState(rfqState)
 
-  if (type === 'change' && isEditMode(value)) {
+  if (type === 'change' && isInvalidTradingValue(value)) {
     // user is trying to enter decimals or modifying a number
     // or deleting previous entry (empty string)
     // disable trading, remove any message

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -35,13 +35,13 @@ export const isValueOverRfqRange = (notional: string) => {
 }
 
 // With these values, user should not be able to trade
-const invalidTradingValuesRegex = /^(\.|,|0|.0|0.|0.0|0.00|$|Infinity|NaN)$/
-// const invalidTradingValuesRegex = /(?!\d?\.\d{2,})^(,|$|0|\.|0\.(\d{1})?|Infinity|NaN)/
+// check https://regex101.com/r/OWDRCO/1 to view this regex in action
+const invalidTradingValuesRegex = /(?!(\d?\.\d{2,})|(\d?\.[1-9]{1}))^(,|$|0|\.|0\.([1-9]{1})?)|(^0.00$|Infinity|NaN)/
 export const isInvalidTradingValue = (value: string) =>
   Boolean(value.match(invalidTradingValuesRegex))
 
 // In edit mode, the notional input should not format
-// check https://regex101.com/r/MrSCRE/2a to view this regex in action
+// check https://regex101.com/r/MrSCRE/2 to view this regex in action
 const editModeRegex = /(?!^,$|^00$|^000$|^(.*)?\.\d{2,}$)^(,|$|0|\.|(.*)\.(\d{1})?)/
 export const isEditMode = (value: string) => Boolean(value.match(editModeRegex))
 

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -42,7 +42,7 @@ export const isInvalidTradingValue = (value: string) =>
   Boolean(value.match(invalidTradingValuesRegex))
 
 // In edit mode, the notional input should not format
-// check https://regex101.com/r/MrSCRE/2 to view this regex explanations and tests
+// check https://regex101.com/r/MrSCRE/3 to view this regex explanations and tests
 const editModeRegex = /(?!^,$|^00$|^000$|^(.*)?\.\d{2,}$)^(,|$|0|\.|(.*)\.(\d{1})?)/
 export const isEditMode = (value: string) => Boolean(value.match(editModeRegex))
 

--- a/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/ui/spotTile/components/Tile/TileBusinessLogic.ts
@@ -35,13 +35,13 @@ export const isValueOverRfqRange = (notional: string) => {
 }
 
 // With these values, user should not be able to trade
-// check https://regex101.com/r/OWDRCO/2 to view this regex in action
+// check https://regex101.com/r/OWDRCO/2 to view this regex explanations and tests
 const invalidTradingValuesRegex = /(?!(\d?\.\d{2,})|(\d?\.[1-9]{1}))^(,|$|0|\.|0\.([1-9]{1})?)|(^0.00$|Infinity|NaN)/
 export const isInvalidTradingValue = (value: string) =>
   Boolean(value.match(invalidTradingValuesRegex))
 
 // In edit mode, the notional input should not format
-// check https://regex101.com/r/MrSCRE/2 to view this regex in action
+// check https://regex101.com/r/MrSCRE/2 to view this regex explanations and tests
 const editModeRegex = /(?!^,$|^00$|^000$|^(.*)?\.\d{2,}$)^(,|$|0|\.|(.*)\.(\d{1})?)/
 export const isEditMode = (value: string) => Boolean(value.match(editModeRegex))
 

--- a/src/client/src/ui/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/ui/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -1,0 +1,1084 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <button
+          className="sc-EHOje gCbQHr"
+          direction="Sell"
+          disabled={true}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                SELL
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <button
+          className="sc-EHOje gCbQHr"
+          direction="Buy"
+          disabled={true}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                BUY
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb ixCVbX"
+            disabled={true}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <div
+          className="sc-iRbamj lkVRJy"
+        >
+          <i
+            className="fas fa-ban fa-flip-horizontal sc-jlyJG cibsWh"
+          />
+          Streaming price unavailable
+        </div>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <div
+          className="sc-iRbamj lkVRJy"
+        >
+          <i
+            className="fas fa-ban fa-flip-horizontal sc-jlyJG cibsWh"
+          />
+          Streaming price unavailable
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb fauXdE"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+          <button
+            className="sc-ifAKCX gROrJN"
+            onClick={[Function]}
+          >
+            <i
+              className="fas fa-redo fa-flip-horizontal"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, RFQ expired 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <button
+          className="sc-EHOje kkdSuS"
+          direction="Sell"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                SELL
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+          <div
+            className="sc-VigVT cLQaHF"
+          >
+            Expired
+          </div>
+        </button>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <button
+          className="sc-EHOje ciDDPg"
+          direction="Buy"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                BUY
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+          <div
+            className="sc-VigVT cLQaHF"
+          >
+            Expired
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb fauXdE"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+          <button
+            className="sc-ifAKCX gROrJN"
+            onClick={[Function]}
+          >
+            <i
+              className="fas fa-redo fa-flip-horizontal"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, RFQ received 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <button
+          className="sc-EHOje ixrtnE"
+          direction="Sell"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                SELL
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <button
+          className="sc-EHOje iHiLlf"
+          direction="Buy"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                BUY
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb ixCVbX"
+            disabled={true}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, RFQ requested 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <div
+          className="sc-iRbamj lkVRJy"
+        >
+          <div
+            className="sc-gipzik eqzpnJ"
+          >
+            <svg
+              height={14}
+              width={14}
+            >
+              <rect
+                className="sc-kEYyzF coOeJm"
+                height={10.5}
+                order={0}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={0.25}
+              />
+              <rect
+                className="sc-kEYyzF gedtZd"
+                height={10.5}
+                order={1}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={3.875}
+              />
+              <rect
+                className="sc-kEYyzF kSdfCf"
+                height={10.5}
+                order={2}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={7.5}
+              />
+              <rect
+                className="sc-kEYyzF brVaZY"
+                height={10.5}
+                order={3}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={11.125}
+              />
+            </svg>
+          </div>
+          Awaiting price
+        </div>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <div
+          className="sc-iRbamj lkVRJy"
+        >
+          <div
+            className="sc-gipzik eqzpnJ"
+          >
+            <svg
+              height={14}
+              width={14}
+            >
+              <rect
+                className="sc-kEYyzF coOeJm"
+                height={10.5}
+                order={0}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={0.25}
+              />
+              <rect
+                className="sc-kEYyzF gedtZd"
+                height={10.5}
+                order={1}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={3.875}
+              />
+              <rect
+                className="sc-kEYyzF kSdfCf"
+                height={10.5}
+                order={2}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={7.5}
+              />
+              <rect
+                className="sc-kEYyzF brVaZY"
+                height={10.5}
+                order={3}
+                speed={0.8}
+                type="secondary"
+                width={2.625}
+                x={11.125}
+              />
+            </svg>
+          </div>
+          Awaiting price
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb ixCVbX"
+            disabled={true}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, defaults, RFQ none, should be able to excute 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <button
+          className="sc-EHOje kkdSuS"
+          direction="Sell"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                SELL
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <button
+          className="sc-EHOje ciDDPg"
+          direction="Buy"
+          disabled={false}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi crpdKd"
+            disabled={false}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                BUY
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb fauXdE"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Snapshot, state derived from props, in trade 1`] = `
+<div
+  className="sc-eqIVtm sc-fAjcbJ koGyEZ"
+>
+  <div
+    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+  >
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-hmzhuo eiuqZU"
+      >
+        <div
+          className="sc-dVhcbM erSHUY"
+        >
+          <div
+            className="sc-hzDkRC hefQwu"
+          >
+            EUR/USD
+          </div>
+          <div
+            className="sc-bRBYWo kCsDOb"
+          >
+            SPT (07 APR)
+          </div>
+        </div>
+      </div>
+      <div
+        className="sc-gPEVay YCpKu"
+      >
+        <button
+          className="sc-EHOje gCbQHr"
+          direction="Sell"
+          disabled={true}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                SELL
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+        <div
+          className="sc-jzJRlG iKkJoh"
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-up sc-jTzLTM gkTtVL"
+            color="green"
+          />
+          <div
+            className="sc-fjdhpX flAxeK"
+          >
+            0.0
+          </div>
+          <i
+            aria-hidden="true"
+            className="fas fa-caret-down sc-jTzLTM TMXdn"
+            color="red"
+          />
+        </div>
+        <button
+          className="sc-EHOje gCbQHr"
+          direction="Buy"
+          disabled={true}
+          onClick={[Function]}
+        >
+          <div
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
+          >
+            <div
+              className="sc-gqjmRU cKkifn"
+            >
+              <div
+                className="sc-bZQynM sc-gzVnrw lDSPw"
+              >
+                BUY
+              </div>
+              <div
+                className="sc-bZQynM sc-htoDjs duRaET"
+              >
+                1.
+              </div>
+            </div>
+            <div
+              className="sc-bZQynM sc-dnqmqq fBMQfa"
+            >
+              48
+            </div>
+            <div
+              className="sc-bZQynM sc-iwsKbI CPNEg"
+            >
+              4
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      className="sc-caSCKo jjNSwx"
+    >
+      <div
+        className="sc-kjoXOD bvCYDb"
+      >
+        <div
+          className="sc-htpNat idZgat"
+        >
+          <span
+            className="sc-bdVaJa bxrsSL"
+          >
+            EUR
+          </span>
+          <input
+            className="sc-bxivhb ixCVbX"
+            disabled={true}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="text"
+            value="1,000,000"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/client/src/ui/spotTile/components/Tile/index.tsx
+++ b/src/client/src/ui/spotTile/components/Tile/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Tile'

--- a/src/client/src/ui/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/ui/spotTile/components/TileSwitch.tsx
@@ -8,7 +8,7 @@ import Tile from './Tile'
 import TileControls from './TileControls'
 import { TileViews } from '../../workspace/workspaceHeader'
 import { TileSwitchChildrenProps, RfqActions, TradingMode } from './types'
-import { getNumericNotional } from './TileBusinessLogic'
+import { getNumericNotional } from './Tile/TileBusinessLogic'
 import { getConstsFromRfqState } from '../model/spotTileUtils'
 
 interface Props {

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.test.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.test.tsx
@@ -1,0 +1,220 @@
+import React from 'react'
+import NotionalInput, { ValidationMessage } from './NotionalInput'
+import { renderWithTheme } from '../../../../../__tests__/helpers'
+
+const notional = '1,000,000'
+const currencyPairSymbol = 'EURUSD'
+const updateNotional = jest.fn()
+const resetNotional = jest.fn()
+const inputValidationMessageError: ValidationMessage = {
+  type: 'error',
+  content: 'Some error',
+}
+const inputValidationMessageWarning: ValidationMessage = {
+  type: 'warning',
+  content: 'Some warning',
+}
+const inputValidationMessageInfo: ValidationMessage = {
+  type: 'info',
+  content: 'Some information',
+}
+
+// Dark theme version
+test('NotionalInput default', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={false}
+      disabled={false}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with error', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageError}
+      showResetButton={false}
+      disabled={false}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with warning', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageWarning}
+      showResetButton={false}
+      disabled={false}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with info', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageInfo}
+      showResetButton={false}
+      disabled={false}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput disabled', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={false}
+      disabled={true}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput show reset button', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={true}
+      disabled={false}
+    />,
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+// Light theme version
+test('NotionalInput default', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={false}
+      disabled={false}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with error', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageError}
+      showResetButton={false}
+      disabled={false}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with warning', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageWarning}
+      showResetButton={false}
+      disabled={false}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput with info', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={inputValidationMessageInfo}
+      showResetButton={false}
+      disabled={false}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput disabled', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={false}
+      disabled={true}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('NotionalInput show reset button', () => {
+  const component = renderWithTheme(
+    <NotionalInput
+      notional={notional}
+      currencyPairSymbol={currencyPairSymbol}
+      updateNotional={updateNotional}
+      resetNotional={resetNotional}
+      validationMessage={null}
+      showResetButton={true}
+      disabled={false}
+    />,
+    'light',
+  )
+  const tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -9,7 +9,7 @@ import {
   MessagePlaceholder,
 } from './styled'
 
-const DOT = '.'
+// const DOT = '.'
 const ENTER = 'Enter'
 const CHAR_CODE_DOT = 46 // .
 const CHAR_CODE_0 = 48 // 0
@@ -83,11 +83,16 @@ export default class NotionalInput extends PureComponent<Props, State> {
     // user may be trying to enter decimals or
     // user may be deleting previous entry (empty string)
     // in those cases, format and update only when completed.
-    if (notional === '.') {
-      return '0.'
-    }
-    const lastTwoChars = notional.substr(-2)
-    const shouldFormat = !isEditMode(notional) && lastTwoChars.indexOf(DOT) === -1
+    // if (notional === '.') {
+    //   return '0.'
+    // }
+    // const lastTwoChars = notional.substr(-2)
+    // const shouldFormat = !isEditMode(notional) && lastTwoChars.indexOf(DOT) === -1
+    const editMode = isEditMode(notional)
+    const shouldFormat = !editMode
+    console.log('notional', notional)
+    console.log('editMode', editMode)
+    // console.log('shouldFormat', shouldFormat)
     return shouldFormat ? numeral(notional).format(NUMERAL_FORMAT) : notional
   }
 

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -81,19 +81,9 @@ export default class NotionalInput extends PureComponent<Props, State> {
 
   formatNotional = (notional: string) => {
     // user may be trying to enter decimals or
-    // user may be deleting previous entry (empty string)
+    // user may be deleting previous entry (empty string, etc)
     // in those cases, format and update only when completed.
-    // if (notional === '.') {
-    //   return '0.'
-    // }
-    // const lastTwoChars = notional.substr(-2)
-    // const shouldFormat = !isEditMode(notional) && lastTwoChars.indexOf(DOT) === -1
-    const editMode = isEditMode(notional)
-    const shouldFormat = !editMode
-    console.log('notional', notional)
-    console.log('editMode', editMode)
-    // console.log('shouldFormat', shouldFormat)
-    return shouldFormat ? numeral(notional).format(NUMERAL_FORMAT) : notional
+    return !isEditMode(notional) ? numeral(notional).format(NUMERAL_FORMAT) : notional
   }
 
   inputIsAllowed = (charCode: number) => {

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -1,6 +1,6 @@
 import numeral from 'numeral'
 import React, { PureComponent } from 'react'
-import { NUMERAL_FORMAT, isEditMode } from '../TileBusinessLogic'
+import { NUMERAL_FORMAT, isEditMode } from '../Tile/TileBusinessLogic'
 import {
   InputWrapper,
   CurrencyPairSymbol,

--- a/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
+++ b/src/client/src/ui/spotTile/components/notional/NotionalInput.tsx
@@ -1,6 +1,4 @@
-import numeral from 'numeral'
 import React, { PureComponent } from 'react'
-import { NUMERAL_FORMAT, isEditMode } from '../Tile/TileBusinessLogic'
 import {
   InputWrapper,
   CurrencyPairSymbol,
@@ -9,7 +7,6 @@ import {
   MessagePlaceholder,
 } from './styled'
 
-// const DOT = '.'
 const ENTER = 'Enter'
 const CHAR_CODE_DOT = 46 // .
 const CHAR_CODE_0 = 48 // 0
@@ -70,20 +67,12 @@ export default class NotionalInput extends PureComponent<Props, State> {
   handleChange = (event: React.FormEvent<HTMLInputElement>) => {
     const { updateNotional } = this.props
     const { currentTarget, type } = event
-    const inputValue = currentTarget.value.trim()
-    const value = this.formatNotional(inputValue)
+    const value = currentTarget.value.trim()
     updateNotional({ value, type })
   }
 
   handleResetNotional = () => {
     this.props.resetNotional()
-  }
-
-  formatNotional = (notional: string) => {
-    // user may be trying to enter decimals or
-    // user may be deleting previous entry (empty string, etc)
-    // in those cases, format and update only when completed.
-    return !isEditMode(notional) ? numeral(notional).format(NUMERAL_FORMAT) : notional
   }
 
   inputIsAllowed = (charCode: number) => {

--- a/src/client/src/ui/spotTile/components/notional/__snapshots__/NotionalInput.test.tsx.snap
+++ b/src/client/src/ui/spotTile/components/notional/__snapshots__/NotionalInput.test.tsx.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotionalInput default 1`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb fauXdE"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+</div>
+`;
+
+exports[`NotionalInput default 2`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb dfDCvR"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+</div>
+`;
+
+exports[`NotionalInput disabled 1`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb ixCVbX"
+    disabled={true}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+</div>
+`;
+
+exports[`NotionalInput disabled 2`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb jPqRyz"
+    disabled={true}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+</div>
+`;
+
+exports[`NotionalInput show reset button 1`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb fauXdE"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <button
+    className="sc-ifAKCX gROrJN"
+    onClick={[Function]}
+  >
+    <i
+      className="fas fa-redo fa-flip-horizontal"
+    />
+  </button>
+</div>
+`;
+
+exports[`NotionalInput show reset button 2`] = `
+<div
+  className="sc-htpNat idZgat"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb dfDCvR"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <button
+    className="sc-ifAKCX fCQbjt"
+    onClick={[Function]}
+  >
+    <i
+      className="fas fa-redo fa-flip-horizontal"
+    />
+  </button>
+</div>
+`;
+
+exports[`NotionalInput with error 1`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb iHOuZf"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH hUHSeX"
+  >
+    Some error
+  </div>
+</div>
+`;
+
+exports[`NotionalInput with error 2`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb iHOuZf"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH hUHSeX"
+  >
+    Some error
+  </div>
+</div>
+`;
+
+exports[`NotionalInput with info 1`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb gDYEmO"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH cHoFLD"
+  >
+    Some information
+  </div>
+</div>
+`;
+
+exports[`NotionalInput with info 2`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb gDYEmO"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH cHoFLD"
+  >
+    Some information
+  </div>
+</div>
+`;
+
+exports[`NotionalInput with warning 1`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb ecOaYV"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH bpWJsW"
+  >
+    Some warning
+  </div>
+</div>
+`;
+
+exports[`NotionalInput with warning 2`] = `
+<div
+  className="sc-htpNat kjfMBr"
+>
+  <span
+    className="sc-bdVaJa bxrsSL"
+  >
+    EURUSD
+  </span>
+  <input
+    className="sc-bxivhb ecOaYV"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    type="text"
+    value="1,000,000"
+  />
+  <div
+    className="sc-bwzfXH bpWJsW"
+  >
+    Some warning
+  </div>
+</div>
+`;


### PR DESCRIPTION
- [x] Improved user input formatting
- [x] Snapshots for `NotionalInput` component
- [x] Snapshots for `Tile` component
- [x] Tests for `TileBusinessLogic` utils
- [x] Tests for `TileBusinessLogic` state derived from props
- [x] Tests for `TileBusinessLogic` state derived from user input
- [x] Tests for invalid trading values' regex https://regex101.com/r/OWDRCO/2 (should disable trading)
- [x] Tests for edit mode' regex https://regex101.com/r/MrSCRE/4 (should format value on the fly or not)
