### PR TITLE
ARTP-715: fix to hide "unavailable" streaming prices when notional >= 10m

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -63,6 +63,7 @@ class AnalyticsTile extends React.PureComponent<Props> {
               priceData={price}
               currencyPair={currencyPair}
               disabled={tradingDisabled}
+              rfqState={rfqState}
             />
           </AnalyticsTileContent>
         </AnalyticsTileStyle>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTilePriceControl.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTilePriceControl.tsx
@@ -52,13 +52,13 @@ const AnalyticsPriceControl: React.SFC<Props> = ({
       />
       <div>
         {isRfqStateCanRequest && (
-          <PriceButtonDisabledPlaceholder data-qa="price-controls__price-button-disabled-1">
+          <PriceButtonDisabledPlaceholder data-qa="analytics-tile-price-control__price-button--disabled">
             <Icon className="fas fa-ban fa-flip-horizontal" />
             Streaming price unavailable
           </PriceButtonDisabledPlaceholder>
         )}
         {isRfqStateCanRequest && (
-          <PriceButtonDisabledPlaceholder data-qa="price-controls__price-button-disabled-1">
+          <PriceButtonDisabledPlaceholder data-qa="analytics-tile-price-control__price-button--disabled">
             <Icon className="fas fa-ban fa-flip-horizontal" />
             Streaming price unavailable
           </PriceButtonDisabledPlaceholder>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTilePriceControl.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTilePriceControl.tsx
@@ -5,12 +5,16 @@ import { SpotPriceTick } from '../../model/spotPriceTick'
 import { getSpread, toRate } from '../../model/spotTileUtils'
 import PriceButton from '../PriceButton'
 import PriceMovement from '../PriceMovement'
+import { RfqState } from '../types'
+import { getConstsFromRfqState } from '../../model/spotTileUtils'
+import { PriceButtonDisabledPlaceholder, Icon } from '../PriceControls/styled'
 
 interface Props {
   currencyPair: CurrencyPair
   priceData: SpotPriceTick
   executeTrade: (direction: Direction, rawSpotRate: number) => void
   disabled: boolean
+  rfqState: RfqState
 }
 const AnalyticsPriceControlHeader = styled.div`
   display: flex;
@@ -23,6 +27,7 @@ const AnalyticsPriceControl: React.SFC<Props> = ({
   priceData,
   executeTrade,
   disabled,
+  rfqState,
 }) => {
   const bidRate = toRate(priceData.bid, currencyPair.ratePrecision, currencyPair.pipsPosition)
   const askRate = toRate(priceData.ask, currencyPair.ratePrecision, currencyPair.pipsPosition)
@@ -32,31 +37,54 @@ const AnalyticsPriceControl: React.SFC<Props> = ({
     currencyPair.pipsPosition,
     currencyPair.ratePrecision,
   )
+  const {
+    isRfqStateReceived,
+    isRfqStateExpired,
+    isRfqStateCanRequest,
+    isRfqStateNone,
+  } = getConstsFromRfqState(rfqState)
+
   return (
-    <AnalyticsPriceControlHeader>
+    <AnalyticsPriceControlHeader data-qa="analytics-tile-price-control__header">
       <PriceMovement
         priceMovementType={priceData.priceMovementType}
         spread={spread.formattedValue}
       />
       <div>
-        <PriceButton
-          handleClick={() => executeTrade(Direction.Sell, priceData.bid)}
-          direction={Direction.Sell}
-          big={bidRate.bigFigure}
-          pip={bidRate.pips}
-          tenth={bidRate.pipFraction}
-          rawRate={bidRate.rawRate}
-          disabled={disabled}
-        />
-        <PriceButton
-          handleClick={() => executeTrade(Direction.Buy, priceData.ask)}
-          direction={Direction.Buy}
-          big={askRate.bigFigure}
-          pip={askRate.pips}
-          tenth={askRate.pipFraction}
-          rawRate={askRate.rawRate}
-          disabled={disabled}
-        />
+        {isRfqStateCanRequest && (
+          <PriceButtonDisabledPlaceholder data-qa="price-controls__price-button-disabled-1">
+            <Icon className="fas fa-ban fa-flip-horizontal" />
+            Streaming price unavailable
+          </PriceButtonDisabledPlaceholder>
+        )}
+        {isRfqStateCanRequest && (
+          <PriceButtonDisabledPlaceholder data-qa="price-controls__price-button-disabled-1">
+            <Icon className="fas fa-ban fa-flip-horizontal" />
+            Streaming price unavailable
+          </PriceButtonDisabledPlaceholder>
+        )}
+        {(isRfqStateNone || isRfqStateReceived || isRfqStateExpired) && (
+          <React.Fragment>
+            <PriceButton
+              handleClick={() => executeTrade(Direction.Sell, priceData.bid)}
+              direction={Direction.Sell}
+              big={bidRate.bigFigure}
+              pip={bidRate.pips}
+              tenth={bidRate.pipFraction}
+              rawRate={bidRate.rawRate}
+              disabled={disabled}
+            />
+            <PriceButton
+              handleClick={() => executeTrade(Direction.Buy, priceData.ask)}
+              direction={Direction.Buy}
+              big={askRate.bigFigure}
+              pip={askRate.pips}
+              tenth={askRate.pipFraction}
+              rawRate={askRate.rawRate}
+              disabled={disabled}
+            />
+          </React.Fragment>
+        )}
       </div>
     </AnalyticsPriceControlHeader>
   )


### PR DESCRIPTION
## Bug:
![Screen Shot 2019-09-20 at 2 05 36 PM](https://user-images.githubusercontent.com/38663839/65348694-c6a56a80-dbaf-11e9-9abe-6e8069b69dec.png)
- Prices are still "streaming" (should be unavailable) even when notional is greater than or equal to 10 million in Analytics Tile view

## Fix:
![Screen Shot 2019-09-20 at 2 07 28 PM](https://user-images.githubusercontent.com/38663839/65348805-00767100-dbb0-11e9-822c-5a7f2405bb2d.png)
- Prices show "Streaming Price Unavailable" when notional is greater than or equal to 10 million