### PR TITLE
ARTP-635 - Clicking the OpenFin logo, bottom right, should go straight to the OpenFin website

### DIFF
--- a/src/client/src/rt-components/index.ts
+++ b/src/client/src/rt-components/index.ts
@@ -27,6 +27,7 @@ export {
   OpenFinControls,
   OpenFinHeader,
   OPENFIN_CHROME_HEADER_HEIGHT,
+  OpenFinBrowserLink,
 } from './open-fin'
 export { Flex, flexStyle } from './flex'
 export { PopoutIcon, ExpandIcon, LogoIcon } from './icons'

--- a/src/client/src/rt-components/open-fin/OpenFinBrowserLink.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinBrowserLink.tsx
@@ -1,0 +1,19 @@
+import React, { FC, MouseEvent, ReactNode } from 'react'
+
+interface Props {
+  href: string
+  children: ReactNode
+  className?: string
+}
+
+const OpenFinBrowserLink: FC<Props> = props => (
+  <a
+    {...props}
+    onClick={(e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault()
+      fin.System.openUrlWithBrowser(e.currentTarget.href)
+    }}
+  />
+)
+
+export default OpenFinBrowserLink

--- a/src/client/src/rt-components/open-fin/OpenFinBrowserLink.tsx
+++ b/src/client/src/rt-components/open-fin/OpenFinBrowserLink.tsx
@@ -6,14 +6,11 @@ interface Props {
   className?: string
 }
 
-const OpenFinBrowserLink: FC<Props> = props => (
-  <a
-    {...props}
-    onClick={(e: MouseEvent<HTMLAnchorElement>) => {
-      e.preventDefault()
-      fin.System.openUrlWithBrowser(e.currentTarget.href)
-    }}
-  />
-)
+const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+  e.preventDefault()
+  fin.System.openUrlWithBrowser(e.currentTarget.href)
+}
+
+const OpenFinBrowserLink: FC<Props> = props => <a {...props} onClick={handleClick} />
 
 export default OpenFinBrowserLink

--- a/src/client/src/rt-components/open-fin/index.ts
+++ b/src/client/src/rt-components/open-fin/index.ts
@@ -4,3 +4,4 @@ export {
   OpenFinHeader,
   OPENFIN_CHROME_HEADER_HEIGHT,
 } from './OpenFinChrome'
+export { default as OpenFinBrowserLink } from './OpenFinBrowserLink'

--- a/src/client/src/ui/status-bar/StatusBar.tsx
+++ b/src/client/src/ui/status-bar/StatusBar.tsx
@@ -1,16 +1,16 @@
 import React, { FC } from 'react'
-import { Fill, Header, Root, OpenFinLogoContainer } from './styled'
+import { Fill, Header, Root, OpenFinLogoLink } from './styled'
 import { OpenFinLogo } from './assets/OpenFinLogo'
-import { usePlatform } from 'rt-components'
+import { OpenFinBrowserLink, usePlatform } from 'rt-components'
 
 const LogoWithPlatform: FC = () => {
   const platform = usePlatform()
   return (
     <div>
       {platform.name === 'openfin' && (
-        <OpenFinLogoContainer>
+        <OpenFinLogoLink href="http://www.openfin.co" as={OpenFinBrowserLink}>
           <OpenFinLogo />
-        </OpenFinLogoContainer>
+        </OpenFinLogoLink>
       )}
     </div>
   )

--- a/src/client/src/ui/status-bar/styled.tsx
+++ b/src/client/src/ui/status-bar/styled.tsx
@@ -63,7 +63,7 @@ export const NodeCount = styled.div`
   opacity: 0.6;
 `
 
-export const OpenFinLogoContainer = styled.div`
+export const OpenFinLogoLink = styled.a`
   .svg-fill {
     fill: ${({ theme }) => theme.core.textColor};
   }


### PR DESCRIPTION
- Added `OpenFinBrowserLink` component to open `<a>` in a new browser window from OpenFin
- Link the OpenFin logo to OpenFin's website