### PR TITLE
Bugfix/artp 780

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
@@ -44,6 +44,7 @@ const defaultParams: DerivedStateFromUserInput = {
     rfqPrice: null,
     rfqState: 'none',
     rfqTimeout: null,
+    rfqReceivedTime: null,
     notional: notionalUpdate,
   },
   currencyPair,

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
@@ -17,7 +17,6 @@ import {
   getNumericNotional,
   getDerivedStateFromUserInput,
   isValueInRfqRange,
-  getDefaultNotionalValue,
 } from './TileBusinessLogic'
 import { getConstsFromRfqState } from '../../model/spotTileUtils'
 import { CurrencyPairNotional } from '../../model/spotTileData'
@@ -123,7 +122,7 @@ class Tile extends React.PureComponent<TileProps, TileState> {
 
   resetNotional = () => {
     const { setTradingMode, currencyPair, updateNotional } = this.props
-    const defaultNotional = getDefaultNotionalValue()
+    const defaultNotional = getDefaultInitialNotionalValue(currencyPair)
     const isInRfqRange = isValueInRfqRange(defaultNotional)
     setTradingMode({ symbol: currencyPair.symbol, mode: isInRfqRange ? 'rfq' : 'esp' })
     updateNotional({

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
@@ -61,16 +61,14 @@ class Tile extends React.PureComponent<TileProps, TileState> {
   // State management derived from props
   static getDerivedStateFromProps(nextProps: TileProps, prevState: TileState) {
     const { setTradingMode, spotTileData, currencyPair } = nextProps
-    return {
-      ...getDerivedStateFromProps(nextProps, prevState),
-      ...getDerivedStateFromUserInput({
-        prevState,
-        notionalUpdate: spotTileData.notional,
-        spotTileData,
-        actions: { setTradingMode },
-        currencyPair,
-      }),
-    }
+    const stateFromProps = getDerivedStateFromProps(nextProps, prevState)
+    return getDerivedStateFromUserInput({
+      prevState: stateFromProps,
+      notionalUpdate: spotTileData.notional,
+      spotTileData,
+      actions: { setTradingMode },
+      currencyPair,
+    })
   }
 
   // We handle the case where the initial Notional value would

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -36,16 +36,16 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
         className="sc-cMljjf buguXb"
       >
         <button
-          className="sc-EHOje kkdSuS"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-sell-eurusd"
           direction="Sell"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -99,16 +99,16 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           />
         </div>
         <button
-          className="sc-EHOje ciDDPg"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-buy-eurusd"
           direction="Buy"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -157,9 +157,9 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
             EUR
           </span>
           <input
-            className="sc-bxivhb fauXdE"
+            className="sc-bxivhb ixCVbX"
             data-qa-id="notional-input__input-eurusd"
-            disabled={false}
+            disabled={true}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -320,16 +320,16 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
         className="sc-cMljjf buguXb"
       >
         <button
-          className="sc-EHOje kkdSuS"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-sell-eurusd"
           direction="Sell"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -389,16 +389,16 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           />
         </div>
         <button
-          className="sc-EHOje ciDDPg"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-buy-eurusd"
           direction="Buy"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -627,9 +627,9 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
             EUR
           </span>
           <input
-            className="sc-bxivhb fauXdE"
+            className="sc-bxivhb ixCVbX"
             data-qa-id="notional-input__input-eurusd"
-            disabled={false}
+            disabled={true}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -823,9 +823,9 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
             EUR
           </span>
           <input
-            className="sc-bxivhb fauXdE"
+            className="sc-bxivhb ixCVbX"
             data-qa-id="notional-input__input-eurusd"
-            disabled={false}
+            disabled={true}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1050,16 +1050,16 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
         className="sc-cMljjf buguXb"
       >
         <button
-          className="sc-EHOje kkdSuS"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-sell-eurusd"
           direction="Sell"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -1113,16 +1113,16 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           />
         </div>
         <button
-          className="sc-EHOje ciDDPg"
+          className="sc-EHOje gCbQHr"
           data-qa="price-button__trade-button"
           data-qa-id="direction-buy-eurusd"
           direction="Buy"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
         >
           <div
-            className="sc-gZMcBi crpdKd"
-            disabled={false}
+            className="sc-gZMcBi egNMcT"
+            disabled={true}
           >
             <div
               className="sc-gqjmRU cKkifn"
@@ -1171,9 +1171,9 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
             EUR
           </span>
           <input
-            className="sc-bxivhb fauXdE"
+            className="sc-bxivhb ixCVbX"
             data-qa-id="notional-input__input-eurusd"
-            disabled={false}
+            disabled={true}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}


### PR DESCRIPTION
## First bug
make notional input disabled when executing trade and initiating RFQ to prevent the `Cannot read property 'bid' of null` error that crashes the app.

### Before bugfix
![crash-on-notional-edit](https://user-images.githubusercontent.com/51333190/66484258-a2cd9a00-ea74-11e9-996b-fafc6025341d.gif)


### After bugfix
![disabled-notional-input](https://user-images.githubusercontent.com/51333190/66484570-34d5a280-ea75-11e9-8979-5d75eef53ddb.gif)

<hr>

## Second bug
make reset notional button reset to the **initial default notional**

### Before bugfix
![reset-notional-bug](https://user-images.githubusercontent.com/51333190/66485259-816dad80-ea76-11e9-953f-178a434c6be8.gif)

### After bugfix
![correct-reset-notional](https://user-images.githubusercontent.com/51333190/66485267-87638e80-ea76-11e9-9d7d-f7789dfd4c1d.gif)
