### PR TITLE
ARTP-599 Typecheck with strict null checks on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "Reactive Trader Cloud",
   "scripts": {
+    "client-strict-null-checks": "tsc -p src/client/tsconfig.strictNullChecks.json",
     "lint": "eslint --ext .ts,.tsx ./src/client/src ./src/node-server/shared/src ./src/node-server/nlp/src",
     "postinstall": "lerna bootstrap"
   },
@@ -21,7 +22,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && npm run client-strict-null-checks"
     }
   },
   "devDependencies": {

--- a/src/client/src/rt-util/asyncUtils.ts
+++ b/src/client/src/rt-util/asyncUtils.ts
@@ -11,8 +11,8 @@ export function wait<T>(time: number, value: T) {
  * Returns a tuple with a new promise and its resolve/reject callbacks to invoke directly
  */
 export function getDeferredPromise<T>(): [Promise<T>, (value?: T) => void, (reason?: any) => void] {
-  let res: (value?: T) => void
-  let rej: (reason?: any) => void
+  let res!: (value?: T) => void
+  let rej!: (reason?: any) => void
   const p = new Promise<T>((r, rj) => {
     res = r
     rej = rj

--- a/src/client/src/rt-util/hooks/useMultiTimeoutPromises.ts
+++ b/src/client/src/rt-util/hooks/useMultiTimeoutPromises.ts
@@ -26,7 +26,9 @@ export function useMultiTimeoutPromises(...params: MultiTimeoutStage[]) {
         setStage(nextStage)
       }
     })
-    return () => (mountedRef.current = false)
+    return () => {
+      mountedRef.current = false
+    }
   }, [stage])
 
   return [stage, (val: number) => goToCb([val, false])] as [number, (val: number) => void]

--- a/src/client/tsconfig.strictNullChecks.json
+++ b/src/client/tsconfig.strictNullChecks.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true
+  },
+  "include": [
+    // "src/apps/**/*",
+    "src/rt-actions/**/*",
+    // "src/rt-components/**/*",
+    // "src/rt-platforms/**/*",
+    // "src/rt-storybook/**/*",
+    // "src/rt-styleguide/**/*",
+    // "src/rt-system/**/*",
+    "src/rt-testing/**/*",
+    "src/rt-theme/**/*",
+    "src/rt-types/**/*",
+    "src/rt-util/**/*",
+    "src/type-declarations/**/*"
+  ]
+}


### PR DESCRIPTION
We want to switch on strict null checks in typescript, but doing so raises 250 type errors, so we want to do this over time, not in a single PR.

I've added a `tsconfig.strictNullChecks.json` which has `strictNullChecks: true` and `include`s only those dirs which pass strictNullChecks.

The npm script `client-strict-null-checks` runs typechecking using this config. This script is run in git pre-commit hook

Over time we can create PRs which remove strictNullCheck errors from more dirs. Those PRs should add the 'fixed' dirs to `tsconfig.strictNullChecks.json` to ensure we don't regress