### PR TITLE
ARTP-772: Store RFQ received time and use it in timer

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
@@ -23,7 +23,14 @@ export default class SpotTile extends PureComponent<Props> {
   render() {
     const {
       currencyPair,
-      spotTileData: { isTradeExecutionInFlight, price, rfqState, rfqPrice, rfqTimeout },
+      spotTileData: {
+        isTradeExecutionInFlight,
+        price,
+        rfqState,
+        rfqPrice,
+        rfqReceivedTime,
+        rfqTimeout,
+      },
       notional,
       updateNotional,
       resetNotional,
@@ -83,7 +90,13 @@ export default class SpotTile extends PureComponent<Props> {
                 disabled={inputDisabled}
               />
             </NotionalInputWrapper>
-            {showTimer && <RfqTimer onRejected={handleRfqRejected} timeout={rfqTimeout} />}
+            {showTimer && (
+              <RfqTimer
+                onRejected={handleRfqRejected}
+                receivedTime={rfqReceivedTime}
+                timeout={rfqTimeout}
+              />
+            )}
           </ReserveSpaceGrouping>
         </SpotTileStyle>
         {children}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -122,6 +122,7 @@ TileSwitch.defaultProps = {
     lastTradeExecutionStatus: null,
     rfqState: 'none',
     rfqPrice: null,
+    rfqReceivedTime: null,
     rfqTimeout: null,
   },
   currencyPair: {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/test-resources/spotTileProps.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/test-resources/spotTileProps.ts
@@ -45,6 +45,7 @@ const spotTileData: Required<SpotTileData> = {
   historicPrices: generateHistoricPrices(50),
   lastTradeExecutionStatus: null,
   rfqState: 'none',
+  rfqReceivedTime: null,
   rfqTimeout: null,
   rfqPrice: null,
 }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/model/rfqRequest.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/model/rfqRequest.ts
@@ -8,6 +8,7 @@ export interface RfqRequest {
 
 export interface RfqReceived extends RfqRequest {
   price: SpotPriceTick
+  time: number
   timeout: number
 }
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
@@ -17,6 +17,7 @@ export interface SpotTileData {
   historicPrices: SpotPriceTick[]
   lastTradeExecutionStatus?: LastTradeExecutionStatus | null
   rfqState: RfqState
+  rfqReceivedTime: number | null
   rfqTimeout: number | null
   rfqPrice: SpotPriceTick | null
 }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileReducer.ts
@@ -26,6 +26,7 @@ const INITIAL_SPOT_TILE_STATE: SpotTileData = {
   },
   rfqState: 'none',
   rfqPrice: null,
+  rfqReceivedTime: null,
   rfqTimeout: null,
 }
 
@@ -70,6 +71,7 @@ const rfqTileReducer = (
 ): SpotTileData => {
   const newState: SpotTileData = {
     ...state,
+    rfqReceivedTime: null,
     rfqTimeout: null,
     rfqPrice: null,
   }
@@ -95,6 +97,7 @@ const rfqTileReducer = (
       return {
         ...newState,
         rfqState: 'received',
+        rfqReceivedTime: action.payload.time,
         rfqTimeout: action.payload.timeout,
         rfqPrice: action.payload.price,
       }


### PR DESCRIPTION
If an RFQ was received and the tile was the unmounted and re-mounted (e.g. by changing the base currency at the top), the RFQ timer would restart at initial timeout. (The RFQ would still expire at the correct time, which would be before the timer counted down fully)

This PR adds the RFQ received time to the data store so it can be used to calculate the time left correctly.