### PR TITLE
ARTP-773: Improve PnL hover price format and transition

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
@@ -31,7 +31,7 @@ const PNLBar: React.FC<PNLBarProps> = ({ symbol, basePnl, maxVal }) => {
   const color = basePnl >= 0 ? 'green' : 'red'
   const distance = getLogRatio(maxVal, basePnl) * TRANSLATION_WIDTH * (basePnl >= 0 ? 1 : -1)
   const price = numeral(Math.abs(basePnl)).format('0a')
-  const hoverPrice = basePnl.toFixed(2)
+  const hoverPrice = numeral(basePnl).format('0,0.00')
   return (
     <BarChart>
       <Label>{symbol}</Label>

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/styled.tsx
@@ -32,14 +32,13 @@ export const OriginTickWrapper = styled(FlexDiv)`
 export const PriceLabel = styled.div<{ color: string; distance: number }>`
   align-self: center;
   height: 1.1rem;
-  transition: font-size 0.2s, transform 0.2s;
+  transition: transform 0.2s;
   color: ${({ theme, color }) => theme.template[color].normal};
   padding-bottom: 0px;
 
   &:hover {
-    font-size: 18px;
-    padding-bottom: 3px;
-    transform: translateX(${({ distance }) => (distance > 35 ? `${(distance / 2) * -1}%` : '0%')});
+    transform: scale(1.64);
+    transform-origin: ${({ distance }) => (distance > 35 ? 'calc(164% - 15px)' : 'center')} 12px;
   }
 `
 export const DiamondShape = styled.div<{ color: string }>`


### PR DESCRIPTION
- changed hover transition to use scale transform instead of font-size, makes animation smoother
- added thousand separators to hover price

![cap3](https://user-images.githubusercontent.com/5602649/66118951-87bfdd80-e5cf-11e9-8df8-37adafb9df4f.gif)
