### PR TITLE
ARTP-631 - When any tile is popped out, you can select and copy text (you should not be able to do so)

### DIFF
--- a/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
@@ -20,6 +20,7 @@ export const OpenFinChrome: SFC = ({ children }) => (
           overflow: hidden;
           min-height: 100%;
           max-height: 100vh;
+          user-select: none;
         }
     `}</style>
     </Helmet>


### PR DESCRIPTION
Disable user selection for tear out windows (OpenfinChrome)