### PR TITLE
ARTP-698: Fix openfin notifications bug

### DIFF
--- a/src/client/src/rt-platforms/openFin/adapter/openFin.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/openFin.ts
@@ -160,6 +160,7 @@ export default class OpenFin extends BasePlatformAdapter {
               iconUrl: `${location.protocol}//${location.host}/static/media/icon.ico`,
             },
           ],
+          category: 'Trade Executed',
         })
         .then((successVal: Notification) => {
           console.info('Notification success', successVal)


### PR DESCRIPTION
+ Fix openfin-notifications:
<img width="399" alt="Screen Shot 2019-09-03 at 4 26 21 PM" src="https://user-images.githubusercontent.com/38663839/64266332-6d2c1300-cf02-11e9-8f22-31118872f640.png">

*** The create function from openfin-notification package requires a category property that was not being provided:
<img width="1272" alt="Screen Shot 2019-09-03 at 4 20 22 PM" src="https://user-images.githubusercontent.com/38663839/64266334-6ef5d680-cf02-11e9-920c-32420e550e9d.png">
