### PR TITLE
Prevent Auto Import of Console

### DIFF
--- a/src/client/src/console.d.ts
+++ b/src/client/src/console.d.ts
@@ -1,0 +1,3 @@
+declare module 'console' {
+  export = typeof import('console')
+}

--- a/src/client/tslint.json
+++ b/src/client/tslint.json
@@ -49,7 +49,8 @@
   "linterOptions": {
     "exclude": [
       "config/**/*.js",
-      "node_modules/**/*.ts"
+      "node_modules/**/*.ts",
+      "console.d.ts"
     ]
   }
 }


### PR DESCRIPTION
Due to a bug with typescript, in the most recent update when you tab to autocomplete console.log it will automatically import console. To prevent this, here is a file to override the behavior.

see: https://github.com/Microsoft/TypeScript/issues/30471 for more information