### PR TITLE
Refactor UI components in rt-components

### DIFF
--- a/src/client/src/rt-components/adaptive-loader/AdaptiveLoader.tsx
+++ b/src/client/src/rt-components/adaptive-loader/AdaptiveLoader.tsx
@@ -1,5 +1,5 @@
 import { memoize } from 'lodash'
-import React, { PureComponent } from 'react'
+import React from 'react'
 import { keyframes } from 'styled-components'
 import { styled } from 'rt-theme'
 
@@ -49,10 +49,8 @@ interface Props {
   speed?: number
 }
 
-export class AdaptiveLoader extends PureComponent<Props> {
-  render() {
-    const { size, type, seperation, speed, children } = this.props
-
+const AdaptiveLoader: React.FC<Props> = React.memo(
+  ({ size, type, seperation, speed, children }) => {
     const sizeNum = Number(size)
     const barHeight = sizeNum * 0.75
     const barWidth = barHeight / 4
@@ -78,7 +76,7 @@ export class AdaptiveLoader extends PureComponent<Props> {
         {children}
       </svg>
     )
-  }
-}
+  },
+)
 
 export default AdaptiveLoader

--- a/src/client/src/rt-components/icons/ExpandIcon.tsx
+++ b/src/client/src/rt-components/icons/ExpandIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const ExpandIcon = () => (
+const ExpandIcon: React.FC = () => (
   <svg
     width="12px"
     height="12px"

--- a/src/client/src/rt-components/loadable/Loadable.tsx
+++ b/src/client/src/rt-components/loadable/Loadable.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import { styled } from 'rt-theme'
 import { ServiceConnectionStatus } from 'rt-types'
 import DisconnectIcon from '../icons/DisconnectIcon'
@@ -35,32 +35,39 @@ interface Props {
   minHeight?: number
 }
 
-export default class Loadable extends Component<Props> {
-  componentDidMount = () => this.props.onMount && this.props.onMount()
+const Loadable: React.FC<Props> = ({
+  status,
+  render,
+  onMount,
+  message = 'Disconnected',
+  minWidth,
+  minHeight,
+}) => {
+  useEffect(() => {
+    onMount && onMount()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  render() {
-    const { status, render, message = 'Disconnected', minWidth, minHeight } = this.props
-
-    if (status === ServiceConnectionStatus.CONNECTED) {
-      return <Content minWidth={`${minWidth}rem`}>{render()}</Content>
-    }
-    return (
-      <LoadableStyle
-        minWidth={`${minWidth}rem`}
-        minHeight={`${minHeight}rem`}
-        data-qa="loadable__loader"
-      >
-        {status === ServiceConnectionStatus.CONNECTING ? (
-          <AdaptiveLoader size={50} speed={1.4} />
-        ) : (
-          <React.Fragment>
-            <div>
-              <DisconnectIcon width={2.75} height={3} />
-            </div>
-            <div>{message}</div>
-          </React.Fragment>
-        )}
-      </LoadableStyle>
-    )
-  }
+  return status === ServiceConnectionStatus.CONNECTED ? (
+    <Content minWidth={`${minWidth}rem`}>{render()}</Content>
+  ) : (
+    <LoadableStyle
+      minWidth={`${minWidth}rem`}
+      minHeight={`${minHeight}rem`}
+      data-qa="loadable__loader"
+    >
+      {status === ServiceConnectionStatus.CONNECTING ? (
+        <AdaptiveLoader size={50} speed={1.4} />
+      ) : (
+        <React.Fragment>
+          <div>
+            <DisconnectIcon width={2.75} height={3} />
+          </div>
+          <div>{message}</div>
+        </React.Fragment>
+      )}
+    </LoadableStyle>
+  )
 }
+
+export default Loadable

--- a/src/client/src/rt-components/modal/Modal.tsx
+++ b/src/client/src/rt-components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { darken } from 'polished'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { styled } from 'rt-theme'
 
@@ -63,31 +63,20 @@ interface Props {
 
 // TODO disable tabbing outside of the modal
 // tslint:disable-next-line:variable-name
-export default class Modal extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props)
-    this.onDismiss = this.onDismiss.bind(this)
-  }
+const Modal: React.FC<Props> = ({ shouldShow, title, onDismiss, children }) => {
+  const onModalDismiss = useCallback(() => onDismiss(), [onDismiss])
 
-  onDismiss() {
-    const { onDismiss } = this.props
-    if (onDismiss) {
-      onDismiss()
-    }
-  }
-
-  render() {
-    const { shouldShow, title, children } = this.props
-    return (
-      shouldShow && (
-        <ModalContainer>
-          <ModalOverlay onClick={this.onDismiss} />
-          <ModalPanel>
-            {title && <Header>{title}</Header>}
-            <Body>{children}</Body>
-          </ModalPanel>
-        </ModalContainer>
-      )
+  return (
+    shouldShow && (
+      <ModalContainer>
+        <ModalOverlay onClick={onModalDismiss} />
+        <ModalPanel>
+          {title && <Header>{title}</Header>}
+          <Body>{children}</Body>
+        </ModalPanel>
+      </ModalContainer>
     )
-  }
+  )
 }
+
+export default Modal

--- a/src/client/src/rt-components/popup/Popup.tsx
+++ b/src/client/src/rt-components/popup/Popup.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from 'react'
+import React, { MouseEvent, useCallback } from 'react'
 import { PopupContainer, PopupPanel, Body } from './styled'
 
 interface Props {
@@ -7,22 +7,16 @@ interface Props {
   onClick?: (e: MouseEvent<HTMLDivElement>) => void
 }
 
-export default class Popup extends React.Component<Props> {
-  onClick(e: MouseEvent<HTMLDivElement>) {
-    const { onClick } = this.props
-    if (onClick) {
-      onClick(e)
-    }
-  }
+const Popup: React.FC<Props> = ({ className, open = false, onClick, children }) => {
+  const onPopupClick = useCallback((e: MouseEvent<HTMLDivElement>) => onClick(e), [onClick])
 
-  render() {
-    const { className, open = false, children } = this.props
-    return (
-      <PopupContainer className={className} open={open} onClick={e => this.onClick(e)}>
-        <PopupPanel>
-          <Body>{children}</Body>
-        </PopupPanel>
-      </PopupContainer>
-    )
-  }
+  return (
+    <PopupContainer className={className} open={open} onClick={onPopupClick}>
+      <PopupPanel>
+        <Body>{children}</Body>
+      </PopupPanel>
+    </PopupContainer>
+  )
 }
+
+export default Popup

--- a/src/client/src/rt-components/resizer/Resizer.tsx
+++ b/src/client/src/rt-components/resizer/Resizer.tsx
@@ -44,7 +44,7 @@ interface Props {
   disabled?: boolean
 }
 
-const Resizer: React.FC<Props> = ({ component, defaultHeight, children }) => {
+const Resizer: React.FC<Props> = ({ component, defaultHeight, children, disabled }) => {
   const wrapperRef = React.createRef<HTMLDivElement>()
   const [height, setHeight] = useState(defaultHeight)
   const [dragging, setDragging] = useState<Boolean>(false)
@@ -68,6 +68,12 @@ const Resizer: React.FC<Props> = ({ component, defaultHeight, children }) => {
       document.removeEventListener('touchend', handleStop)
     }
   })
+
+  useEffect(() => {
+    if (disabled) setHeight(0)
+
+    return () => setHeight(defaultHeight)
+  }, [disabled, defaultHeight])
 
   const handleStart = useCallback(() => setDragging(true), [setDragging])
 

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -57,10 +57,9 @@ export interface TearOffProps {
   dragTearOff: boolean
 }
 
-const TearOff: React.FC<TearOffProps> = props => {
+const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff, dragTearOff }) => {
   const { allowTearOff } = usePlatform()
   const dispatch = useDispatch()
-  const { render, externalWindowProps, tornOff, dragTearOff } = props
   const windowName = externalWindowProps.config.name
   const popOut = useCallback(
     (x: number, y: number) =>


### PR DESCRIPTION
Refactored the following files from a class component to functional component with hooks:
- `Loadable.tsx`
- `Modal.tsx`
- `Popup.tsx`
- `Resizer.tsx`

Refactored `AdaptiveLoader.tsx` to use `React.memo()` instead of a `PureComponent` class

Minor changes in `TearOff.tsx` and `ExpandIcon.tsx`
