### PR TITLE
add momentum scrolling to OverflowScroll

### DIFF
--- a/src/client/src/shell/routes/styled.tsx
+++ b/src/client/src/shell/routes/styled.tsx
@@ -1,9 +1,10 @@
 import { styled } from 'rt-theme'
+import { rules } from 'rt-styleguide'
 
 export const OverflowScroll = styled.div`
   overflow-y: scroll;
+  ${rules.touchScroll};
   height: 100%;
-  scrollbar-width: thin;
 `
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
**Problem:** stuttery scrolling on mobile, lack of momentum
**Solution:** add `-webkit-overflow-scrolling: touch`

https://weareadaptive.atlassian.net/browse/ARTP-646