### PR TITLE
ARTP-710: OpenFin installer - ChartIQ doesn't open if tile graph activated

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -34,6 +34,7 @@ class AnalyticsTile extends React.PureComponent<Props> {
       tradingDisabled,
       inputDisabled,
       inputValidationMessage,
+      displayCurrencyChart,
     } = this.props
     const spotDate = spotDateFormatter(price.valueDate, false).toUpperCase()
     const date = spotDate && `SPT (${spotDate})`
@@ -52,7 +53,11 @@ class AnalyticsTile extends React.PureComponent<Props> {
           data-qa="analytics-tile__spot-tile"
           data-qa-id={`currency-pair-${currencyPair.symbol.toLowerCase()}`}
         >
-          <TileHeader ccyPair={currencyPair} date={date} />
+          <TileHeader
+            ccyPair={currencyPair}
+            date={date}
+            displayCurrencyChart={displayCurrencyChart}
+          />
           <AnalyticsTileContent>
             <GraphNotionalWrapper>
               <LineChartWrapper>


### PR DESCRIPTION
Pass `displayCurrencyChart` prop to `TileHeader` component to enable chart-iq feature for `AnalyticsTile` 

See [**ARTP-710**: OpenFin installer - ChartIQ doesn't open if tile graph activated](https://weareadaptive.atlassian.net/browse/ARTP-710?atlOrigin=eyJpIjoiNTg1ZTk2M2QwZTMzNDZiMmE1N2U5MGViNmQxNWViZWUiLCJwIjoiaiJ9)