### PR TITLE
ARTP-637 - Remove the central zero on the PnL tab range indicators

### DIFF
--- a/src/client/src/ui/analytics/components/analyticsBarChart/PNLBar.tsx
+++ b/src/client/src/ui/analytics/components/analyticsBarChart/PNLBar.tsx
@@ -11,7 +11,6 @@ import {
   Bar,
   OriginTickWrapper,
   OriginTick,
-  Origin,
 } from './styled'
 interface PNLBarProps {
   basePnl: number
@@ -26,28 +25,28 @@ const getLogRatio: (max: number, numb: number) => number = (max, numb) => {
   const logNumb = Math.log10(Math.abs(numb))
   return logNumb / logMax
 }
-export default class PNLBar extends React.Component<PNLBarProps> {
-  render() {
-    const { symbol, basePnl, maxVal } = this.props
-    const color = basePnl >= 0 ? 'green' : 'red'
-    const distance = getLogRatio(maxVal, basePnl) * TRANSLATION_WIDTH * (basePnl >= 0 ? 1 : -1)
-    const price = numeral(Math.abs(basePnl)).format('0a')
-    return (
-      <BarChart>
-        <Label>{symbol}</Label>
-        <Offset />
-        <BarPriceContainer>
-          <PriceContainer distance={distance}>
-            <PriceLabel color={color}>{price}</PriceLabel>
-            <DiamondShape color={color} />
-          </PriceContainer>
-          <Bar />
-          <OriginTickWrapper>
-            <OriginTick />
-            <Origin>0</Origin>
-          </OriginTickWrapper>
-        </BarPriceContainer>
-      </BarChart>
-    )
-  }
+
+const PNLBar: React.FC<PNLBarProps> = ({ symbol, basePnl, maxVal }) => {
+  const color = basePnl >= 0 ? 'green' : 'red'
+  const distance = getLogRatio(maxVal, basePnl) * TRANSLATION_WIDTH * (basePnl >= 0 ? 1 : -1)
+  const price = numeral(Math.abs(basePnl)).format('0a')
+
+  return (
+    <BarChart>
+      <Label>{symbol}</Label>
+      <Offset />
+      <BarPriceContainer>
+        <PriceContainer distance={distance}>
+          <PriceLabel color={color}>{price}</PriceLabel>
+          <DiamondShape color={color} />
+        </PriceContainer>
+        <Bar />
+        <OriginTickWrapper>
+          <OriginTick />
+        </OriginTickWrapper>
+      </BarPriceContainer>
+    </BarChart>
+  )
 }
+
+export default PNLBar

--- a/src/client/src/ui/analytics/components/analyticsBarChart/styled.tsx
+++ b/src/client/src/ui/analytics/components/analyticsBarChart/styled.tsx
@@ -26,6 +26,7 @@ export const Offset = styled.div`
 export const OriginTickWrapper = styled(FlexDiv)`
   width: 100%;
   align-items: center;
+  height: 20px;
 `
 
 export const PriceLabel = styled.div<{ color: string }>`
@@ -64,9 +65,4 @@ export const OriginTick = styled.div`
   height: 5px;
   background-color: ${bgColor};
   border: 1px solid ${bgColor};
-`
-export const Origin = styled.div`
-  font-size: 11px;
-  text-align: center;
-  color: ${({ theme }) => theme.core.textColor};
 `


### PR DESCRIPTION
- Removed Origin from PNLBar
- Refactored to functional component

**Before**
![ARTP-637-before](https://user-images.githubusercontent.com/50445182/58163103-50cdd880-7c7b-11e9-9f33-075a249725ed.PNG)

**After**
![ARTP-637-after](https://user-images.githubusercontent.com/50445182/58163116-55928c80-7c7b-11e9-87c8-2978fb710481.PNG)
