### PR TITLE
ARTP-631 - When any tile is popped out, you can select and copy text (you should not be able to do so)

### DIFF
--- a/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinChrome.tsx
@@ -20,7 +20,6 @@ export const OpenFinChrome: SFC = ({ children }) => (
           overflow: hidden;
           min-height: 100%;
           max-height: 100vh;
-          user-select: none;
         }
     `}</style>
     </Helmet>

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -12,6 +12,7 @@ const RouteStyle = styled('div')<{ platform: PlatformAdapter }>`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  user-select: none;
 
   /* When in Finsemble a 25px header is injected,
    this resets body to the correct height */


### PR DESCRIPTION
Added `user-select: none` to `RouteWrapper` and removed from `OpenfinChrome` to target all platforms