### PR TITLE
Address react-hooks/exhaustive-deps warnings

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/analytics/components/Analytics.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/Analytics.tsx
@@ -37,7 +37,7 @@ const Analytics: React.FC<Props> = ({
   // Resizing the window is causing the nvd3 chart to resize incorrectly. This forces a render when the window resizes
   useEffect(() => {
     forceUpdate()
-  }, [windowSize])
+  }, [windowSize, forceUpdate])
   return (
     <AnalyticsStyle inExternalWindow={inExternalWindow} data-qa="analytics__analytics-content">
       <ProfitAndLoss

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/AnalyticsLineChart.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/AnalyticsLineChart.tsx
@@ -80,7 +80,8 @@ const LineCharts: React.FC<LineChartProps> = React.memo(props => {
   useEffect(() => {
     const newOffset = offsetState + 1 === intervalWidth ? 0 : offsetState + 1
     setOffsetState(newOffset)
-  }, [props, offsetState])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props])
 
   const getDataPoint = useCallback(
     (dataPoints: DataPoint[]) =>

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/AnalyticsLineChart.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/AnalyticsLineChart.tsx
@@ -80,7 +80,7 @@ const LineCharts: React.FC<LineChartProps> = React.memo(props => {
   useEffect(() => {
     const newOffset = offsetState + 1 === intervalWidth ? 0 : offsetState + 1
     setOffsetState(newOffset)
-  }, [props])
+  }, [props, offsetState])
 
   const getDataPoint = useCallback(
     (dataPoints: DataPoint[]) =>

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/Blotter.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/Blotter.tsx
@@ -90,11 +90,14 @@ const Blotter: React.FC<BlotterProps> = props => {
     platform.fdc3.broadcast(getCurrencyPairContext(currencyPair))
   }
 
-  const onGridReady = useCallback(({ api }: { api: GridApi }) => {
-    setGridApi(api)
-    onModelUpdated()
-    api.sizeColumnsToFit()
-  }, [])
+  const onGridReady = useCallback(
+    ({ api }: { api: GridApi }) => {
+      setGridApi(api)
+      onModelUpdated()
+      api.sizeColumnsToFit()
+    },
+    [onModelUpdated],
+  )
 
   const exportToExcel = useCallback(() => {
     if (gridApi) {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileHeader.tsx
@@ -25,7 +25,7 @@ const TileHeader: React.SFC<Props> = ({ ccyPair, date, displayCurrencyChart }) =
     if (platform.hasFeature('share')) {
       platform.share(ccyPair.symbol)
     }
-  }, [ccyPair.symbol])
+  }, [ccyPair.symbol, platform])
 
   const baseTerm = `${ccyPair.base}/${ccyPair.terms}`
   return (

--- a/src/client/src/rt-components/tear-off/ExternalWindow.tsx
+++ b/src/client/src/rt-components/tear-off/ExternalWindow.tsx
@@ -52,6 +52,7 @@ const ExternalWindow: FC<ExternalWindowProps> = ({
         externalWindow.close()
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return null

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -67,7 +67,7 @@ const TearOff: React.FC<TearOffProps> = props => {
       dispatch(
         LayoutActions.updateContainerVisibilityAction({ name: windowName, display: false, x, y }),
       ),
-    [windowName],
+    [windowName, dispatch],
   )
   const popIn = useCallback(
     () =>

--- a/src/client/src/rt-util/hooks/useMultiTimeout.ts
+++ b/src/client/src/rt-util/hooks/useMultiTimeout.ts
@@ -18,7 +18,8 @@ export function useMultiTimeout(...params: MultiTimeoutStage[]) {
 
   function runStage() {
     if (stageRef.current < params.length) {
-      const { onEnter = () => {}, duration = 0, onLeave = () => {} } = params[stageRef.current] || {}
+      const { onEnter = () => {}, duration = 0, onLeave = () => {} } =
+        params[stageRef.current] || {}
       onEnter(stageRef.current)
       // clearTimeout(timeoutRef.current)
       timeoutRef.current = window.setTimeout(() => {
@@ -46,6 +47,7 @@ export function useMultiTimeout(...params: MultiTimeoutStage[]) {
       mountedRef.current = false
       clearTimeout(timeoutRef.current)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return [stage, gotoStage] as [number, (stage: number) => void]


### PR DESCRIPTION
[Enabling `eslint` to warn missing deps caused some components to throw warnings during compile time.](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/1212)

![Screen Shot 2019-10-15 at 9 47 15 AM](https://user-images.githubusercontent.com/38663839/66842089-b4adb200-ef38-11e9-841c-14a988dd8b38.png)

** I purposely put `// eslint-disable-next-line react-hooks/exhaustive-deps` on some `useEffect` hooks since I assumed they are being used as a `componentDidMount()` (empty deps array).