### PR TITLE
feat: build and deploy using semver versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,168 +1,223 @@
-version: 2
-jobs:
-  build_and_test:
-    machine:
-      enabled: true
+version: 2.1
+
+references:
+  push_images_list: &push_images_list
+    client pricehistory bot nlp servers broker eventstore nginx
+
+commands:
+  install_tools:
     steps:
-      - checkout
       - run:
-          name: 'Configure the environment'
+          name: Install tools
           command: |
-            # Inject a dummy user for builds triggered from forks, because secure variables are not available there.
-            # This allows the job to proceed with building and testing docker images.
-            if [[ -n "${CIRCLE_PR_REPONAME}" ]] ; then
-              echo 'export DOCKER_USER=adaptive' >> $BASH_ENV
-            fi
+            sudo npm i -g semver@6.3.0
       - run:
-          name: Create network
-          command: 'docker network create -d bridge circleci'
-      - run:
-          name: Build client
-          command: 'cd ./src/client  && docker build -t ${DOCKER_USER}/client:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build servers
-          command: 'cd ./src/server && docker build -t ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build nginx
-          command: 'cd ./src/services/nginx  && docker build -t ${DOCKER_USER}/nginx:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build broker
-          command: 'cd ./src/services/broker  && docker build -t ${DOCKER_USER}/broker:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build eventstore
-          command: 'cd ./src/services/eventstore  && docker build -t ${DOCKER_USER}/baseeventstore .'
-      - run:
-          name: Build pricehistory
-          command: 'cd ./src/server/Adaptive.ReactiveTrader.Server.PriceHistory/ && docker build -t ${DOCKER_USER}/pricehistory:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build bot
-          command: 'cd ./src/server/Adaptive.ReactiveTrader.Server.Bot/ && docker build -t ${DOCKER_USER}/bot:${CIRCLE_BUILD_NUM} .'
-      - run:
-          name: Build nlp
-          command: 'cd ./src/node-server/ && docker build -t ${DOCKER_USER}/nlp:${CIRCLE_BUILD_NUM} -f ./Nlp.Dockerfile .'
-      - run:
-          name: Run broker
-          command: 'docker run -d --net circleci --name broker ${DOCKER_USER}/broker:${CIRCLE_BUILD_NUM}'
-      - run:
-          name: Run eventstore
-          command: 'docker run -d --net circleci --name eventstore ${DOCKER_USER}/baseeventstore'
-      - run:
-          name: Populate eventstore
-          command: 'docker run --net circleci --name servers ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.Launcher.dll config.prod.json --populate-eventstore'
-      - run:
-          name: Save eventstore
-          command: 'docker commit eventstore ${DOCKER_USER}/eventstore:${CIRCLE_BUILD_NUM}'
-      - run:
-          name: Run analytics
-          command: 'docker run -d --net circleci --name analytics ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.Analytics.dll config.prod.json'
-      - run:
-          name: Run pricing
-          command: 'docker run -d --net circleci --name pricing ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.Pricing.dll config.prod.json'
-      - run:
-          name: Run referencedataread
-          command: 'docker run -d --net circleci --name referencedataread ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.ReferenceDataRead.dll config.prod.json'
-      - run:
-          name: Run tradeexecution
-          command: 'docker run -d --net circleci --name tradeexecution ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.TradeExecution.dll config.prod.json'
-      - run:
-          name: Run blotter
-          command: 'docker run -d --net circleci --name blotter ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet ./Adaptive.ReactiveTrader.Server.Blotter.dll config.prod.json'
-      - run:
-          name: Run nginx
-          command: 'docker run -d --net circleci -p 80:80 --name nginx ${DOCKER_USER}/nginx:${CIRCLE_BUILD_NUM}'
-      - run:
-          name: Run client
-          command: 'docker run -d --net circleci --name client ${DOCKER_USER}/client:${CIRCLE_BUILD_NUM}'
-      - run:
-          name: List containers
-          command: 'docker ps'
-      - run:
-          name: Print container logs
-          command: 'docker ps -q -a | xargs -t -L 1 docker logs'
-      - run:
-          name: Run server tests
-          command: 'docker run --net circleci --name tests ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM} dotnet vstest ./Adaptive.ReactiveTrader.Server.IntegrationTests.dll'
-      - run:
-          name: Build client tests
-          command: 'cd ./src/client && docker build -t ${DOCKER_USER}/client-test${CIRCLE_BUILD_NUM} -f ./Dockerfile.dev .'
-      - run:
-          name: Run client tests
-          command: 'docker run -e CI=true ${DOCKER_USER}/client-test${CIRCLE_BUILD_NUM} npm run test -- --coverage'
-      - run:
-          name: 'Skip the next steps for PRs'
+          name: Setup git
           command: |
-            # Check the environment and gracefully stop the job for PRs
-            if [[ "$CIRCLE_BRANCH" != "master" ]] && [[ "$CIRCLE_BRANCH" != "develop" ]] ; then
-              circleci-agent step halt
-            fi
+            # TODO: Use correct environment variables
+            git config --global user.email "$GIT_AUTHOR_NAME"
+            git config --global user.name “$EMAIL”
+
+  semver:
+    description: "Setup semver version for this release"
+    parameters:
+      bump:
+        default: "minor"
+        description: The semver bump type. Must be one of "major", "minor", "patch".
+        type: enum
+        enum: ["major", "minor", "patch", "prerelease"]
+    steps:
       - run:
-          name: Push images to dockerhub
+          name: Semver Versioning "<< parameters.bump >>"
+          command: |
+            PREVIOUS_TAG="$(semver valid $(git describe --tags) || echo 1.0.0)"
+            NEW_TAG="$(semver -i << parameters.bump >> ${PREVIOUS_TAG})"
+            echo "export BUILD_VERSION=$NEW_TAG" >> $BASH_ENV
+            echo "export DOCKER_USER=$DOCKER_USER" >> $BASH_ENV
+            git tag $NEW_TAG -a -m "v$NEW_TAG"
+            echo "Created new tag: $(git describe --abbr=0)"
+
+  build_images:
+    description: "Build the deployable container images"
+    steps:
+      - run:
+          name: Build Images
+          command: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.deploy.yml build
+
+  run_tests:
+    description: "Runs the integration tests"
+    steps:
+      - run:
+          name: Integration Tests
+          command: docker-compose -f ./src/docker-compose.e2e.yml -f ./src/docker-compose.yml run integration
+
+  list_images:
+    steps:
+      - run:
+          name: List images
+          command: docker images -a
+
+  push_images:
+    parameters:
+      images:
+        type: string
+    steps:
+      - run:
+          name: Push Images
           command: |
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
-            docker push ${DOCKER_USER}/client:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/pricehistory:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/bot:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/nlp:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/servers:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/broker:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/eventstore:${CIRCLE_BUILD_NUM}
-            docker push ${DOCKER_USER}/nginx:${CIRCLE_BUILD_NUM}
-      - run:
-          name: Store build number
-          command: |
-            mkdir -p envs
-            echo "export BUILD_NUM=${CIRCLE_BUILD_NUM}" >> envs/env_build_num
-      - persist_to_workspace:
-          root: envs
-          paths:
-            - env_build_num
+            docker-compose \
+              -f src/docker-compose.deploy.yml -f src/docker-compose.yml \
+              push << parameters.images >>
+            echo "Pushing new tag to remote"
+            git push origin $BUILD_VERSION
 
-  deploy:
-    docker:
-      - image: google/cloud-sdk
+  deploy_to_environment:
+    description: "Deploy the specific version to gcloud"
+    parameters:
+      version:
+        description: The environment variable specifiying the version to deploy. Must already be hosted on dockerhub
+        type: env_var_name
+      environment:
+        description: The environment variable containing the environment to deploy to. One of "dev", "demo"
+        type: env_var_name
     steps:
-      - checkout
-      - attach_workspace:
-          at: /envs
-      - run:
-          name: Restore build number
-          command: cat /envs/env_build_num >> $BASH_ENV;
       - run:
           name: Authenticate with gcloud
           command: |
+            echo $BASH_ENV
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
             gcloud config set project ${GOOGLE_PROJECT_ID}
             gcloud config set compute/zone ${GOOGLE_COMPUTE_ZONE}
             gcloud container clusters get-credentials cluster
       - run:
-          name: Set namespace
-          command: declare -A envs=( ["develop"]="dev" ["master"]="demo"); echo "export NAMESPACE='${envs[$CIRCLE_BRANCH]}'" >> $BASH_ENV;
-      - run:
-          name: Update images
+          name: Updating deployment definition to new images
           command: |
-            kubectl --namespace=${NAMESPACE} set image deployments/broker-deployment broker=${DOCKER_USER}/broker:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/eventstore-deployment eventstore=${DOCKER_USER}/eventstore:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/web-deployment web=${DOCKER_USER}/nginx:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/client-deployment client=${DOCKER_USER}/client:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/referencedataread-deployment referencedataread=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/pricing-deployment pricing=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/tradeexecution-deployment tradeexecution=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/analytics-deployment analytics=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/blotter-deployment blotter=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/tradeexecution-deployment tradeexecution=${DOCKER_USER}/servers:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/pricehistory-deployment pricehistory=${DOCKER_USER}/pricehistory:${BUILD_NUM}
-            kubectl --namespace=${NAMESPACE} set image deployments/bot-deployment bot=${DOCKER_USER}/bot:${BUILD_NUM}
+            # TODO: look for new deployment config from git history
+            # TODO: create new environment automatically
+            # TODO: validate package exists
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/broker-deployment broker=${DOCKER_USER}/broker:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/eventstore-deployment eventstore=${DOCKER_USER}/eventstore:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/web-deployment web=${DOCKER_USER}/nginx:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/client-deployment client=${DOCKER_USER}/client:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/referencedataread-deployment referencedataread=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/pricing-deployment pricing=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/tradeexecution-deployment tradeexecution=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/analytics-deployment analytics=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/blotter-deployment blotter=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/tradeexecution-deployment tradeexecution=${DOCKER_USER}/servers:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/pricehistory-deployment pricehistory=${DOCKER_USER}/pricehistory:${ << parameters.version >> }
+            kubectl --namespace=${ << parameters.environment >> } set image deployments/bot-deployment bot=${DOCKER_USER}/bot:${ << parameters.version >> }
+
+
+  main_pipeline:
+    description: "Main pipeline"
+    parameters:
+      bump:
+        description: The semver bump type. Must be one of "major", "minor", "patch".
+        type: enum
+        enum: ["major", "minor", "patch", "prerelease"]
+      environment:
+        type: string
+    steps:
+      - setup_remote_docker
+      - install_tools
+      - checkout
+      - semver:
+          bump: << parameters.bump >>
+      - run:
+          name: Set up persisted variables
+          command: |
+            mkdir -p ~/vars
+            echo "export DEPLOY_TARGET=<< parameters.environment >>" >> ~/vars/env
+            echo "export BUILD_VERSION=$BUILD_VERSION" >> ~/vars/env
+      - persist_to_workspace:
+          root: ~/
+          paths: vars/env
+      - build_images
+      - list_images
+      - run_tests
+
+
+jobs:
+  release_build:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - main_pipeline:
+          bump: minor
+          environment: dev
+      - push_images:
+          images: *push_images_list
+
+  patch_build:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - main_pipeline:
+          bump: patch
+          environment: none
+      - push_images:
+          images: *push_images_list
+
+  feature_build:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - main_pipeline:
+          bump: prerelease
+          environment: none
+
+  deployment:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Retrieve deployment parameters"
+          command: |
+            # Check we have the correct variables present
+            # These can come from the persisted workspace or from parameters
+            # passed via the circleci api (https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-the-api)
+            source ~/vars/env || true
+            echo "Deploying version $BUILD_VERSION to environment $DEPLOY_TARGET"
+            if [[ "$DEPLOY_TARGET" = "" ]] ; then
+              echo "Missing parameter DEPLOY_TARGET"
+              circleci-agent step halt
+            fi
+            if [[ "$BUILD_VERSION" = "" ]] ; then
+              echo "Missing parameter BUILD_VERSION"
+              circleci-agent step halt
+            fi
+      - deploy_to_environment:
+          version: BUILD_VERSION
+          environment: DEPLOY_TARGET
+
 
 workflows:
-  version: 2
+  version: 2.1
   main:
     jobs:
-      - build_and_test
-      - deploy:
-          requires:
-            - build_and_test
+      - patch_build:
           filters:
             branches:
-              only:
+              only: /^release\/.*/
+      - release_build:
+          filters:
+            branches:
+              only: master
+      - deployment:
+          requires:
+            - release_build
+          filters:
+            branches:
+              only: master
+      - feature_build:
+          filters:
+            branches:
+              ignore:
                 - master
-                - develop
+                - /^release\/.*/
+
+

--- a/src/.env
+++ b/src/.env
@@ -1,0 +1,3 @@
+# Default environmnet variables for docker-compose
+BUILD_VERSION=0.0.0
+DOCKER_USER=localuser

--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -1,8 +1,17 @@
 FROM node:11.10-alpine as builder
 WORKDIR '/app'
+
+ARG CI
+ARG REACT_APP_BUILD_VERSION
+
 COPY ./package*.json ./
 RUN npm install
 COPY . .
+
+ENV CI=$CI
+ENV REACT_APP_BUILD_VERSION=$REACT_APP_BUILD_VERSION
+
+RUN npm run test -- --coverage
 RUN npm run build
 RUN npm run storybook:build
 

--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react'
+import { styled } from 'rt-theme'
+
+export const Wrapper = styled.div`
+  color: ${props => props.theme.textColor};
+  opacity: 0.59;
+  font-size: 0.75rem;
+`
+
+const FooterVersion: FC = () => <Wrapper>v{process.env.REACT_APP_BUILD_VERSION}</Wrapper>
+
+export default FooterVersion

--- a/src/client/src/apps/MainRoute/widgets/footer-version/index.ts
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FooterVersion'

--- a/src/client/src/apps/MainRoute/widgets/status-connection/StatusButton.tsx
+++ b/src/client/src/apps/MainRoute/widgets/status-connection/StatusButton.tsx
@@ -12,6 +12,7 @@ import {
   ServiceList,
 } from './styled'
 import Service from './Service'
+import FooterVersion from '../footer-version'
 
 interface Props {
   connectionStatus: ConnectionState
@@ -72,6 +73,8 @@ export const StatusButton: React.FC<Props> = ({
           {services.map(service => (
             <Service key={service.serviceType} service={service} />
           ))}
+
+          <FooterVersion />
         </ServiceList>
       </ServiceListPopup>
     </Root>

--- a/src/client/src/index.tsx
+++ b/src/client/src/index.tsx
@@ -14,6 +14,8 @@ const SpotlightRoute = lazy(() => import('./apps/SpotlightRoute'))
 const urlParams = new URLSearchParams(window.location.search)
 
 async function init() {
+  console.info('BUILD_VERSION: ', process.env.REACT_APP_BUILD_VERSION)
+
   if (urlParams.has('startAsSymphonyController')) {
     const { initiateSymphony } = await getSymphonyPlatform()
     await initiateSymphony(urlParams.get('env'))

--- a/src/docker-compose.deploy.yml
+++ b/src/docker-compose.deploy.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  servers:
+    image: ${DOCKER_USER}/servers:${BUILD_VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: ./server
+    depends_on:
+      - eventstore
+    command: 'echo "Override base docker-compose to not populate event store"'

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  integration:
+    image: ${DOCKER_USER}/servers:${BUILD_VERSION}
+    hostname: integration
+    container_name: integration
+    depends_on:
+      - servers
+    command: dotnet vstest ./Adaptive.ReactiveTrader.Server.IntegrationTests.dll

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,21 +1,32 @@
 version: '3'
 services:
   eventstore:
+    image: ${DOCKER_USER}/eventstore:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./services/eventstore
   broker:
+    image: ${DOCKER_USER}/broker:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./services/broker
+    ports:
+      - '8000:8000'
   servers:
+    image: ${DOCKER_USER}/servers:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
     depends_on:
+      - broker
       - eventstore
-    command: 'dotnet ./Adaptive.ReactiveTrader.Server.Launcher.dll config.prod.json --populate-eventstore'
+      - referencedataread
+      - pricing
+      - blotter
+      - tradeexecution
+    command: dotnet ./Adaptive.ReactiveTrader.Server.Launcher.dll config.prod.json --populate-eventstore
   nginx:
+    image: ${DOCKER_USER}/nginx:${BUILD_VERSION}
     restart: always
     build:
       dockerfile: Dockerfile
@@ -23,10 +34,15 @@ services:
     ports:
       - '80:80'
   client:
+    image: ${DOCKER_USER}/client:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./client
+      args:
+        - CI=true
+        - REACT_APP_BUILD_VERSION=${BUILD_VERSION}
   analytics:
+    image: ${DOCKER_USER}/analytics:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
@@ -35,6 +51,7 @@ services:
       - broker
       - eventstore
   pricing:
+    image: ${DOCKER_USER}/pricing:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
@@ -44,6 +61,7 @@ services:
       - eventstore
       - analytics
   referencedataread:
+    image: ${DOCKER_USER}/referencedataread:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
@@ -53,6 +71,7 @@ services:
       - eventstore
       - pricing
   tradeexecution:
+    image: ${DOCKER_USER}/tradeexecution:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
@@ -62,6 +81,7 @@ services:
       - eventstore
       - referencedataread
   blotter:
+    image: ${DOCKER_USER}/blotter:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile
       context: ./server
@@ -71,6 +91,7 @@ services:
       - eventstore
       - tradeexecution
   pricehistory:
+    image: ${DOCKER_USER}/pricehistory:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile.dev
       context: ./server/Adaptive.ReactiveTrader.Server.PriceHistory
@@ -81,6 +102,8 @@ services:
      - BROKER_HOST=broker
      - BROKER_PORT=8000
   nlp:
+    image: ${DOCKER_USER}/nlp:${BUILD_VERSION}
+    hostname: nlp
     build:
       dockerfile: Nlp.Dockerfile
       context: ./node-server
@@ -89,3 +112,8 @@ services:
     environment:
       - BROKER_HOST=broker
       - BROKER_PORT=8000
+  bot:
+    hostname: bot
+    image: ${DOCKER_USER}/bot:${BUILD_VERSION}
+    build:
+      context: ./server/Adaptive.ReactiveTrader.Server.Bot


### PR DESCRIPTION
Reworking of the build process to move towards _continous delivery_.

- All merges to master will create a new _semver_ minor  version (1.1.0, 1.2.0, 1.3.0...). 
- Master will be deployed to `dev` environment
- We will use the [circleapi](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-the-api) (at this initial stage) to run the deployment job passing the environment variables `BUILD_TARGET=demo` `BUILD_VERSION=1.23.0`. 

There is a  significant reworking of how we were doing the build/run/test stages within ciricleci. This moves all the setup config to be done purely via docker-compose. Now, to run the server integration tests:
```
docker-compose -f docker-compose.e2e.yml run integration
```
This simplifies differences between local reproduction and from within CI. 
I've added the semver build version to the console log and to within the Connection Status footer (will check with UX).

Overall this will be a significant change in the release / patching process. This diagram will explain a little more the process. 

![Group 1](https://user-images.githubusercontent.com/3878103/68293479-f20fe600-0085-11ea-9f75-417499fa592c.png)

![Screenshot 2019-11-06 at 12 18 37](https://user-images.githubusercontent.com/3878103/68297752-9cd8d200-008f-11ea-9caf-43bbd610ab0c.png)

