### PR TITLE
Remove unnecessary onDismiss function

### DIFF
--- a/src/client/src/rt-components/modal/Modal.tsx
+++ b/src/client/src/rt-components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { darken } from 'polished'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { styled } from 'rt-theme'
 
@@ -64,12 +64,10 @@ interface Props {
 // TODO disable tabbing outside of the modal
 // tslint:disable-next-line:variable-name
 const Modal: React.FC<Props> = ({ shouldShow, title, onDismiss, children }) => {
-  const onModalDismiss = useCallback(() => onDismiss(), [onDismiss])
-
   return (
     shouldShow && (
       <ModalContainer>
-        <ModalOverlay onClick={onModalDismiss} />
+        <ModalOverlay />
         <ModalPanel>
           {title && <Header>{title}</Header>}
           <Body>{children}</Body>


### PR DESCRIPTION
Removed unnecessary `onDismiss` function since it isn't being used to begin with.

For more context, `onDismiss` is being passed as a prop to the `<Modal />` component, however not one of the components that uses `<Modal />` passes down an `onDismiss` function.

### Before bugfix:
![broken](https://user-images.githubusercontent.com/38663839/67048447-3866ca80-f102-11e9-89e9-2ece68074661.gif)

### After bugfix:
![fixed](https://user-images.githubusercontent.com/38663839/67048473-46b4e680-f102-11e9-9ce9-618f91c190b4.gif)
