### PR TITLE
ARTP-639 - The P & L tile loses its scroll bar when popped out

### DIFF
--- a/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
@@ -80,14 +80,11 @@ const HeaderControl = styled.div<{ accent?: AccentName }>`
 `
 
 export const Root = styled.div`
-  display: grid;
   background-color: ${props => props.theme.core.darkBackground};
   color: ${props => props.theme.core.textColor};
 
   height: 100%;
   width: 100%;
-
-  grid-template-rows: 1.5rem 1fr;
 `
 
 export default OpenFinChrome

--- a/src/client/src/rt-components/platform/externalWindowDefault.ts
+++ b/src/client/src/rt-components/platform/externalWindowDefault.ts
@@ -18,7 +18,7 @@ const analyticsRegion: ExternalWindow = {
   title: 'Analytics',
   config: {
     name: 'analytics',
-    width: 400,
+    width: 372, // 332 content + 20 padding
     height: 800,
     url: '/analytics',
   },

--- a/src/client/src/shell/routes/AnalyticsRoute.tsx
+++ b/src/client/src/shell/routes/AnalyticsRoute.tsx
@@ -5,7 +5,7 @@ import { styled } from 'rt-theme'
 
 const AnalyticsRouteStyle = styled.div`
   max-width: 25rem;
-  height: 100%;
+  height: calc(100% - (21px + 0.625rem)); // minus chrome header and top padding
   padding: 0.625rem;
   margin: auto;
 `


### PR DESCRIPTION
Updated css and config to enable scrollbar on pnl popout

**Before**
<a href="https://user-images.githubusercontent.com/50445182/58166371-95f50900-7c81-11e9-9d1b-35a3b28d9acf.PNG"><img src="https://user-images.githubusercontent.com/50445182/58166371-95f50900-7c81-11e9-9d1b-35a3b28d9acf.PNG" width="300" /></a>

**After**
<a href="https://user-images.githubusercontent.com/50445182/58166378-9b525380-7c81-11e9-9ddf-cf83803cac4b.PNG"><img src="https://user-images.githubusercontent.com/50445182/58166378-9b525380-7c81-11e9-9ddf-cf83803cac4b.PNG" width="300" /></a>
