### PR TITLE
ARTP-703: Fix window resizing of tear outs in OpenFin

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/workspace/selectors.ts
+++ b/src/client/src/apps/MainRoute/widgets/workspace/selectors.ts
@@ -19,6 +19,10 @@ const makeExternalWindowProps: (key: string, tileLayout?: WindowPosition) => Ext
     name: `${key}`,
     width: 366, // 346 content + 10 padding
     height: 193,
+    minWidth: 366,
+    minHeight: 193,
+    maxWidth: 366,
+    maxHeight: 193,
     url: `/spot/${key}`,
     x: tileLayout ? tileLayout.x : undefined,
     y: tileLayout ? tileLayout.y : undefined,

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -10,6 +10,8 @@ const blotterRegion: ExternalWindow = {
     name: 'blotter',
     width: 850,
     height: 450,
+    minWidth: 300,
+    minHeight: 200,
     url: '/blotter',
   },
 }
@@ -20,6 +22,8 @@ const analyticsRegion: ExternalWindow = {
     name: 'analytics',
     width: 352, // 332 content + 10 padding
     height: 800,
+    minWidth: 360,
+    minHeight: 200,
     url: '/analytics',
   },
 }

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -36,7 +36,10 @@ export const openDesktopWindow = (
   onClose?: () => void,
   position?: {},
 ) => {
-  const { url, width: defaultWidth, height: defaultHeight } = config
+  const { url, width: defaultWidth, height: defaultHeight, maxHeight, maxWidth } = config
+  const minWidth = config.minWidth ? config.minWidth : 100
+  const minHeight = config.minHeight ? config.minHeight : 100
+
   return returnChildWindows().then((childWindows: fin.OpenFinWindow[]) => {
     let updatedPosition = {}
     const hasChildWindows = childWindows && childWindows.length > 0
@@ -62,6 +65,10 @@ export const openDesktopWindow = (
           url,
           defaultWidth,
           defaultHeight,
+          minWidth,
+          minHeight,
+          maxHeight,
+          maxWidth,
           defaultCentered: shouldBeDefaultCentered,
           autoShow: true,
           frame: false,

--- a/src/client/src/rt-platforms/types.ts
+++ b/src/client/src/rt-platforms/types.ts
@@ -10,6 +10,10 @@ export interface WindowConfig {
   url: string
   width: number
   height: number
+  minHeight?: number
+  minWidth?: number
+  maxHeight?: number
+  maxWidth?: number
   center?: 'parent' | 'screen'
   x?: number
   y?: number


### PR DESCRIPTION
***Things done:
+ Fix resizing of tear out windows in openfin that make them disappear.
    - added `minHeight`, `minWidth`, `maxHeight`, `maxWidth` to each tear out components

*BUG*
![ARTP-703_bug](https://user-images.githubusercontent.com/38663839/64557934-a9031600-d310-11e9-8f0c-c6acda414178.gif)

*FIX*
![ARTP-703_fix](https://user-images.githubusercontent.com/38663839/64558268-79a0d900-d311-11e9-97ba-638c01cd5a0b.gif)

