### PR TITLE
Fix FSBL platform check

### DIFF
--- a/src/client/src/rt-components/platform/platform.ts
+++ b/src/client/src/rt-components/platform/platform.ts
@@ -1,12 +1,6 @@
 import { Browser, Finsemble, OpenFin, PlatformAdapter } from './adapters'
 
-/* 
-    No types currently publicly available for Finsemble 
-    https://documentation.chartiq.com/finsemble/tutorial-FAQ.html 
-*/
-let FSBL: any
-
-const isFinsemble = FSBL in window
+const isFinsemble = 'FSBL' in window
 const isOpenFin = typeof fin !== 'undefined'
 
 const getPlatform: () => PlatformAdapter = () => {


### PR DESCRIPTION
There is a bug where every platform is evaluated as Finsemble
```
let FSBL: any
const isFinsemble = FSBL in window
```
which is effectively 
```
undefined in window // === true
```

This PR fixes that to restore the platforms