### PR TITLE
ARTP-629 - The reject button on an RFQ overlaps slightly on the chartIQ button

### DIFF
--- a/src/client/src/ui/spotTile/components/SpotTile.tsx
+++ b/src/client/src/ui/spotTile/components/SpotTile.tsx
@@ -33,6 +33,7 @@ export default class SpotTile extends PureComponent<Props> {
       inputDisabled,
       inputValidationMessage,
       rfq,
+      displayCurrencyChart,
     } = this.props
 
     const spotDate = price.valueDate && spotDateFormatter(price.valueDate, false).toUpperCase()
@@ -51,7 +52,11 @@ export default class SpotTile extends PureComponent<Props> {
         <SpotTileStyle className="spot-tile">
           <ReserveSpaceGrouping>
             <TileHeaderWrapper>
-              <TileHeader baseTerm={baseTerm} date={date} />
+              <TileHeader
+                baseTerm={baseTerm}
+                date={date}
+                displayCurrencyChart={displayCurrencyChart}
+              />
             </TileHeaderWrapper>
             <PriceControls
               executeTrade={executeTrade}

--- a/src/client/src/ui/spotTile/components/Tile/Tile.tsx
+++ b/src/client/src/ui/spotTile/components/Tile/Tile.tsx
@@ -27,6 +27,7 @@ export interface TileProps {
   executionStatus: ServiceConnectionStatus
   executeTrade: (tradeRequestObj: ExecuteTradeRequest) => void
   setTradingMode: (tradingMode: TradingMode) => void
+  displayCurrencyChart?: () => void
   tileView?: TileViews
   children: ({ notional, userError }: TileSwitchChildrenProps) => JSX.Element
   rfq: RfqActions
@@ -126,7 +127,15 @@ class Tile extends React.PureComponent<TileProps, TileState> {
   }
 
   render() {
-    const { children, currencyPair, spotTileData, executionStatus, tileView, rfq } = this.props
+    const {
+      children,
+      currencyPair,
+      spotTileData,
+      executionStatus,
+      tileView,
+      rfq,
+      displayCurrencyChart,
+    } = this.props
     const {
       notional,
       inputDisabled,
@@ -155,6 +164,7 @@ class Tile extends React.PureComponent<TileProps, TileState> {
         inputValidationMessage={inputValidationMessage}
         tradingDisabled={tradingDisabled || !canExecute}
         rfq={rfq}
+        displayCurrencyChart={displayCurrencyChart}
       >
         {children({
           notional,

--- a/src/client/src/ui/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/ui/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -2,27 +2,27 @@
 
 exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -125,10 +125,10 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -157,27 +157,27 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 
 exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -224,10 +224,10 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -264,27 +264,27 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 
 exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -397,10 +397,10 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -437,27 +437,27 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 
 exports[`Snapshot, state derived from props, RFQ received 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -560,10 +560,10 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -592,27 +592,27 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 
 exports[`Snapshot, state derived from props, RFQ requested 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -743,10 +743,10 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -775,27 +775,27 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
 
 exports[`Snapshot, state derived from props, defaults, RFQ none, should be able to excute 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -898,10 +898,10 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"
@@ -930,27 +930,27 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 
 exports[`Snapshot, state derived from props, in trade 1`] = `
 <div
-  className="sc-eqIVtm sc-fAjcbJ fjggro"
+  className="sc-dVhcbM sc-eqIVtm fUWgaP"
 >
   <div
-    className="sc-jhAzac spot-tile sc-gisBJw iZBBaU"
+    className="sc-hzDkRC spot-tile sc-caSCKo jOpZpT"
   >
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
         className="sc-hmzhuo eiuqZU"
       >
         <div
-          className="sc-dVhcbM erSHUY"
+          className="sc-fMiknA anWfE"
         >
           <div
-            className="sc-hzDkRC hefQwu"
+            className="sc-bRBYWo eEXrJH"
           >
             EUR/USD
           </div>
           <div
-            className="sc-bRBYWo kCsDOb"
+            className="sc-Rmtcm dpuvgb"
           >
             SPT (07 APR)
           </div>
@@ -1053,10 +1053,10 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
       </div>
     </div>
     <div
-      className="sc-caSCKo jjNSwx"
+      className="sc-fAjcbJ byigni"
     >
       <div
-        className="sc-kjoXOD bvCYDb"
+        className="sc-gisBJw iSHpXw"
       >
         <div
           className="sc-htpNat idZgat"

--- a/src/client/src/ui/spotTile/components/TileControls.tsx
+++ b/src/client/src/ui/spotTile/components/TileControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { PopoutIcon, usePlatform } from 'rt-components'
+import { PopoutIcon } from 'rt-components'
 import { styled } from 'rt-theme'
 
 export const TopRightButton = styled('button')`
@@ -16,37 +16,19 @@ export const TopRightButton = styled('button')`
   }
 `
 
-export const BottomRightButton = styled('button')`
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  opacity: 0;
-  transition: opacity 0.2s;
-  padding: 0.25rem;
-`
-
 interface Props {
   canPopout?: boolean
   onPopoutClick?: () => void
-  displayCurrencyChart?: () => void
 }
 
-const TileControls: React.FC<Props> = ({ onPopoutClick, canPopout, displayCurrencyChart }) => {
-  const platform = usePlatform()
-  return (
-    <React.Fragment>
-      {canPopout && (
-        <TopRightButton onClick={onPopoutClick}>
-          <PopoutIcon width={0.8125} height={0.75} />
-        </TopRightButton>
-      )}
-      {platform.type !== 'browser' && (
-        <BottomRightButton onClick={displayCurrencyChart}>
-          <i className="fas fa-chart-bar" />
-        </BottomRightButton>
-      )}
-    </React.Fragment>
-  )
-}
+const TileControls: React.FC<Props> = ({ onPopoutClick, canPopout }) => (
+  <React.Fragment>
+    {canPopout && (
+      <TopRightButton onClick={onPopoutClick}>
+        <PopoutIcon width={0.8125} height={0.75} />
+      </TopRightButton>
+    )}
+  </React.Fragment>
+)
 
 export default TileControls

--- a/src/client/src/ui/spotTile/components/TileHeader.tsx
+++ b/src/client/src/ui/spotTile/components/TileHeader.tsx
@@ -1,15 +1,36 @@
 import React from 'react'
+import { usePlatform } from 'rt-components'
+import { styled } from 'rt-theme'
 import { TileHeader as Header, TileSymbol, DeliveryDate } from './styled'
+
 interface Props {
   baseTerm: string
   date: string
+  displayCurrencyChart?: () => void
 }
 
-const TileHeader: React.SFC<Props> = ({ baseTerm, date }) => (
-  <Header>
-    <TileSymbol>{baseTerm}</TileSymbol>
-    <DeliveryDate>{date}</DeliveryDate>
-  </Header>
-)
+export const BottomRightButton = styled('button')`
+  opacity: 0;
+  transition: opacity 0.2s;
+  margin-left: 8px;
+  padding-left: 8px;
+  border-left: 1px solid white;
+`
+
+const TileHeader: React.SFC<Props> = ({ baseTerm, date, displayCurrencyChart }) => {
+  const platform = usePlatform()
+
+  return (
+    <Header>
+      <TileSymbol>{baseTerm}</TileSymbol>
+      {platform.type !== 'browser' && (
+        <BottomRightButton onClick={displayCurrencyChart}>
+          <i className="fas fa-chart-bar" />
+        </BottomRightButton>
+      )}
+      <DeliveryDate>{date}</DeliveryDate>
+    </Header>
+  )
+}
 
 export default TileHeader

--- a/src/client/src/ui/spotTile/components/TileHeader.tsx
+++ b/src/client/src/ui/spotTile/components/TileHeader.tsx
@@ -9,7 +9,7 @@ interface Props {
   displayCurrencyChart?: () => void
 }
 
-export const BottomRightButton = styled('button')`
+export const CurrencyChartButton = styled('button')`
   opacity: 0;
   transition: opacity 0.2s;
   margin-left: 8px;
@@ -24,9 +24,9 @@ const TileHeader: React.SFC<Props> = ({ baseTerm, date, displayCurrencyChart }) 
     <Header>
       <TileSymbol>{baseTerm}</TileSymbol>
       {platform.type !== 'browser' && (
-        <BottomRightButton onClick={displayCurrencyChart}>
+        <CurrencyChartButton onClick={displayCurrencyChart}>
           <i className="fas fa-chart-bar" />
-        </BottomRightButton>
+        </CurrencyChartButton>
       )}
       <DeliveryDate>{date}</DeliveryDate>
     </Header>

--- a/src/client/src/ui/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/ui/spotTile/components/TileSwitch.tsx
@@ -54,14 +54,11 @@ const TileSwitch: React.FC<Props> = ({
       tileView={tileView}
       setTradingMode={setTradingMode}
       rfq={rfq}
+      displayCurrencyChart={displayCurrencyChart}
     >
       {({ notional, userError }: TileSwitchChildrenProps) => (
         <>
-          <TileControls
-            canPopout={isRfqStateNone && canPopout}
-            onPopoutClick={onPopoutClick}
-            displayCurrencyChart={displayCurrencyChart}
-          />
+          <TileControls canPopout={isRfqStateNone && canPopout} onPopoutClick={onPopoutClick} />
           <TileBooking show={spotTileData.isTradeExecutionInFlight} color="blue" showLoader>
             Executing
           </TileBooking>

--- a/src/client/src/ui/spotTile/components/stories/TileSwitch.stories.tsx
+++ b/src/client/src/ui/spotTile/components/stories/TileSwitch.stories.tsx
@@ -61,6 +61,7 @@ stories.add('Booking', () => (
           onPopoutClick={action('On popout click')}
           setTradingMode={setTradingMode}
           rfq={rfq}
+          displayCurrencyChart={action('On currency chart click')}
         />
       </div>
     </Centered>
@@ -86,6 +87,7 @@ stories.add('Executed', () => (
           onPopoutClick={action('On popout click')}
           setTradingMode={setTradingMode}
           rfq={rfq}
+          displayCurrencyChart={action('On currency chart click')}
         />
       </div>
     </Centered>
@@ -111,6 +113,7 @@ stories.add('Rejected', () => (
           onPopoutClick={action('On popout click')}
           setTradingMode={setTradingMode}
           rfq={rfq}
+          displayCurrencyChart={action('On currency chart click')}
         />
       </div>
     </Centered>
@@ -142,6 +145,7 @@ stories.add('Switch', () => {
             onPopoutClick={action('On popout click')}
             setTradingMode={setTradingMode}
             rfq={rfq}
+            displayCurrencyChart={action('On currency chart click')}
           />
         </div>
       </Centered>

--- a/src/client/src/ui/spotTile/components/styled.tsx
+++ b/src/client/src/ui/spotTile/components/styled.tsx
@@ -1,7 +1,7 @@
 import { RouteStyle } from 'rt-components'
 import { styled } from 'rt-theme'
 import { TopRightButton } from './TileControls'
-import { BottomRightButton } from './TileHeader'
+import { CurrencyChartButton } from './TileHeader'
 
 export interface ColorProps {
   color?: string
@@ -53,7 +53,7 @@ export const TileWrapperBase = styled.div`
   &:hover ${TopRightButton} {
     opacity: 0.75;
   }
-  &:hover ${BottomRightButton} {
+  &:hover ${CurrencyChartButton} {
     opacity: 0.75;
   }
   color: ${({ theme }) => theme.core.textColor};

--- a/src/client/src/ui/spotTile/components/styled.tsx
+++ b/src/client/src/ui/spotTile/components/styled.tsx
@@ -1,6 +1,7 @@
 import { RouteStyle } from 'rt-components'
 import { styled } from 'rt-theme'
-import { TopRightButton, BottomRightButton } from './TileControls'
+import { TopRightButton } from './TileControls'
+import { BottomRightButton } from './TileHeader'
 
 export interface ColorProps {
   color?: string
@@ -12,6 +13,7 @@ export const DeliveryDate = styled.div`
   font-size: 0.625rem;
   line-height: 1rem;
   opacity: 0.59;
+  margin-left: auto;
 `
 
 export const TileSymbol = styled.div`
@@ -44,7 +46,6 @@ export const Button = styled('button')`
 export const TileHeader = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
 `
 
 export const TileWrapperBase = styled.div`

--- a/src/client/src/ui/spotTile/components/types.ts
+++ b/src/client/src/ui/spotTile/components/types.ts
@@ -44,4 +44,5 @@ export interface Props {
   tradingDisabled: boolean
   chartData?: []
   rfq: RfqActions
+  displayCurrencyChart?: () => void
 }


### PR DESCRIPTION
Moved chartIQ button to fix some overlapping issues

**Before**
![ARTP-629-before](https://user-images.githubusercontent.com/50445182/58328056-0be7a480-7e29-11e9-85b5-f80e2a0006f8.png)

**After**
![ARTP-629-after](https://user-images.githubusercontent.com/50445182/58328119-36d1f880-7e29-11e9-8434-72eb0aa12b53.png)

