### PR TITLE
ARTP-642 Openfin Cloud - Restore workspace

### DIFF
--- a/src/client/src/routes/MainRoute/MainRoute.tsx
+++ b/src/client/src/routes/MainRoute/MainRoute.tsx
@@ -4,7 +4,7 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { timer } from 'rxjs'
 
 import { ConnectionActions } from 'rt-actions'
-import { platform, PlatformProvider } from 'rt-components'
+import { platform, PlatformProvider, setupWorkspaces } from 'rt-components'
 import { AutobahnConnectionProxy } from 'rt-system'
 import { ThemeProvider } from 'rt-theme'
 
@@ -29,6 +29,14 @@ const store = configureStore(
     user: FakeUserRepository.currentUser,
   }),
 )
+
+setupWorkspaces(store)
+  .then(successVal => {
+    console.info('setupWorkspaces success', successVal)
+  })
+  .catch(err => {
+    console.error('setupWorkspaces error', err)
+  })
 
 store.dispatch(ConnectionActions.connect())
 

--- a/src/client/src/rt-components/index.ts
+++ b/src/client/src/rt-components/index.ts
@@ -7,6 +7,7 @@ import {
   WindowConfig,
   openFinNotifications,
   setupGlobalOpenfinNotifications,
+  setupWorkspaces,
   usePlatform,
 } from './platform'
 
@@ -17,6 +18,7 @@ export {
   PlatformProvider,
   openFinNotifications,
   setupGlobalOpenfinNotifications,
+  setupWorkspaces,
 }
 export type PlatformAdapter = PlatformAdapter
 export type PlatformName = PlatformName

--- a/src/client/src/rt-components/platform/adapters/index.ts
+++ b/src/client/src/rt-components/platform/adapters/index.ts
@@ -1,13 +1,18 @@
 import { WindowConfig, PlatformName } from './types'
-import OpenFin from './openfin/openFin';
-import Browser from './browser/browser';
-import Finsemble from './finsemble/finsemble';
+import OpenFin from './openfin/openFin'
+import Browser from './browser/browser'
+import Finsemble from './finsemble/finsemble'
 
 export type PlatformAdapter = OpenFin | Browser | Finsemble
 export type WindowConfig = WindowConfig
 export type PlatformName = PlatformName
 export { default as Browser } from './browser/browser'
-export { default as OpenFin, openFinNotifications, setupGlobalOpenfinNotifications } from './openfin/openFin'
+export {
+  default as OpenFin,
+  openFinNotifications,
+  setupGlobalOpenfinNotifications,
+  setupWorkspaces,
+} from './openfin/openFin'
 export { default as Finsemble } from './finsemble/finsemble'
 export { excelAdapter } from './openfin/excel'
 export { InteropTopics } from './types'

--- a/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
@@ -5,11 +5,14 @@ import { fromEventPattern } from 'rxjs'
 import { excelAdapter } from './excel'
 import { CurrencyPairPositionWithPrice } from 'rt-types'
 import { LayoutActions } from '../../../../shell/layouts/layoutActions'
+import { workspaces } from 'openfin-layouts'
+import { Store } from 'redux'
 
-export async function setupWorkspaces(store: any) {
+export async function setupWorkspaces(store: Store) {
   if (typeof fin !== 'undefined') {
-    const workspaces = require('openfin-layouts').workspaces
-    await workspaces.setRestoreHandler((workspace: any) => appRestoreHandler(workspace, store))
+    await workspaces.setRestoreHandler((workspace: workspaces.WorkspaceApp) =>
+      appRestoreHandler(workspace, store),
+    )
     await workspaces.ready()
   }
 }
@@ -126,11 +129,11 @@ export default class OpenFin extends BasePlatformAdapter {
   }
 }
 
-async function appRestoreHandler(workspaceApp: any, store: any) {
+async function appRestoreHandler(workspaceApp: workspaces.WorkspaceApp, store: Store) {
   const ofApp = await fin.Application.getCurrent()
   const openWindows = await ofApp.getChildWindows()
 
-  const opened = workspaceApp.childWindows.map(async (win: any, index: any) => {
+  const opened = workspaceApp.childWindows.map(async (win: workspaces.WorkspaceWindow) => {
     if (!openWindows.some(w => w.identity.name === win.name)) {
       const config: WindowConfig = {
         name: win.name,
@@ -167,8 +170,7 @@ async function appRestoreHandler(workspaceApp: any, store: any) {
   return workspaceApp
 }
 
-async function positionWindow(win: any): Promise<void> {
-  console.error('dans positionWindow', win)
+async function positionWindow(win: workspaces.WorkspaceWindow): Promise<void> {
   try {
     const { isShowing, isTabbed } = win
 

--- a/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
@@ -31,6 +31,13 @@ export const setupGlobalOpenfinNotifications = () => {
 }
 
 type OpenFinWindowState = Parameters<Parameters<fin.OpenFinWindow['getState']>[0]>[0]
+
+enum WindowState {
+  Normal = 'normal',
+  Minimized = 'minimized',
+  Maximized = 'maximized',
+}
+
 export default class OpenFin extends BasePlatformAdapter {
   readonly name = 'openfin'
   readonly type = 'desktop'
@@ -52,11 +59,11 @@ export default class OpenFin extends BasePlatformAdapter {
       const win = fin.desktop.Window.getCurrent()
       win.getState((state: OpenFinWindowState) => {
         switch (state) {
-          case 'maximized':
-          case 'minimized':
+          case WindowState.Maximized:
+          case WindowState.Minimized:
             win.restore(() => win.bringToFront())
             break
-          case 'normal':
+          case WindowState.Normal:
           default:
             win.maximize()
             break
@@ -185,13 +192,13 @@ async function positionWindow(win: workspaces.WorkspaceWindow): Promise<void> {
     await ofWin.leaveGroup()
 
     if (isShowing) {
-      if (win.state === 'normal') {
+      if (win.state === WindowState.Normal) {
         // Need to both restore and show because the restore function doesn't emit a `shown` or `show-requested` event
         await ofWin.restore()
         await ofWin.show()
-      } else if (win.state === 'minimized') {
+      } else if (win.state === WindowState.Minimized) {
         await ofWin.minimize()
-      } else if (win.state === 'maximized') {
+      } else if (win.state === WindowState.Maximized) {
         await ofWin.maximize()
       }
     } else {

--- a/src/client/src/rt-components/platform/adapters/openfin/window.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/window.ts
@@ -13,13 +13,17 @@ const generateRandomName = function() {
   return text
 }
 
-export const openDesktopWindow = (config: DesktopWindowProps, onClose?: () => void) => {
+export const openDesktopWindow = (
+  config: DesktopWindowProps,
+  onClose?: () => void,
+  position?: {},
+) => {
   const { url, width: defaultWidth, height: defaultHeight } = config
 
   return new Promise<Window>(resolve => {
     const win = new fin.desktop.Window(
       {
-        name: generateRandomName(),
+        name: config.name || generateRandomName(),
         url,
         defaultWidth,
         defaultHeight,
@@ -28,6 +32,7 @@ export const openDesktopWindow = (config: DesktopWindowProps, onClose?: () => vo
         frame: false,
         saveWindowState: false,
         shadow: true,
+        ...position,
       } as any, // any needed because OpenFin does not have correct typings for WindowOptions @kdesai
       () => {
         if (onClose) {

--- a/src/client/src/rt-components/platform/index.ts
+++ b/src/client/src/rt-components/platform/index.ts
@@ -10,6 +10,7 @@ export {
   Finsemble,
   openFinNotifications,
   setupGlobalOpenfinNotifications,
+  setupWorkspaces,
 } from './adapters'
 export { default as platform } from './platform'
 export { PlatformProvider, usePlatform } from './context'

--- a/src/client/src/shell/index.ts
+++ b/src/client/src/shell/index.ts
@@ -1,10 +1,12 @@
 import { compositeStatusServiceReducer } from './compositeStatus'
 import { connectionStatusReducer } from './connectionStatus'
 import { currencyPairReducer } from './referenceData'
+import { layoutReducer } from './layouts/reducer'
 
 export { Router } from './Router'
 export const reducers = {
   currencyPairs: currencyPairReducer,
   compositeStatusService: compositeStatusServiceReducer,
-  connectionStatus: connectionStatusReducer
+  connectionStatus: connectionStatusReducer,
+  layout: layoutReducer,
 }

--- a/src/client/src/shell/layouts/layoutActions.ts
+++ b/src/client/src/shell/layouts/layoutActions.ts
@@ -1,0 +1,19 @@
+import { action, ActionUnion } from '../../rt-util'
+
+export interface ContainerVisibility {
+  name: string
+  display: boolean
+}
+
+export enum LAYOUT_ACTION_TYPES {
+  CONTAINER_VISIBILITY_UPDATE = '@ReactiveTraderCloud/CONTAINER_VISIBILITY_UPDATE',
+}
+
+export const LayoutActions = {
+  updateContainerVisibilityAction: action<
+    LAYOUT_ACTION_TYPES.CONTAINER_VISIBILITY_UPDATE,
+    ContainerVisibility
+  >(LAYOUT_ACTION_TYPES.CONTAINER_VISIBILITY_UPDATE),
+}
+
+export type LayoutActions = ActionUnion<typeof LayoutActions>

--- a/src/client/src/shell/layouts/reducer.ts
+++ b/src/client/src/shell/layouts/reducer.ts
@@ -1,0 +1,51 @@
+import { LAYOUT_ACTION_TYPES, LayoutActions } from './layoutActions'
+import { externalWindowDefault } from '../../rt-components'
+
+interface TilesLayout {
+  [key: string]: boolean
+}
+
+export interface LayoutState {
+  displayBlotter: boolean
+  displayAnalytics: boolean
+  spotTiles: TilesLayout
+}
+
+const INITIAL_STATE: LayoutState = {
+  displayBlotter: true,
+  displayAnalytics: true,
+  spotTiles: {},
+}
+
+export const layoutReducer = (
+  state: LayoutState = INITIAL_STATE,
+  action: LayoutActions,
+): LayoutState => {
+  switch (action.type) {
+    case LAYOUT_ACTION_TYPES.CONTAINER_VISIBILITY_UPDATE: {
+      switch (action.payload.name) {
+        case externalWindowDefault.blotterRegion.config.name:
+          return {
+            ...state,
+            displayBlotter: action.payload.display,
+          }
+        case externalWindowDefault.analyticsRegion.config.name:
+          return {
+            ...state,
+            displayAnalytics: action.payload.display,
+          }
+        default:
+          // this is a spot tile
+          return {
+            ...state,
+            spotTiles: {
+              ...state.spotTiles,
+              [action.payload.name]: action.payload.display,
+            },
+          }
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/src/client/src/shell/layouts/selectors.ts
+++ b/src/client/src/shell/layouts/selectors.ts
@@ -1,0 +1,14 @@
+import { GlobalState } from '../../StoreTypes'
+import { createSelector } from 'reselect'
+
+export const selectState = (state: GlobalState) => state.layout
+
+export const displayBlotterSelector = createSelector(
+  [selectState],
+  state => state.displayBlotter,
+)
+
+export const displayAnalyticsSelector = createSelector(
+  [selectState],
+  state => state.displayAnalytics,
+)

--- a/src/client/src/shell/routes/ShellRoute.tsx
+++ b/src/client/src/shell/routes/ShellRoute.tsx
@@ -11,27 +11,19 @@ import { WorkspaceContainer } from '../../ui/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import DefaultLayout from '../layouts/DefaultLayout'
 import { BlotterWrapper, AnalyticsWrapper, WorkspaceWrapper, OverflowScroll } from './styled'
+import { GlobalState } from '../../StoreTypes'
+import { displayAnalyticsSelector, displayBlotterSelector } from '../layouts/selectors'
+import { connect } from 'react-redux'
 
 interface Props {
   header?: React.ReactChild
-}
-
-interface State {
   displayBlotter: boolean
+  displayAnalytics: boolean
 }
 
-class ShellRoute extends PureComponent<Props, State> {
-  state = {
-    displayBlotter: true,
-  }
-
-  showBlotter = () => this.setState({ displayBlotter: true })
-
-  hideBlotter = () => this.setState({ displayBlotter: false })
-
+class ShellRoute extends PureComponent<Props> {
   render() {
-    const { header } = this.props
-    const { displayBlotter } = this.state
+    const { header, displayBlotter, displayAnalytics } = this.props
     return (
       <DefaultLayout
         header={header}
@@ -43,9 +35,10 @@ class ShellRoute extends PureComponent<Props, State> {
                 <TearOff
                   id="blotter"
                   externalWindowProps={externalWindowDefault.blotterRegion}
-                  render={(popOut, tornOff) => <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable />}
-                  popIn={this.showBlotter}
-                  popOut={this.hideBlotter}
+                  render={(popOut, tornOff) => (
+                    <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+                  )}
+                  tornOff={!displayBlotter}
                 />
               </BlotterWrapper>
             )}
@@ -63,7 +56,10 @@ class ShellRoute extends PureComponent<Props, State> {
             <TearOff
               id="region"
               externalWindowProps={externalWindowDefault.analyticsRegion}
-              render={(popOut, tornOff) => <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable />}
+              render={(popOut, tornOff) => (
+                <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+              )}
+              tornOff={!displayAnalytics}
             />
           </AnalyticsWrapper>
         }
@@ -78,4 +74,9 @@ class ShellRoute extends PureComponent<Props, State> {
   }
 }
 
-export default ShellRoute
+const mapStateToProps = (state: GlobalState) => ({
+  displayBlotter: displayBlotterSelector(state),
+  displayAnalytics: displayAnalyticsSelector(state),
+})
+
+export default connect(mapStateToProps)(ShellRoute)

--- a/src/client/src/ui/blotter/epics/blotterServiceEpic.ts
+++ b/src/client/src/ui/blotter/epics/blotterServiceEpic.ts
@@ -63,6 +63,7 @@ export const publishBlotterToExcelEpic: ApplicationEpic = (action$, state$, { pl
 export const connectBlotterToNotifications: ApplicationEpic = (action$, state$, { platform }) =>
   action$.pipe(
     ofType<Action, NewTradesAction>(BLOTTER_ACTION_TYPES.BLOTTER_SERVICE_NEW_TRADES),
+    filter(() => state$.value.layout.displayBlotter),
     filter(action => action.payload.trades.length > 0),
     map(action => action.payload.trades[0]),
     skipWhile(trade => !state$.value.currencyPairs[trade.symbol]),

--- a/src/client/src/ui/workspace/Workspace.tsx
+++ b/src/client/src/ui/workspace/Workspace.tsx
@@ -20,6 +20,7 @@ const WorkspaceItem = styled.div`
 interface SpotTile {
   key: string
   externalWindowProps: ExternalWindowProps
+  tornOff: boolean
 }
 
 interface Props {
@@ -45,16 +46,23 @@ const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions }) => {
       <WorkspaceItems>
         {spotTiles
           .filter(({ key }) => key.includes(currency) || currency === 'ALL')
-          .map(({ key, externalWindowProps }) => (
+          .map(({ key, externalWindowProps, tornOff }) => (
             <TearOff
               id={key}
+              key={key}
               externalWindowProps={appendTileViewToUrl(externalWindowProps, tileView)}
               render={(popOut, tornOff) => (
                 <WorkspaceItem>
-                  <SpotTileContainer id={key} tileView={tileView} onPopoutClick={popOut} tornOff={tornOff} tearable />
+                  <SpotTileContainer
+                    id={key}
+                    tileView={tileView}
+                    onPopoutClick={popOut}
+                    tornOff={tornOff}
+                    tearable
+                  />
                 </WorkspaceItem>
               )}
-              key={key}
+              tornOff={tornOff}
             />
           ))}
       </WorkspaceItems>

--- a/src/client/src/ui/workspace/selectors.ts
+++ b/src/client/src/ui/workspace/selectors.ts
@@ -12,7 +12,7 @@ export interface ExternalWindowProps {
 const makeExternalWindowProps: (key: string) => ExternalWindowProps = (key: string) => ({
   title: `${key} Spot`,
   config: {
-    name: `${key} Spot`,
+    name: `${key}`,
     width: 366, // 346 content + 10 padding
     height: 193,
     url: `/spot/${key}`,
@@ -21,13 +21,15 @@ const makeExternalWindowProps: (key: string) => ExternalWindowProps = (key: stri
 })
 
 const getSpotTiles = (state: GlobalState) => state.currencyPairs
+const getSpotTilesLayout = (state: GlobalState) => state.layout.spotTiles
 
 export const selectSpotTiles = createSelector(
-  [getSpotTiles],
-  spotTileKeys =>
+  [getSpotTiles, getSpotTilesLayout],
+  (spotTileKeys, tilesLayout) =>
     Object.keys(spotTileKeys).map(key => ({
       key,
       externalWindowProps: makeExternalWindowProps(key),
+      tornOff: tilesLayout[key] === undefined ? false : !tilesLayout[key],
     })),
 )
 


### PR DESCRIPTION
This MR is to have the Workspace feature of Openfin Cloud working correctly. To have a successful restore of a workspace, the applicatino has to implement the restore behavior for the child windows. In order to do that I had to refactor the way the application handles the child windows (popIn/popOut). This is now done via dispatch of actions.