### PR TITLE
show reset button when notional differs default notional

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
@@ -3,6 +3,7 @@ import { spotDateFormatter } from '../model/dateUtils'
 import NotionalInput from './notional'
 import PriceControls from './PriceControls'
 import TileHeader from './TileHeader'
+import { getDefaultNotionalValue } from './Tile/TileBusinessLogic'
 import {
   NotionalInputWrapper,
   SpotTileWrapper,
@@ -39,10 +40,16 @@ export default class SpotTile extends PureComponent<Props> {
     const spotDate = price.valueDate && spotDateFormatter(price.valueDate, false).toUpperCase()
     const date = spotDate && `SPT (${spotDate})`
     const handleRfqRejected = () => rfq.reject({ currencyPair })
-    const { isRfqStateReceived, isRfqStateExpired, isRfqStateCanRequest } = getConstsFromRfqState(
-      rfqState,
-    )
-    const showResetButton = isRfqStateCanRequest || isRfqStateExpired
+    const {
+      isRfqStateReceived,
+      isRfqStateExpired,
+      isRfqStateCanRequest,
+      isRfqStateNone,
+    } = getConstsFromRfqState(rfqState)
+    const showResetButton =
+      !isTradeExecutionInFlight &&
+      getDefaultNotionalValue(currencyPair) !== notional &&
+      (isRfqStateNone || isRfqStateCanRequest || isRfqStateExpired)
     const showTimer = isRfqStateReceived && rfqTimeout
     const priceData = isRfqStateReceived || isRfqStateExpired ? rfqPrice : price
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -277,15 +277,6 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
             type="text"
             value="1,000,000"
           />
-          <button
-            className="sc-ifAKCX gROrJN"
-            data-qa="notional-input__reset-input-value"
-            onClick={[Function]}
-          >
-            <i
-              className="fas fa-redo fa-flip-horizontal"
-            />
-          </button>
         </div>
       </div>
     </div>
@@ -472,15 +463,6 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
             type="text"
             value="1,000,000"
           />
-          <button
-            className="sc-ifAKCX gROrJN"
-            data-qa="notional-input__reset-input-value"
-            onClick={[Function]}
-          >
-            <i
-              className="fas fa-redo fa-flip-horizontal"
-            />
-          </button>
         </div>
       </div>
     </div>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -4,7 +4,7 @@ import AnalyticsPriceControl from './AnalyticsTilePriceControl'
 import NotionalInput from '../notional'
 import AnalyticsTileChart from './AnalyticsTileChart'
 import { usePlatform } from 'rt-components'
-
+import { getDefaultNotionalValue } from '../Tile/TileBusinessLogic'
 import {
   AnalyticsTileStyle,
   AnalyticsTileContent,
@@ -24,7 +24,7 @@ class AnalyticsTile extends React.PureComponent<Props> {
   render() {
     const {
       currencyPair,
-      spotTileData: { price, historicPrices, rfqState },
+      spotTileData: { isTradeExecutionInFlight, price, historicPrices, rfqState },
       notional,
       updateNotional,
       resetNotional,
@@ -36,8 +36,13 @@ class AnalyticsTile extends React.PureComponent<Props> {
     } = this.props
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
     const date = spotDate && `SPT (${spotDate})`
-    const { isRfqStateExpired, isRfqStateCanRequest } = getConstsFromRfqState(rfqState)
-    const showResetButton = isRfqStateCanRequest || isRfqStateExpired
+    const { isRfqStateExpired, isRfqStateCanRequest, isRfqStateNone } = getConstsFromRfqState(
+      rfqState,
+    )
+    const showResetButton =
+      !isTradeExecutionInFlight &&
+      getDefaultNotionalValue(currencyPair) !== notional &&
+      (isRfqStateNone || isRfqStateCanRequest || isRfqStateExpired)
 
     return (
       <AnalyticsWrapperWithPlatform>


### PR DESCRIPTION
Show the reset button next to the notional input whenever a user enters a notional that is different from a SpotTile's default notional

## Before Bugfix
![artp-755-bug](https://user-images.githubusercontent.com/51333190/66132009-63a9cf80-e5c2-11e9-91b4-ee76ad1df1a4.gif)


## After Bugfix
![show-reset-button](https://user-images.githubusercontent.com/51333190/66132025-6a384700-e5c2-11e9-9c77-3410245c3bf4.gif)

