### PR TITLE
Bugfix/artp 808: RFQ: cancel not working on Requote

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -85,6 +85,13 @@ const TileSwitch: React.FC<Props> = ({
             RFQ
           </TileBooking>
           <TileBooking
+            show={!spotTileData.isTradeExecutionInFlight && isRfqStateExpired}
+            color="blue"
+            onBookingPillClick={() => rfq.requote({ notional, currencyPair })}
+          >
+            Requote
+          </TileBooking>
+          <TileBooking
             show={isRfqStateRequested}
             color="red"
             onBookingPillClick={() => rfq.cancel({ currencyPair })}
@@ -92,13 +99,6 @@ const TileSwitch: React.FC<Props> = ({
             Cancel
             <br />
             RFQ
-          </TileBooking>
-          <TileBooking
-            show={isRfqStateExpired}
-            color="blue"
-            onBookingPillClick={() => rfq.request({ notional, currencyPair })}
-          >
-            Requote
           </TileBooking>
           <NotificationContainer
             isPriceStale={!spotTileData.lastTradeExecutionStatus && spotTileData.price.priceStale}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux'
 import { ofType } from 'redux-observable'
-import { delay, filter, map, mergeMap, takeUntil, tap } from 'rxjs/operators'
+import { delay, filter, map, mergeMap, takeUntil } from 'rxjs/operators'
 import { ApplicationEpic } from 'StoreTypes'
 import { SpotTileActions, TILE_ACTION_TYPES } from '../actions'
 import { concat, from, Observable, of, timer } from 'rxjs'
@@ -111,7 +111,6 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
       return concat(
         timer(action.payload.timeout + 1000).pipe(map(() => rfqExpired({ currencyPair }))),
         timer(IDLE_TIME_MS).pipe(
-          tap(timer => console.log('*** timer ', timer)),
           mergeMap(() =>
             from([
               setNotional({

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux'
 import { ofType } from 'redux-observable'
-import { delay, filter, map, mergeMap, takeUntil } from 'rxjs/operators'
+import { delay, filter, map, mergeMap, takeUntil, tap } from 'rxjs/operators'
 import { ApplicationEpic } from 'StoreTypes'
 import { SpotTileActions, TILE_ACTION_TYPES } from '../actions'
 import { concat, from, Observable, of, timer } from 'rxjs'
@@ -104,7 +104,6 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
         ofType<Action, RfqReceivedTimerCancellableType>(
           TILE_ACTION_TYPES.RFQ_RESET,
           TILE_ACTION_TYPES.RFQ_CANCEL,
-          TILE_ACTION_TYPES.RFQ_REJECT,
         ),
         filter(cancelAction => cancelAction.payload.currencyPair.symbol === currencyPair.symbol),
       )
@@ -112,6 +111,7 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
       return concat(
         timer(action.payload.timeout + 1000).pipe(map(() => rfqExpired({ currencyPair }))),
         timer(IDLE_TIME_MS).pipe(
+          tap(timer => console.log('*** timer ', timer)),
           mergeMap(() =>
             from([
               setNotional({

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -16,6 +16,7 @@ const {
   rfqReject,
   rfqCancel,
   rfqReset,
+  rfqRequote,
   setNotional,
   setTradingMode,
 } = SpotTileActions
@@ -31,6 +32,7 @@ type RfqReceivedTimerCancellableType =
   | RfqExpiredActionType
   | RfqResetActionType
   | RfqCancelActionType
+type RfqRequoteActionType = ReturnType<typeof rfqRequote>
 
 const EXPIRATION_TIMEOUT_MS = 10000
 export const IDLE_TIME_MS = 60000
@@ -64,10 +66,16 @@ const rfqService = (
 
 export const rfqRequestEpic: ApplicationEpic = (action$, state$) =>
   action$.pipe(
-    ofType<Action, RfqRequestActionType>(TILE_ACTION_TYPES.RFQ_REQUEST),
+    ofType<Action, RfqRequestActionType | RfqRequoteActionType>(
+      TILE_ACTION_TYPES.RFQ_REQUEST,
+      TILE_ACTION_TYPES.RFQ_REQUOTE,
+    ),
     mergeMap(action => {
       const cancel$ = action$.pipe(
-        ofType<Action, RfqCancelActionType>(TILE_ACTION_TYPES.RFQ_CANCEL),
+        ofType<Action, RfqCancelActionType | RfqRejectActionType>(
+          TILE_ACTION_TYPES.RFQ_CANCEL,
+          TILE_ACTION_TYPES.RFQ_REJECT,
+        ),
         filter(
           cancelAction =>
             cancelAction.payload.currencyPair.symbol === action.payload.currencyPair.symbol,
@@ -96,6 +104,7 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
         ofType<Action, RfqReceivedTimerCancellableType>(
           TILE_ACTION_TYPES.RFQ_RESET,
           TILE_ACTION_TYPES.RFQ_CANCEL,
+          TILE_ACTION_TYPES.RFQ_REJECT,
         ),
         filter(cancelAction => cancelAction.payload.currencyPair.symbol === currencyPair.symbol),
       )


### PR DESCRIPTION
[Jira ticket](https://weareadaptive.atlassian.net/browse/ARTP-808)
**Changed:**
- Accounted for `rfqRequote` action in `rfqRequestEpic`
- Added `rfqReject` action in `cancel$` observable
- Swapped location of `Cancel RFQ` and `Requote` tile booking pills.

_Before Fix:_
![requote-broken](https://user-images.githubusercontent.com/38663839/67225310-0191fc80-f401-11e9-9d4f-abd23d1a991d.gif)

_After Fix:_
![requote-fixed](https://user-images.githubusercontent.com/38663839/67225331-09ea3780-f401-11e9-9c7f-477cbe6e2186.gif)
