### PR TITLE
remove nlp deployment step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
             kubectl --namespace=${NAMESPACE} set image deployments/tradeexecution-deployment tradeexecution=${DOCKER_USER}/servers:${BUILD_NUM}
             kubectl --namespace=${NAMESPACE} set image deployments/pricehistory-deployment pricehistory=${DOCKER_USER}/pricehistory:${BUILD_NUM}
             kubectl --namespace=${NAMESPACE} set image deployments/bot-deployment bot=${DOCKER_USER}/bot:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/nlp-deployment nlp=${DOCKER_USER}/nlp:${BUILD_NUM}
+
 workflows:
   version: 2
   main:


### PR DESCRIPTION
This PR removes one of the step introduced by https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/1201, and which causes the deploy build to fail