### PR TITLE
enable eslint to warn on missing hooks dependencies

### DIFF
--- a/src/client/.eslintrc.json
+++ b/src/client/.eslintrc.json
@@ -6,7 +6,7 @@
   "rules": {
     "no-restricted-globals": "off",
     "jsx-a11y/anchor-has-content": "off",
-    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/exhaustive-deps": "warn",
     "@typescript-eslint/no-angle-bracket-type-assertion": "off"
   }
 }


### PR DESCRIPTION
enable eslint to warn on missing hooks dependencies