### PR TITLE
ARTP-699: Don't call close callback on tear-off window refresh

### DIFF
--- a/src/client/src/rt-platforms/browser/window.ts
+++ b/src/client/src/rt-platforms/browser/window.ts
@@ -29,7 +29,18 @@ export const openBrowserWindow = function(
   )
 
   if (onClose && win) {
-    win.addEventListener('beforeunload', onClose)
+    const unloadListener = () => {
+      setTimeout(() => {
+        if (win.closed) {
+          onClose()
+        } else {
+          // needs to be re-set after window reload
+          setUnloadListener()
+        }
+      }, 100)
+    }
+    const setUnloadListener = () => win.addEventListener('unload', unloadListener)
+    setUnloadListener()
   }
 
   this.prevWindow = win


### PR DESCRIPTION
Fixes issue where refreshing a torn-off spot ticket could lead to the ticket becoming lost entirely (see https://weareadaptive.atlassian.net/browse/ARTP-699 for full detail)

The `onClose` callback is now only called if the tear-off window is flagged as closed 100ms after the unload event fired.