### PR TITLE
Artp 700: Fix Highlight Trade In Blotter button bug

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -7515,9 +7515,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
@@ -12974,9 +12974,9 @@
       }
     },
     "openfin-notifications": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/openfin-notifications/-/openfin-notifications-0.10.1.tgz",
-      "integrity": "sha512-jDM3NILb+8RZGaF/Vx3AvT4iBIzM00CcOO0aA0WbDaOrBqniumbtLB8FEwaompQlKWkLoCLdjHTolWn/9EDx5g=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/openfin-notifications/-/openfin-notifications-0.11.0.tgz",
+      "integrity": "sha512-V9/v5z//V76z4/p6TYK9tmupSTafyQJD/FMIctimKu1LpFBCN9jl2S5lMtKt6VmSRtiL66I8GYfiqWKjKoNSRQ=="
     },
     "opn": {
       "version": "5.5.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -59,7 +59,6 @@
     ]
   },
   "dependencies": {
-    "uuid": "3.3.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.2",
@@ -76,7 +75,7 @@
     "moment": "^2.22.2",
     "openfin-fdc3": "^0.1.1",
     "openfin-layouts": "^1.0.5",
-    "openfin-notifications": "^0.10.1",
+    "openfin-notifications": "^0.11.0",
     "polished": "^3.4.1",
     "query-string": "^6.8.2",
     "react": "^16.8.6",
@@ -99,7 +98,8 @@
     "styled-components": "^4.3.2",
     "typeface-lato": "^0.0.54",
     "typeface-montserrat": "^0.0.54",
-    "ua-parser-js": "0.7.10"
+    "ua-parser-js": "0.7.10",
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/src/client/src/rt-platforms/openFin/adapter/openFin.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/openFin.ts
@@ -10,7 +10,7 @@ import { excelAdapter } from './excel'
 import { CurrencyPairPositionWithPrice } from 'rt-types'
 import { LayoutActions } from 'apps/MainRoute/layouts/layoutActions'
 import { workspaces } from 'openfin-layouts'
-import { Notification, NotificationButtonClickedEvent } from 'openfin-notifications'
+import { Notification, NotificationActionEvent } from 'openfin-notifications'
 import { NotificationMessage } from '../../browser/utils/sendNotification'
 import OpenFinRoute from './OpenFinRoute'
 import { Context } from 'openfin-fdc3'
@@ -46,12 +46,14 @@ export default class OpenFin extends BasePlatformAdapter {
   constructor() {
     super()
     this.openFinNotifications.addEventListener(
-      'notification-button-clicked',
-      (event: NotificationButtonClickedEvent) => {
-        fin.desktop.InterApplicationBus.publish(
-          InteropTopics.HighlightBlotter,
-          event.notification.customData,
-        )
+      'notification-action',
+      (event: NotificationActionEvent) => {
+        if (event.result['task'] === 'highlight-trade') {
+          fin.desktop.InterApplicationBus.publish(
+            InteropTopics.HighlightBlotter,
+            event.notification.customData,
+          )
+        }
       },
     )
   }
@@ -158,6 +160,7 @@ export default class OpenFin extends BasePlatformAdapter {
             {
               title: 'Highlight trade in blotter',
               iconUrl: `${location.protocol}//${location.host}/static/media/icon.ico`,
+              onClick: { task: 'highlight-trade' },
             },
           ],
           category: 'Trade Executed',
@@ -185,7 +188,7 @@ export default class OpenFin extends BasePlatformAdapter {
   }
 
   getNotificationBody({ tradeNotification }: NotificationMessage) {
-    return `vs. ${tradeNotification.termsCurrency} - Rate ${tradeNotification.spotRate} - Trade ID ${tradeNotification.tradeId}`
+    return `vs. OOOOOOOOOOOOOOOO ${tradeNotification.termsCurrency} - Rate ${tradeNotification.spotRate} - Trade ID ${tradeNotification.tradeId}`
   }
 }
 

--- a/src/client/src/rt-platforms/openFin/adapter/openFin.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/openFin.ts
@@ -188,7 +188,7 @@ export default class OpenFin extends BasePlatformAdapter {
   }
 
   getNotificationBody({ tradeNotification }: NotificationMessage) {
-    return `vs. OOOOOOOOOOOOOOOO ${tradeNotification.termsCurrency} - Rate ${tradeNotification.spotRate} - Trade ID ${tradeNotification.tradeId}`
+    return `vs. ${tradeNotification.termsCurrency} - Rate ${tradeNotification.spotRate} - Trade ID ${tradeNotification.tradeId}`
   }
 }
 


### PR DESCRIPTION
***Things done:
+ Updated `openfin-notifcations` package from version `0.10.1` to `0.11.0`
+ Fixed the `Highlight Trade In Blotter` button bug for OpenFin notifications

![Screen Shot 2019-09-05 at 3 29 31 PM](https://user-images.githubusercontent.com/38663839/64374494-fcfcba80-cff1-11e9-8fdc-ba0eb9337a0e.png)

***See the changes in `openfin-notifcations` docs:
[0.10.1 docs](https://cdn.openfin.co/docs/services/notifications/0.10.1/api/modules/index.html)
[0.11.0 docs](https://cdn.openfin.co/docs/services/notifications/0.11.0/api/modules/notifications.html)
