### PR TITLE
Fix Symphony share callback attachment

### DIFF
--- a/src/client/src/rt-platforms/symphony/adapter/index.ts
+++ b/src/client/src/rt-platforms/symphony/adapter/index.ts
@@ -1,17 +1,19 @@
 import { BasePlatformAdapter } from '../../platformAdapter'
 import { WindowConfig } from '../../types'
 import { SymphonyClient, SYMPHONY_APP_ID, FX_ENTITY_TYPE, createTileMessage } from '../index'
+import { waitForObject } from 'rt-util'
 
 export default class Symphony extends BasePlatformAdapter {
   readonly name = 'browser'
   readonly type = 'browser'
+  symphony: SymphonyClient;
 
   async init() {
-    const symphony: SymphonyClient = window.SYMPHONY
+    this.symphony = await waitForObject('SYMPHONY');
 
     try {
-      await symphony.remote.hello()
-      await symphony.application.connect(SYMPHONY_APP_ID, ['modules', 'share'])
+      await this.symphony.remote.hello()
+      await this.symphony.application.connect(SYMPHONY_APP_ID, ['modules', 'share'])
       console.info('Adaptive Symphony Initialised')
     } catch (e) {
       console.error('Adaptive Symphony Failed' + e)
@@ -40,8 +42,7 @@ export default class Symphony extends BasePlatformAdapter {
   }
 
   share = (obj: any) => {
-    const symphony: SymphonyClient = window.SYMPHONY
-    const shareService = symphony.services.subscribe('share')
+    const shareService = this.symphony.services.subscribe('share')
     const ccyPair = 'GBPUSD'
     shareService.share(FX_ENTITY_TYPE, {
       plaintext: `Latest Price for $${ccyPair}`,

--- a/src/server/Adaptive.ReactiveTrader.Server.Bot/package.json
+++ b/src/server/Adaptive.ReactiveTrader.Server.Bot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "adaptive.reactivetrader.server.boy",
+  "name": "adaptive.reactivetrader.server.bot",
   "version": "0.0.1",
   "description": "Bot Service for Reactive Trader",
   "main": "lib/index",


### PR DESCRIPTION
This is a low impact fix to address issue where the Symphony share hookup is attempted before the Symphony window object is available.
Not 100% sure how this looks under the new platform refactorings...