### PR TITLE
Spotlight - basic fdc3 integration

### DIFF
--- a/src/client/public/config/openfin/launcher-local.json
+++ b/src/client/public/config/openfin/launcher-local.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "fdc3",
-      "manifestUrl": "https://cdn.openfin.co/services/openfin/fdc3/0.2.0/app.json"
+      "manifestUrl": "http://localhost:3000/config/openfin/local-fdc3.json"
     },
     {
       "name": "notifications",

--- a/src/client/public/config/openfin/local-app-directory.json
+++ b/src/client/public/config/openfin/local-app-directory.json
@@ -1,0 +1,15 @@
+[
+  {
+    "appId": "fdc3-blotter",
+    "name": "fdc3-blotter",
+    "manifest": "http://localhost:3000/config/openfin/local-blotter.json",
+    "manifestType": "openfin",
+    "title": "Blotter",
+    "intents": [
+      {
+        "name": "fdc3.ViewBlotter",
+        "displayName": "View Blotter"
+      }
+    ]
+  }
+]

--- a/src/client/public/config/openfin/local-blotter.json
+++ b/src/client/public/config/openfin/local-blotter.json
@@ -1,0 +1,46 @@
+{
+  "devtools_port": 9090,
+  "splashScreenImage": "http://localhost:3000/static/media/splash-screen.jpg",
+  "startup_app": {
+    "name": "Reactive Trader Cloud Blotter (LOCAL)",
+    "url": "http://localhost:3000/blotter",
+    "uuid": "reactive-trader-cloud-blotter-local",
+    "applicationIcon": "http://localhost:3000/static/media/adaptive-mark-large.png",
+    "autoShow": true,
+    "defaultWidth": 1280,
+    "defaultHeight": 900,
+    "minWidth": 800,
+    "minHeight": 600,
+    "resizable": true,
+    "maximizable": true,
+    "frame": false,
+    "shadow": true,
+    "contextMenu": true,
+    "accelerator": {
+      "devtools": true,
+      "reload": true,
+      "reloadIgnoringCache": true,
+      "zoom": true
+    }
+  },
+  "runtime": {
+    "version": "13.76.44.21"
+  },
+  "services": [
+    {
+      "name": "layouts",
+      "config": {
+        "features": {
+          "snap": true,
+          "dock": true,
+          "tab": false
+        }
+      },
+      "manifestUrl": "https://cdn.openfin.co/services/openfin/layouts/app.json"
+    },
+    {
+      "name": "fdc3",
+      "manifestUrl": "https://cdn.openfin.co/services/openfin/fdc3/app.json"
+    }
+  ]
+}

--- a/src/client/public/config/openfin/local-fdc3.json
+++ b/src/client/public/config/openfin/local-fdc3.json
@@ -1,0 +1,18 @@
+{
+  "devtools_port": 9090,
+  "startup_app": {
+    "name": "FDC3-Service",
+    "description": "OpenFin FDC3 Desktop Service",
+    "url": "https://cdn.openfin.co/services/openfin/fdc3/0.2.1-alpha.57/provider.html",
+    "uuid": "fdc3-service",
+    "autoShow": false,
+    "defaultHeight": 400,
+    "defaultWidth": 500
+  },
+  "runtime": {
+    "version": "13.76.44.21"
+  },
+  "serviceConfiguration": {
+    "applicationDirectory": "http://localhost:3000/config/openfin/local-app-directory.json"
+  }
+}

--- a/src/client/src/apps/SimpleLauncher/Launcher.tsx
+++ b/src/client/src/apps/SimpleLauncher/Launcher.tsx
@@ -10,6 +10,7 @@ import { createGlobalStyle } from 'styled-components'
 import { ThemeStorageSwitch, styled } from 'rt-theme'
 import { open } from './tools'
 import { getOpenFinPlatform } from 'rt-platforms'
+
 library.add(faSignOutAlt)
 
 const exitHandler = async () => {

--- a/src/client/src/apps/SpotlightRoute/fdc3/browserFdc3.ts
+++ b/src/client/src/apps/SpotlightRoute/fdc3/browserFdc3.ts
@@ -1,0 +1,12 @@
+import { DetectIntentResponse } from 'dialogflow'
+import { SpotlightFdc3 } from './fdc3'
+
+export class BrowserFdc3 implements SpotlightFdc3 {
+  getMatchingApps(response: DetectIntentResponse) {
+    return Promise.resolve([])
+  }
+
+  open(appId: string): Promise<void> {
+    return Promise.reject('Not Supported')
+  }
+}

--- a/src/client/src/apps/SpotlightRoute/fdc3/context.ts
+++ b/src/client/src/apps/SpotlightRoute/fdc3/context.ts
@@ -1,0 +1,9 @@
+import React, { useContext } from 'react'
+import { SpotlightFdc3 } from './fdc3'
+
+const Fdc3Context = React.createContext<SpotlightFdc3>(null)
+export const { Provider: Fdc3Provider } = Fdc3Context
+
+export function useFdc3() {
+  return useContext(Fdc3Context)
+}

--- a/src/client/src/apps/SpotlightRoute/fdc3/fdc3.ts
+++ b/src/client/src/apps/SpotlightRoute/fdc3/fdc3.ts
@@ -1,0 +1,24 @@
+import { DetectIntentResponse } from 'dialogflow'
+
+const getOpenfinFdc3 = () => import('./openfinFdc3')
+const getBrowserFdc3 = () => import('./browserFdc3')
+
+export interface SpotlightApplication {
+  id: string
+  name: string
+}
+
+export interface SpotlightFdc3 {
+  getMatchingApps(response: DetectIntentResponse): Promise<SpotlightApplication[]>
+
+  open(appId: string): Promise<void>
+}
+
+export const getFdc3 = async () => {
+  if ((window as any).fin) {
+    const { OpenfinFdc3 } = await getOpenfinFdc3()
+    return new OpenfinFdc3()
+  }
+  const { BrowserFdc3 } = await getBrowserFdc3()
+  return new BrowserFdc3()
+}

--- a/src/client/src/apps/SpotlightRoute/fdc3/openfinFdc3.ts
+++ b/src/client/src/apps/SpotlightRoute/fdc3/openfinFdc3.ts
@@ -1,0 +1,41 @@
+import { DetectIntentResponse } from 'dialogflow'
+import { findIntent, open } from 'openfin-fdc3'
+import { SpotlightApplication, SpotlightFdc3 } from './fdc3'
+import { TRADES_INFO_INTENT } from '../intents'
+
+const mapIntentToFdc3 = (response: DetectIntentResponse): string => {
+  if (!response) {
+    return null
+  }
+
+  switch (response.queryResult.intent.displayName) {
+    case TRADES_INFO_INTENT:
+      return `fdc3.ViewBlotter`
+    default:
+      return null
+  }
+}
+
+export class OpenfinFdc3 implements SpotlightFdc3 {
+  getMatchingApps(response: DetectIntentResponse) {
+    const fdc3Intent = mapIntentToFdc3(response)
+
+    if (!response || !fdc3Intent) {
+      return Promise.resolve([])
+    }
+
+    return findIntent(fdc3Intent).then(({ apps }) =>
+      apps.map(
+        ({ appId, title }) =>
+          ({
+            id: appId,
+            name: title,
+          } as SpotlightApplication),
+      ),
+    )
+  }
+
+  open(appId: string): Promise<void> {
+    return open(appId)
+  }
+}

--- a/src/client/src/apps/SpotlightRoute/index.tsx
+++ b/src/client/src/apps/SpotlightRoute/index.tsx
@@ -5,6 +5,8 @@ import { Spotlight } from './Spotlight'
 import { AutobahnConnectionProxy } from 'rt-system'
 import { createServiceStub } from './transport'
 import { ServiceStubProvider } from './context'
+import { getFdc3 } from './fdc3/fdc3'
+import { Fdc3Provider } from './fdc3/context'
 
 const autobahn = new AutobahnConnectionProxy(
   process.env.REACT_APP_BROKER_HOST || location.hostname,
@@ -14,26 +16,33 @@ const autobahn = new AutobahnConnectionProxy(
 
 export default function SpotlightRoute() {
   const [platform, setPlatform] = useState(null)
+  const [fdc3, setFdc3] = useState(null)
   const [serviceStub, setServiceStub] = useState(null)
 
   useEffect(() => {
     const bootstrap = async () => {
       const serviceStubResult = createServiceStub(autobahn)
       const platformResult = await getPlatformAsync()
+      const fdc3Result = await getFdc3()
       setServiceStub(serviceStubResult)
       setPlatform(platformResult)
+      setFdc3(fdc3Result)
     }
 
     bootstrap()
   }, [])
 
   return (
-    platform && serviceStub && (
+    platform &&
+    serviceStub &&
+    fdc3 && (
       <ThemeProvider>
         <ServiceStubProvider value={serviceStub}>
-          <PlatformProvider value={platform}>
-            <Spotlight/>
-          </PlatformProvider>
+          <Fdc3Provider value={fdc3}>
+            <PlatformProvider value={platform}>
+              <Spotlight />
+            </PlatformProvider>
+          </Fdc3Provider>
         </ServiceStubProvider>
       </ThemeProvider>
     )


### PR DESCRIPTION
Spotlight now shows results from the fdc3 app directory, along with existing results
(we might not want to keep that long term, but it does get us started with fdc3)

This PR lets us open the blotter using the fdc3 api.

The app directory is hosted by the launcher, using the following configuration:
```
// launcher.local.json
{
  "name": "fdc3",
  "manifestUrl": "http://localhost:3000/config/openfin/local-fdc3.json"
},
```
```
// local-fdc3.json
"serviceConfiguration": {
  "applicationDirectory": "http://localhost:3000/config/openfin/local-app-directory.json"
}

```