### PR TITLE
ARTP-628: Correctly Position Torn-out Child Windows

### DIFF
--- a/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
@@ -171,7 +171,7 @@ export default class OpenFin extends BasePlatformAdapter {
 async function appRestoreHandler(workspaceApp: workspaces.WorkspaceApp, store: Store) {
   const ofApp = await fin.Application.getCurrent()
   const openWindows = await ofApp.getChildWindows()
-
+  console.log(openWindows)
   const opened = workspaceApp.childWindows.map(async (win: workspaces.WorkspaceWindow) => {
     if (!openWindows.some(w => w.identity.name === win.name)) {
       const config: WindowConfig = {

--- a/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/openFin.ts
@@ -171,7 +171,7 @@ export default class OpenFin extends BasePlatformAdapter {
 async function appRestoreHandler(workspaceApp: workspaces.WorkspaceApp, store: Store) {
   const ofApp = await fin.Application.getCurrent()
   const openWindows = await ofApp.getChildWindows()
-  console.log(openWindows)
+
   const opened = workspaceApp.childWindows.map(async (win: workspaces.WorkspaceWindow) => {
     if (!openWindows.some(w => w.identity.name === win.name)) {
       const config: WindowConfig = {

--- a/src/client/src/rt-components/platform/adapters/openfin/window.ts
+++ b/src/client/src/rt-components/platform/adapters/openfin/window.ts
@@ -1,4 +1,8 @@
 import { WindowConfig } from '../types'
+import { last as _last, get as _get } from 'lodash'
+
+const TEAR_OUT_OFFSET_LEFT = 50
+const TEAR_OUT_OFFSET_TOP = 50
 
 type DesktopWindowProps = WindowConfig
 
@@ -13,6 +17,19 @@ const generateRandomName = function() {
   return text
 }
 
+const returnChildWindows = () => {
+  return new Promise<fin.OpenFinWindow[]>((resolve, reject) => {
+    fin.desktop.Application.getCurrent().getChildWindows(
+      (children: fin.OpenFinWindow[]) => {
+        resolve(children)
+      },
+      (error: string) => {
+        reject(error)
+      },
+    )
+  })
+}
+
 export const openDesktopWindow = (
   config: DesktopWindowProps,
   onClose?: () => void,
@@ -20,29 +37,43 @@ export const openDesktopWindow = (
 ) => {
   const { url, width: defaultWidth, height: defaultHeight } = config
 
-  return new Promise<Window>(resolve => {
-    const win = new fin.desktop.Window(
-      {
-        name: config.name || generateRandomName(),
-        url,
-        defaultWidth,
-        defaultHeight,
-        defaultCentered: true,
-        autoShow: true,
-        frame: false,
-        saveWindowState: false,
-        shadow: true,
-        ...position,
-      } as any, // any needed because OpenFin does not have correct typings for WindowOptions @kdesai
-      () => {
-        if (onClose) {
-          win.addEventListener('closed', onClose)
-        }
-        resolve(win.getNativeWindow())
-      },
-      error => {
-        console.log('Error creating window:', error)
-      },
-    )
+  return returnChildWindows().then((childWindows: fin.OpenFinWindow[]) => {
+    let updatedPosition = {}
+    const hasChildWindows = childWindows && childWindows.length > 0
+    const shouldBeDefaultCentered = !hasChildWindows
+
+    if (hasChildWindows) {
+      const lastWindow = _last(childWindows)
+      updatedPosition = {
+        defaultLeft: _get(lastWindow, 'nativeWindow.screenLeft') + TEAR_OUT_OFFSET_LEFT,
+        defaultTop: _get(lastWindow, 'nativeWindow.screenTop') + TEAR_OUT_OFFSET_TOP,
+      }
+    }
+    return new Promise<Window>(resolve => {
+      const win = new fin.desktop.Window(
+        {
+          name: config.name || generateRandomName(),
+          url,
+          defaultWidth,
+          defaultHeight,
+          defaultCentered: shouldBeDefaultCentered,
+          autoShow: true,
+          frame: false,
+          saveWindowState: false,
+          shadow: true,
+          ...position,
+          ...updatedPosition,
+        } as any, // any needed because OpenFin does not have correct typings for WindowOptions @kdesai
+        () => {
+          if (onClose) {
+            win.addEventListener('closed', onClose)
+          }
+          resolve(win.getNativeWindow())
+        },
+        error => {
+          console.log('Error creating window:', error)
+        },
+      )
+    })
   })
 }


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/3123490/59375107-6fc00780-8d1b-11e9-8565-6f6beb7c1255.gif)

Uses `getChildWindows()` to get the position of the last torn out child window. Newly created child windows are then positioned with an offset.