### PR TITLE
ARTP-771: Remove line animation on analytics tile chart

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTileChart.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTileChart.tsx
@@ -32,7 +32,7 @@ const AnalyticsTileChart: React.FC<Props> = ({ history }) => {
               <stop stopColor="#737987" stopOpacity={1} strokeWidth={1.2} />
             </linearGradient>
           </defs>
-          <Line dataKey="mid" dot={false} stroke="url(#lineColour)" />
+          <Line dataKey="mid" dot={false} stroke="url(#lineColour)" isAnimationActive={false} />
           <YAxis
             width={0}
             domain={['dataMin', 'dataMax']}


### PR DESCRIPTION
Analytics graph in tile was wriggling around meaninglessly:

![cap1](https://user-images.githubusercontent.com/5602649/66112240-67d5ed00-e5c2-11e9-96c9-06b39d34d476.gif)

I've removed animation to stop this:

![cap2](https://user-images.githubusercontent.com/5602649/66112336-8b009c80-e5c2-11e9-8988-feaf73c73376.gif)

JIRA: https://weareadaptive.atlassian.net/browse/ARTP-771