### PR TITLE
cancel RFQ timer when RFQ_CANCEL action is dispatched

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -30,6 +30,7 @@ type RfqReceivedTimerCancellableType =
   | RfqRejectActionType
   | RfqExpiredActionType
   | RfqResetActionType
+  | RfqCancelActionType
 
 const EXPIRATION_TIMEOUT_MS = 10000
 export const IDLE_TIME_MS = 60000
@@ -95,6 +96,7 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
         ofType<Action, RfqReceivedTimerCancellableType>(
           TILE_ACTION_TYPES.RFQ_REJECT,
           TILE_ACTION_TYPES.RFQ_RESET,
+          TILE_ACTION_TYPES.RFQ_CANCEL,
         ),
         filter(cancelAction => cancelAction.payload.currencyPair.symbol === currencyPair.symbol),
       )


### PR DESCRIPTION
if timer is not canceled when a RFQ_CANCEL action is dispatched then the RFQ_EXPIRE action will eventually get dispatched. This will result in a `null` price for the spot tile, leading to a `TypeError: Cannot read property 'bid' of null` that crashes the application