### PR TITLE
fix(ci): get highest semver version from current head

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - run:
           name: Semver Versioning "<< parameters.bump >>"
           command: |
-            PREVIOUS_TAG="$(semver valid $(git describe --tags --abbrev=0) || echo 1.0.0)"
+            PREVIOUS_TAG="$(semver $(git tag --merged) 1.0.0 | tail -n -1)"
             NEW_TAG="$(semver -i << parameters.bump >> ${PREVIOUS_TAG})"
             echo "export BUILD_VERSION=$NEW_TAG" >> $BASH_ENV
             echo "export DOCKER_USER=$DOCKER_USER" >> $BASH_ENV


### PR DESCRIPTION
Before there was an issue where if a commit had two tags it would get only the last tag not necessarily the highest. 
This is also a fix for when a `release/` branch is merged into master, as semver will give the highest valid tag version. 

