### PR TITLE
ARTP-633 - On a popped tile, the x is too high, and not quite placed correctly

### DIFF
--- a/src/client/src/rt-components/index.ts
+++ b/src/client/src/rt-components/index.ts
@@ -22,7 +22,12 @@ export type PlatformAdapter = PlatformAdapter
 export type PlatformName = PlatformName
 export type WindowConfig = WindowConfig
 export { TearOff } from './tear-off'
-export { OpenFinChrome, OpenFinControls, OpenFinHeader } from './open-fin'
+export {
+  OpenFinChrome,
+  OpenFinControls,
+  OpenFinHeader,
+  OPENFIN_CHROME_HEADER_HEIGHT,
+} from './open-fin'
 export { Flex, flexStyle } from './flex'
 export { PopoutIcon, ExpandIcon, LogoIcon } from './icons'
 export { default as Modal } from './modal'

--- a/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
@@ -52,11 +52,14 @@ export const OpenFinControls: React.FC<ControlProps> = ({ minimize, maximize, cl
   </React.Fragment>
 )
 
+export const OPENFIN_CHROME_HEADER_HEIGHT = '21px'
+
 const Header = styled.div`
   display: flex;
   width: 100%;
   min-height: 1.5rem;
   font-size: 1rem;
+  height: ${OPENFIN_CHROME_HEADER_HEIGHT};
 `
 
 const DragRegion = styled.div`
@@ -69,7 +72,8 @@ const HeaderControl = styled.div<{ accent?: AccentName }>`
   display: flex;
   justify-content: center;
   align-self: center;
-  min-width: 2.5rem;
+  min-width: 2.3rem;
+  padding-top: 7px;
 
   color: ${props => props.theme.button.secondary.backgroundColor};
   cursor: pointer;

--- a/src/client/src/rt-components/open-fin/index.ts
+++ b/src/client/src/rt-components/open-fin/index.ts
@@ -1,1 +1,6 @@
-export { OpenFinChrome, OpenFinControls, OpenFinHeader } from './OpenFinChrome'
+export {
+  OpenFinChrome,
+  OpenFinControls,
+  OpenFinHeader,
+  OPENFIN_CHROME_HEADER_HEIGHT,
+} from './OpenFinChrome'

--- a/src/client/src/rt-components/platform/externalWindowDefault.ts
+++ b/src/client/src/rt-components/platform/externalWindowDefault.ts
@@ -18,7 +18,7 @@ const analyticsRegion: ExternalWindow = {
   title: 'Analytics',
   config: {
     name: 'analytics',
-    width: 372, // 332 content + 20 padding
+    width: 352, // 332 content + 10 padding
     height: 800,
     url: '/analytics',
   },

--- a/src/client/src/shell/routes/AnalyticsRoute.tsx
+++ b/src/client/src/shell/routes/AnalyticsRoute.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { RouteWrapper } from 'rt-components'
+import { OPENFIN_CHROME_HEADER_HEIGHT, RouteWrapper } from 'rt-components'
 import { AnalyticsContainer } from '../../ui/analytics'
 import { styled } from 'rt-theme'
 
 const AnalyticsRouteStyle = styled.div`
   max-width: 25rem;
-  height: calc(100% - (21px + 0.625rem)); // minus chrome header and top padding
+  height: calc(100% - ${OPENFIN_CHROME_HEADER_HEIGHT});
   padding: 0.625rem;
   margin: auto;
 `

--- a/src/client/src/shell/routes/BlotterRoute.tsx
+++ b/src/client/src/shell/routes/BlotterRoute.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { RouteWrapper } from 'rt-components'
+import { OPENFIN_CHROME_HEADER_HEIGHT, RouteWrapper } from 'rt-components'
 import { BlotterContainer } from '../../ui/blotter'
 import { styled } from 'rt-theme'
 
 const BlotterContainerStyle = styled('div')`
-  height: 100%;
+  height: calc(100% - ${OPENFIN_CHROME_HEADER_HEIGHT});
   width: 100%;
   padding: 0.625rem;
   margin: auto;

--- a/src/client/src/ui/workspace/selectors.ts
+++ b/src/client/src/ui/workspace/selectors.ts
@@ -13,8 +13,8 @@ const makeExternalWindowProps: (key: string) => ExternalWindowProps = (key: stri
   title: `${key} Spot`,
   config: {
     name: `${key} Spot`,
-    width: 370,
-    height: 184,
+    width: 366, // 346 content + 10 padding
+    height: 193,
     url: `/spot/${key}`,
   },
   browserConfig: { center: 'screen' },


### PR DESCRIPTION
Updated `OpenfinChrome` css to align close icon and padding

<img src="https://user-images.githubusercontent.com/50445182/58181355-90a8b600-7ca3-11e9-961d-596578f401fe.PNG" width="360" />
<img src="https://user-images.githubusercontent.com/50445182/58181356-91414c80-7ca3-11e9-983a-0e01ff8ec919.PNG" width="600" />
<img src="https://user-images.githubusercontent.com/50445182/58181358-91414c80-7ca3-11e9-9265-495c5c6aa5d1.PNG" width="300" />
