### PR TITLE
Bugfix/artp 802: reset NZDUSD notional to 10m instead of 1m

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/TileBusinessLogic.ts
@@ -12,7 +12,6 @@ const MIN_RFQ_VALUE = 10000000
 
 // Utils
 export const getFormattedValue = (value: number | string) => numeral(value).format(NUMERAL_FORMAT)
-export const getDefaultNotionalValue = () => DEFAULT_NOTIONAL_VALUE
 export const getDefaultInitialNotionalValue = (currencyPair: CurrencyPair) =>
   // This is to simply to have one Tile showing RFQ prompt on page load
   // check JIRA ticket ARTP-532

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.test.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.test.ts
@@ -6,7 +6,7 @@ import { CurrencyPair } from 'rt-types'
 import { DeepPartial } from 'rt-util'
 import { GlobalState } from 'StoreTypes'
 import { TILE_ACTION_TYPES } from '../actions'
-import { getDefaultNotionalValue } from '../components/Tile/TileBusinessLogic'
+import { getDefaultInitialNotionalValue } from '../components/Tile/TileBusinessLogic'
 
 describe('rfqEpics', () => {
   const currencyPair: CurrencyPair = {
@@ -161,7 +161,7 @@ describe('rfqEpics', () => {
         type: TILE_ACTION_TYPES.SET_NOTIONAL,
         payload: {
           currencyPair: currencyPair.symbol,
-          notional: getDefaultNotionalValue(),
+          notional: getDefaultInitialNotionalValue(currencyPair),
         },
       },
       c: {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -7,7 +7,7 @@ import { concat, from, Observable, of, timer } from 'rxjs'
 import { RfqReceived, RfqRequest } from '../model/rfqRequest'
 import { SpotTileState } from '../spotTileReducer'
 import { CurrencyPairState } from '../../../data/referenceData'
-import { getDefaultNotionalValue } from '../components/Tile/TileBusinessLogic'
+import { getDefaultInitialNotionalValue } from '../components/Tile/TileBusinessLogic'
 
 const {
   rfqRequest,
@@ -115,7 +115,7 @@ export const rfqReceivedEpic: ApplicationEpic = action$ =>
             from([
               setNotional({
                 currencyPair: currencyPair.symbol,
-                notional: getDefaultNotionalValue(),
+                notional: getDefaultInitialNotionalValue(currencyPair),
               }),
               setTradingMode({
                 symbol: currencyPair.symbol,


### PR DESCRIPTION
[Jira ticket](https://weareadaptive.atlassian.net/browse/ARTP-802)

Two functions existed in the `TileBusinessLogic.ts` file, one `getDefaultNotionalValue` that **_did not_** account for `NZDUSD`'s initial value and another one `getDefaultInitialNotionalValue ` that did account for `NZDUSD`'s initial value (10m).

I replaced `getDefaultNotionalValue` with `getDefaultInitialNotionalValue` to the `rfqReceivedEpic` so that when timer runs out, it can `setNotional` to the correct default values - accounting for `NZDUSD` currency pair.