### PR TITLE
fix mobile tile padding issue

### DIFF
--- a/src/client/src/shell/routes/styled.tsx
+++ b/src/client/src/shell/routes/styled.tsx
@@ -15,6 +15,10 @@ export const Wrapper = styled.div`
 export const WorkspaceWrapper = styled(Wrapper)`
   padding-right: 0;
   height: 100%;
+
+  @media (max-width: 480px) {
+    padding-right: 1rem;
+  }
 `
 
 export const AnalyticsWrapper = styled(Wrapper)`


### PR DESCRIPTION
issue: tiles bleed to the right edge on mobile
![File](https://user-images.githubusercontent.com/22047364/59129515-0c109580-893b-11e9-843d-c71358c38947.jpg)

solution: add in padding with breakpoint at max 480px (should prevent double padding in browser sizes)