### PR TITLE
fix(ci): semver fails when tag is a release tag due to hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
       - run:
           name: Semver Versioning "<< parameters.bump >>"
           command: |
-            PREVIOUS_TAG="$(semver valid $(git describe --tags) || echo 1.0.0)"
+            PREVIOUS_TAG="$(semver valid $(git describe --tags --abbrev=0) || echo 1.0.0)"
             NEW_TAG="$(semver -i << parameters.bump >> ${PREVIOUS_TAG})"
             echo "export BUILD_VERSION=$NEW_TAG" >> $BASH_ENV
             echo "export DOCKER_USER=$DOCKER_USER" >> $BASH_ENV


### PR DESCRIPTION
Silly mistake.
When the tag is a github release tag it is in the format of `1.1.0-9-g7112def2`.
This is a prerelease in semver therefore `semver minor 1.1.0-9-g7112def2` -> `1.1.0`.
