### PR TITLE
ARTP-636 - The Live Rates label, top left, should not be a clickable area

### DIFF
--- a/src/client/src/ui/workspace/workspaceHeader/styled.tsx
+++ b/src/client/src/ui/workspace/workspaceHeader/styled.tsx
@@ -26,6 +26,9 @@ export const LeftNavItemFirst = styled(LiStyle)`
   list-style-type: none;
   margin-right: 30px;
   font-size: 16px;
+  &:hover {
+    cursor: default;
+  }
   @media (max-width: 768px) {
     margin-right: 5px;
   }


### PR DESCRIPTION
Remove cursor pointer from live rates label