### PR TITLE
Fixed for notional display

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/SpotTileContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/SpotTileContainer.tsx
@@ -50,8 +50,10 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: SpotTileContainerOwnPr
 const makeMapStateToProps = () => (state: GlobalState, ownProps: SpotTileContainerOwnProps) => ({
   pricingStatus: selectPricingStatus(state),
   executionStatus: selectExecutionStatus(state),
-  currencyPair: selectCurrencyPair(state, ownProps),
-  spotTileData: selectSpotTileData(state, ownProps),
+
+  // here 'ownProps.id' is an ID of the tile, but it's ID of the currency pair too (same thing for now)
+  currencyPair: selectCurrencyPair(state, ownProps.id),
+  spotTileData: selectSpotTileData(state, ownProps.id),
 })
 
 type SpotTileContainerDispatchProps = ReturnType<typeof mapDispatchToProps>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
@@ -3,7 +3,7 @@ import { spotDateFormatter } from '../model/dateUtils'
 import NotionalInput from './notional'
 import PriceControls from './PriceControls'
 import TileHeader from './TileHeader'
-import { getDefaultInitialNotionalValue } from './Tile/TileBusinessLogic'
+import { getDefaultNotionalValue } from './Tile/TileBusinessLogic'
 import {
   NotionalInputWrapper,
   SpotTileWrapper,
@@ -49,7 +49,7 @@ export default class SpotTile extends PureComponent<SpotTileProps> {
     } = getConstsFromRfqState(rfqState)
     const showResetButton =
       !isTradeExecutionInFlight &&
-      getDefaultInitialNotionalValue(currencyPair) !== notional &&
+      getDefaultNotionalValue(currencyPair) !== notional &&
       (isRfqStateNone || isRfqStateCanRequest || isRfqStateExpired)
     const showTimer = isRfqStateReceived && rfqTimeout
     const priceData = (isRfqStateReceived || isRfqStateExpired) && rfqPrice ? rfqPrice : price

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { CurrencyPair, Direction, ServiceConnectionStatus } from 'rt-types'
-import { createTradeRequest, ExecuteTradeRequest, SpotTileData, TradeRequest } from '../../model'
+import { createTradeRequest, ExecuteTradeRequest, SpotTileDataWithNotional, TradeRequest } from '../../model'
 import SpotTile from '../SpotTile'
 import { AnalyticsTile } from '../analyticsTile/index'
 import { TileViews } from '../../../workspace/workspaceHeader'
 import { RfqActions, TileSwitchChildrenProps, TradingMode } from '../types'
 import { ValidationMessage } from '../notional'
 import {
-  getDefaultInitialNotionalValue,
+  getDefaultNotionalValue,
   getDerivedStateFromProps,
   getDerivedStateFromUserInput,
   isValueInRfqRange,
@@ -17,7 +17,7 @@ import { CurrencyPairNotional } from '../../model/spotTileData'
 
 export interface TileProps {
   currencyPair: CurrencyPair
-  spotTileData: SpotTileData
+  spotTileData: SpotTileDataWithNotional
   executionStatus: ServiceConnectionStatus
   executeTrade: (tradeRequestObj: ExecuteTradeRequest) => void
   setTradingMode: (tradingMode: TradingMode) => void
@@ -110,9 +110,11 @@ class Tile extends React.PureComponent<TileProps, TileState> {
     })
   }
 
+  // TODO: it looks like this should be moved to a reducer or epic. There should be an
+  // action called ResetNotional and all logic below should be there
   resetNotional = () => {
     const { setTradingMode, currencyPair, updateNotional } = this.props
-    const defaultNotional = getDefaultInitialNotionalValue(currencyPair)
+    const defaultNotional = getDefaultNotionalValue(currencyPair)
     const isInRfqRange = isValueInRfqRange(defaultNotional)
     setTradingMode({ symbol: currencyPair.symbol, mode: isInRfqRange ? 'rfq' : 'esp' })
     updateNotional({

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/TileBusinessLogic.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/TileBusinessLogic.ts
@@ -1,8 +1,8 @@
 import numeral from 'numeral'
 import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
 import { TileProps, TileState } from './Tile'
-import { SpotTileData } from '../../model/spotTileData'
 import { getConstsFromRfqState } from '../../model/spotTileUtils'
+import { SpotTileDataWithNotional } from '../../model';
 
 // Constants
 export const NUMERAL_FORMAT = '0,000,000[.]00'
@@ -12,7 +12,7 @@ const MIN_RFQ_VALUE = 10000000
 
 // Utils
 export const getFormattedValue = (value: number | string) => numeral(value).format(NUMERAL_FORMAT)
-export const getDefaultInitialNotionalValue = (currencyPair: CurrencyPair) =>
+export const getDefaultNotionalValue = (currencyPair: CurrencyPair) =>
   // This is to simply to have one Tile showing RFQ prompt on page load
   // check JIRA ticket ARTP-532
   currencyPair.symbol === 'NZDUSD' ? MIN_RFQ_VALUE : DEFAULT_NOTIONAL_VALUE
@@ -66,7 +66,7 @@ export const getDerivedStateFromUserInput = ({
   currencyPair,
 }: {
   prevState: TileState
-  spotTileData: SpotTileData
+  spotTileData: SpotTileDataWithNotional
   actions: {
     setTradingMode: TileProps['setTradingMode']
   }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
 import { ExecuteTradeRequest, SpotTileDataWithNotional } from '../model'
-import { PriceMovementTypes } from '../model/priceMovementTypes'
+// import { PriceMovementTypes } from '../model/priceMovementTypes'
 import NotificationContainer, { TileBooking } from './notifications'
 import Tile from './Tile'
 import TileControls from './TileControls'
@@ -102,35 +102,35 @@ const TileSwitch: React.FC<Props> = ({
   )
 }
 
-TileSwitch.defaultProps = {
-  spotTileData: {
-    notional: 0,
-    isTradeExecutionInFlight: false,
-    historicPrices: [],
-    price: {
-      ask: 0,
-      bid: 0,
-      mid: 0,
-      creationTimestamp: 0,
-      symbol: '',
-      valueDate: '',
-      priceMovementType: PriceMovementTypes.None,
-      priceStale: false,
-    },
-    currencyChartIsOpening: false,
-    lastTradeExecutionStatus: null,
-    rfqState: 'none',
-    rfqPrice: null,
-    rfqReceivedTime: null,
-    rfqTimeout: null,
-  },
-  currencyPair: {
-    symbol: '',
-    ratePrecision: 0,
-    pipsPosition: 0,
-    base: '',
-    terms: '',
-  },
-}
+// TileSwitch.defaultProps = {
+//   spotTileData: {
+//     notional: 0,
+//     isTradeExecutionInFlight: false,
+//     historicPrices: [],
+//     price: {
+//       ask: 0,
+//       bid: 0,
+//       mid: 0,
+//       creationTimestamp: 0,
+//       symbol: '',
+//       valueDate: '',
+//       priceMovementType: PriceMovementTypes.None,
+//       priceStale: false,
+//     },
+//     currencyChartIsOpening: false,
+//     lastTradeExecutionStatus: null,
+//     rfqState: 'none',
+//     rfqPrice: null,
+//     rfqReceivedTime: null,
+//     rfqTimeout: null,
+//   },
+//   currencyPair: {
+//     symbol: '',
+//     ratePrecision: 0,
+//     pipsPosition: 0,
+//     base: '',
+//     terms: '',
+//   },
+// }
 
 export default TileSwitch

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
-import { ExecuteTradeRequest, SpotTileData } from '../model'
+import { ExecuteTradeRequest, SpotTileDataWithNotional } from '../model'
 import { PriceMovementTypes } from '../model/priceMovementTypes'
 import NotificationContainer, { TileBooking } from './notifications'
 import Tile from './Tile'
@@ -9,11 +9,10 @@ import { TileViews } from '../../workspace/workspaceHeader'
 import { RfqActions, TileSwitchChildrenProps, TradingMode } from './types'
 import { getConstsFromRfqState } from '../model/spotTileUtils'
 import { CurrencyPairNotional } from '../model/spotTileData'
-import { getDefaultInitialNotionalValue } from './Tile/TileBusinessLogic'
 
 interface Props {
   currencyPair: CurrencyPair
-  spotTileData: SpotTileData
+  spotTileData: SpotTileDataWithNotional
   canPopout: boolean
   executionStatus: ServiceConnectionStatus
   executeTrade: (tradeRequestObj: ExecuteTradeRequest) => void
@@ -47,18 +46,10 @@ const TileSwitch: React.FC<Props> = ({
     isRfqStateNone,
   } = getConstsFromRfqState(spotTileData.rfqState)
 
-  const spotTileDataWithNotional =
-    spotTileData.notional === null
-      ? {
-          ...spotTileData,
-          notional: getDefaultInitialNotionalValue(currencyPair),
-        }
-      : spotTileData
-
   return (
     <Tile
       currencyPair={currencyPair}
-      spotTileData={spotTileDataWithNotional}
+      spotTileData={spotTileData}
       executeTrade={executeTrade}
       executionStatus={executionStatus}
       tileView={tileView}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { CurrencyPair, ServiceConnectionStatus } from 'rt-types'
 import { ExecuteTradeRequest, SpotTileDataWithNotional } from '../model'
-// import { PriceMovementTypes } from '../model/priceMovementTypes'
 import NotificationContainer, { TileBooking } from './notifications'
 import Tile from './Tile'
 import TileControls from './TileControls'
@@ -101,36 +100,5 @@ const TileSwitch: React.FC<Props> = ({
     </Tile>
   )
 }
-
-// TileSwitch.defaultProps = {
-//   spotTileData: {
-//     notional: 0,
-//     isTradeExecutionInFlight: false,
-//     historicPrices: [],
-//     price: {
-//       ask: 0,
-//       bid: 0,
-//       mid: 0,
-//       creationTimestamp: 0,
-//       symbol: '',
-//       valueDate: '',
-//       priceMovementType: PriceMovementTypes.None,
-//       priceStale: false,
-//     },
-//     currencyChartIsOpening: false,
-//     lastTradeExecutionStatus: null,
-//     rfqState: 'none',
-//     rfqPrice: null,
-//     rfqReceivedTime: null,
-//     rfqTimeout: null,
-//   },
-//   currencyPair: {
-//     symbol: '',
-//     ratePrecision: 0,
-//     pipsPosition: 0,
-//     base: '',
-//     terms: '',
-//   },
-// }
 
 export default TileSwitch

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -4,7 +4,7 @@ import PriceControls from '../PriceControls'
 import NotionalInput from '../notional'
 import AnalyticsTileChart from './AnalyticsTileChart'
 import { usePlatform } from 'rt-platforms'
-import { getDefaultInitialNotionalValue } from '../Tile/TileBusinessLogic'
+import { getDefaultNotionalValue } from '../Tile/TileBusinessLogic'
 
 import {
   AnalyticsTileStyle,
@@ -42,7 +42,7 @@ class AnalyticsTile extends React.PureComponent<SpotTileProps> {
     )
     const showResetButton =
       !isTradeExecutionInFlight &&
-      getDefaultInitialNotionalValue(currencyPair) !== notional &&
+      getDefaultNotionalValue(currencyPair) !== notional &&
       (isRfqStateNone || isRfqStateCanRequest || isRfqStateExpired)
 
     return (

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/test-resources/spotTileProps.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/test-resources/spotTileProps.ts
@@ -1,5 +1,5 @@
 import { Direction } from 'rt-types'
-import { SpotPriceTick, SpotTileData } from '../../model'
+import { SpotPriceTick, SpotTileDataWithNotional } from '../../model'
 import { PriceMovementTypes } from '../../model/priceMovementTypes'
 
 const currencyPair = {
@@ -29,7 +29,7 @@ const generateHistoricPrices: (totalPricePrick: number) => SpotPriceTick[] = tot
   return historicPrices
 }
 
-const spotTileData: SpotTileData = {
+const spotTileData: SpotTileDataWithNotional = {
   notional: 1000000,
   currencyChartIsOpening: false,
   isTradeExecutionInFlight: false,

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/types.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/types.ts
@@ -1,14 +1,7 @@
 import { CurrencyPair, Direction, ServiceConnectionStatus } from 'rt-types'
-import { SpotTileData } from '../model'
+import { SpotTileDataWithNotional } from '../model'
 import { ValidationMessage } from './notional'
-import {
-  RfqRequest,
-  RfqCancel,
-  RfqRequote,
-  RfqExpired,
-  RfqReject,
-  RfqReset,
-} from '../model/rfqRequest'
+import { RfqCancel, RfqExpired, RfqReject, RfqRequest, RfqRequote, RfqReset, } from '../model/rfqRequest'
 
 export interface TradingMode {
   symbol: CurrencyPair['symbol']
@@ -33,7 +26,7 @@ export interface TileSwitchChildrenProps {
 
 export interface SpotTileProps {
   currencyPair: CurrencyPair
-  spotTileData: SpotTileData
+  spotTileData: SpotTileDataWithNotional
   executionStatus: ServiceConnectionStatus
   executeTrade: (direction: Direction, rawSpotRate: number) => void
   updateNotional: (notional: number) => void

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.test.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.test.ts
@@ -6,7 +6,7 @@ import { CurrencyPair } from 'rt-types'
 import { DeepPartial } from 'rt-util'
 import { GlobalState } from 'StoreTypes'
 import { TILE_ACTION_TYPES } from '../actions'
-import { getDefaultInitialNotionalValue } from '../components/Tile/TileBusinessLogic'
+import { getDefaultNotionalValue } from '../components/Tile/TileBusinessLogic'
 
 describe('rfqEpics', () => {
   const currencyPair: CurrencyPair = {
@@ -161,7 +161,7 @@ describe('rfqEpics', () => {
         type: TILE_ACTION_TYPES.SET_NOTIONAL,
         payload: {
           currencyPair: currencyPair.symbol,
-          notional: getDefaultInitialNotionalValue(currencyPair),
+          notional: getDefaultNotionalValue(currencyPair),
         },
       },
       c: {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/rfqEpics.ts
@@ -5,9 +5,9 @@ import { ApplicationEpic } from 'StoreTypes'
 import { SpotTileActions, TILE_ACTION_TYPES } from '../actions'
 import { concat, from, Observable, of, timer } from 'rxjs'
 import { RfqReceived, RfqRequest } from '../model/rfqRequest'
-import { SpotTileState } from '../spotTileReducer'
+import { SpotTileState } from '../spotTileDataReducer'
 import { CurrencyPairState } from '../../../data/referenceData'
-import { getDefaultInitialNotionalValue } from '../components/Tile/TileBusinessLogic'
+import { getDefaultNotionalValue } from '../components/Tile/TileBusinessLogic'
 
 const {
   rfqRequest,
@@ -115,7 +115,7 @@ export const rfqReceivedEpic: ApplicationEpic<{}> = action$ =>
             from([
               setNotional({
                 currencyPair: currencyPair.symbol,
-                notional: getDefaultInitialNotionalValue(currencyPair),
+                notional: getDefaultNotionalValue(currencyPair),
               }),
               setTradingMode({
                 symbol: currencyPair.symbol,

--- a/src/client/src/apps/MainRoute/widgets/spotTile/index.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/index.ts
@@ -1,3 +1,3 @@
-export { spotTileDataReducer } from './spotTileReducer'
+export { spotTileDataReducer } from './spotTileDataReducer'
 export { default as createSpotTileEpic } from './epics'
 export { default as SpotTileContainer } from './SpotTileContainer'

--- a/src/client/src/apps/MainRoute/widgets/spotTile/model/index.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/model/index.ts
@@ -1,8 +1,9 @@
-import { SpotTileData } from './spotTileData'
+import { SpotTileData, SpotTileDataWithNotional } from './spotTileData'
 import { ExecuteTradeRequest } from './executeTradeRequest'
 import { createTradeRequest, DEFAULT_NOTIONAL, TradeRequest } from './spotTileUtils'
 import { SpotPriceTick } from './spotPriceTick'
 export type SpotTileData = SpotTileData
+export type SpotTileDataWithNotional = SpotTileDataWithNotional
 export type ExecuteTradeRequest = ExecuteTradeRequest
 export { createTradeRequest, DEFAULT_NOTIONAL }
 export type TradeRequest = TradeRequest

--- a/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
@@ -20,8 +20,11 @@ export interface SpotTileData {
   rfqReceivedTime: number | null
   rfqTimeout: number | null
   rfqPrice: SpotPriceTick | null
-  notional: number
+  notional?: number
 }
+
+type SpotTileDataNotional = Pick<SpotTileData, 'notional'>
+export type SpotTileDataWithNotional = SpotTileData & Required<SpotTileDataNotional>
 
 export interface CurrencyPairNotional {
   currencyPair: string

--- a/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/model/spotTileData.ts
@@ -24,6 +24,17 @@ export interface SpotTileData {
 }
 
 type SpotTileDataNotional = Pick<SpotTileData, 'notional'>
+
+/**
+ `SpotTileData` has optional `notional` field, but notice that `SpotTileDataWithNotional` has required notional field.
+ This has been done because we don't know notional when we create `SpotTileData`, default `notional`
+ will change from currency to currency.
+ We are adding a default `notional` in the spotData selector based on currency (see `spotTile/selectors.ts`).
+ I can't say that I like this approach - I would prefer to control this data dependency
+ in a high-level reducer. But it would have been much bigger change - resetting reference
+ data would need to create new tiles in reducer, then new tiles will need to reset all records in
+ `tileData` slice. I'd like to address that some other time and left some TODOs
+ */
 export type SpotTileDataWithNotional = SpotTileData & Required<SpotTileDataNotional>
 
 export interface CurrencyPairNotional {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/selectors.test.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/selectors.test.ts
@@ -1,0 +1,19 @@
+import { publishPositionToExcelEpic } from './analyticsServiceEpic'
+import { ActionsObservable, StateObservable } from 'redux-observable'
+import { Action } from 'redux'
+import { PositionUpdates } from '../model'
+import { AnalyticsActions } from '../actions'
+import { MockScheduler } from 'rt-testing'
+import { CurrencyPairPosition, CurrencyPairPositionWithPrice } from 'rt-types'
+import { GlobalState } from 'StoreTypes'
+import { ExcelApp } from 'rt-platforms'
+import { selectSpotTileData } from './selectors';
+
+
+describe('selectSpotTileData', () => {
+  it('should set default notional to 0', () => {
+
+    selectSpotTileData()
+
+  })
+})

--- a/src/client/src/apps/MainRoute/widgets/spotTile/selectors.test.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/selectors.test.ts
@@ -1,19 +1,107 @@
-import { publishPositionToExcelEpic } from './analyticsServiceEpic'
-import { ActionsObservable, StateObservable } from 'redux-observable'
-import { Action } from 'redux'
-import { PositionUpdates } from '../model'
-import { AnalyticsActions } from '../actions'
-import { MockScheduler } from 'rt-testing'
-import { CurrencyPairPosition, CurrencyPairPositionWithPrice } from 'rt-types'
 import { GlobalState } from 'StoreTypes'
-import { ExcelApp } from 'rt-platforms'
 import { selectSpotTileData } from './selectors';
+import { SpotTileData, SpotTileDataWithNotional } from './model';
+import { ConnectionStatus } from 'rt-system';
+import { PriceMovementTypes } from './model/priceMovementTypes';
 
+const getDefaultGlobalState = (): GlobalState => ({
+  analyticsService: {
+    history: [],
+    currentPositions: []
+  },
+  blotterService: {
+    trades: []
+  },
+  compositeStatusService: {},
+  connectionStatus: {
+    status: ConnectionStatus.connected,
+    transportType: 'unknown',
+    url: ''
+  },
+  currencyPairs: {},
+  layoutService: {
+    analytics: {
+      visible: true,
+      x: 0,
+      y: 0
+    },
+    blotter: {
+      visible: true,
+      x: 0,
+      y: 0
+    },
+    spotTiles: {}
+  },
+  spotTilesData: {}
+})
+
+const getDefaultSpotTileData = (): SpotTileData => ({
+  isTradeExecutionInFlight: false,
+  historicPrices: [],
+  price: {
+    ask: 0,
+    bid: 0,
+    mid: 0,
+    creationTimestamp: 0,
+    symbol: '',
+    valueDate: '',
+    priceMovementType: PriceMovementTypes.None,
+    priceStale: false,
+  },
+  currencyChartIsOpening: false,
+  lastTradeExecutionStatus: null,
+  rfqState: 'none',
+  rfqPrice: null,
+  rfqReceivedTime: null,
+  rfqTimeout: null
+})
 
 describe('selectSpotTileData', () => {
-  it('should set default notional to 0', () => {
 
-    selectSpotTileData()
+  it('should set default notional to 1000000 for GBPUSD', () => {
+    const globalState: GlobalState = {
+      ...getDefaultGlobalState(),
+      currencyPairs: {
+        'GBPUSD': {
+          symbol: 'GBPUSD',
+          ratePrecision: 2,
+          pipsPosition: 2,
+          base: '',
+          terms: ''
+        }
+      }
+    }
 
+    const spotTileData = selectSpotTileData(globalState, 'GBPUSD');
+    const expectedTileDataForGBPUSD: SpotTileDataWithNotional = {
+      ...getDefaultSpotTileData(),
+      notional: 1000000
+    }
+
+    expect(spotTileData).toEqual(expectedTileDataForGBPUSD);
+  })
+
+  it('should set default notional to 10000000 for NZDUSD', () => {
+
+    const globalState: GlobalState = {
+      ...getDefaultGlobalState(),
+      currencyPairs: {
+        'NZDUSD': {
+          symbol: 'NZDUSD',
+          ratePrecision: 2,
+          pipsPosition: 2,
+          base: '',
+          terms: ''
+        }
+      }
+    }
+
+    const spotTileData = selectSpotTileData(globalState, 'NZDUSD');
+    const expectedTileDataForGBPUSD: SpotTileDataWithNotional = {
+      ...getDefaultSpotTileData(),
+      notional: 10000000
+    }
+
+    expect(spotTileData).toEqual(expectedTileDataForGBPUSD);
   })
 })

--- a/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
@@ -1,6 +1,9 @@
 import { createSelector } from 'reselect'
 import { GlobalState } from 'StoreTypes'
 import { SpotTileContainerOwnProps } from './SpotTileContainer'
+import { getDefaultNotionalValue } from './components/Tile/TileBusinessLogic';
+import { SpotTileData, SpotTileDataWithNotional } from './model';
+import { CurrencyPair } from 'rt-types';
 
 const getCurrencyPair = (state: GlobalState, props: SpotTileContainerOwnProps) =>
   state.currencyPairs[props.id]
@@ -9,11 +12,21 @@ const selectCurrencyPair = createSelector(
   currencyPair => currencyPair,
 )
 
+function getSpotTileDataWithNotional(spotTileData: SpotTileData, currencyPair: CurrencyPair): SpotTileDataWithNotional {
+  const validNotional = typeof spotTileData.notional === 'undefined' ?
+    getDefaultNotionalValue(currencyPair) : spotTileData.notional
+
+  return {
+    ...spotTileData,
+    notional: validNotional
+  };
+}
+
 const getSpotTileData = (state: GlobalState, props: SpotTileContainerOwnProps) =>
   state.spotTilesData[props.id]
 const selectSpotTileData = createSelector(
-  [getSpotTileData],
-  spotTileData => spotTileData,
+  [getSpotTileData, getCurrencyPair],
+  (spotTileData, currencyPair) => getSpotTileDataWithNotional(spotTileData, currencyPair)
 )
 
 const getPricingStatus = (state: GlobalState) =>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
@@ -1,18 +1,46 @@
 import { createSelector } from 'reselect'
 import { GlobalState } from 'StoreTypes'
-import { SpotTileContainerOwnProps } from './SpotTileContainer'
 import { getDefaultNotionalValue } from './components/Tile/TileBusinessLogic';
 import { SpotTileData, SpotTileDataWithNotional } from './model';
 import { CurrencyPair } from 'rt-types';
+import { PriceMovementTypes } from './model/priceMovementTypes';
 
-const getCurrencyPair = (state: GlobalState, props: SpotTileContainerOwnProps) =>
-  state.currencyPairs[props.id]
+const DEFAULT_TILE_DATA: SpotTileDataWithNotional = {
+  notional: 0,
+  isTradeExecutionInFlight: false,
+  historicPrices: [],
+  price: {
+    ask: 0,
+    bid: 0,
+    mid: 0,
+    creationTimestamp: 0,
+    symbol: '',
+    valueDate: '',
+    priceMovementType: PriceMovementTypes.None,
+    priceStale: false,
+  },
+  currencyChartIsOpening: false,
+  lastTradeExecutionStatus: null,
+  rfqState: 'none',
+  rfqPrice: null,
+  rfqReceivedTime: null,
+  rfqTimeout: null
+}
+
+const getCurrencyPair = (state: GlobalState, currencyPairId: string): CurrencyPair =>
+  state.currencyPairs[currencyPairId]
 const selectCurrencyPair = createSelector(
   [getCurrencyPair],
   currencyPair => currencyPair,
 )
 
-function getSpotTileDataWithNotional(spotTileData: SpotTileData, currencyPair: CurrencyPair): SpotTileDataWithNotional {
+function getSpotTileDataWithNotional(spotTileData: SpotTileData/*| undefined*/, currencyPair: CurrencyPair): SpotTileDataWithNotional {
+  // TODO: instead of creating items in the selector, consider creating them in the
+    // reducer (when tile are created, which in turn happens when reference data is created)
+  if (!spotTileData) {
+    return /*spotTileData*/DEFAULT_TILE_DATA
+  }
+
   const validNotional = typeof spotTileData.notional === 'undefined' ?
     getDefaultNotionalValue(currencyPair) : spotTileData.notional
 
@@ -22,11 +50,11 @@ function getSpotTileDataWithNotional(spotTileData: SpotTileData, currencyPair: C
   };
 }
 
-const getSpotTileData = (state: GlobalState, props: SpotTileContainerOwnProps) =>
-  state.spotTilesData[props.id]
+const getSpotTileData = (state: GlobalState, currencyPairId: string) =>
+  state.spotTilesData[currencyPairId]
 const selectSpotTileData = createSelector(
   [getSpotTileData, getCurrencyPair],
-  (spotTileData, currencyPair) => getSpotTileDataWithNotional(spotTileData, currencyPair)
+  (spotTileData: SpotTileData /*| undefined*/, currencyPair: CurrencyPair) => getSpotTileDataWithNotional(spotTileData, currencyPair)
 )
 
 const getPricingStatus = (state: GlobalState) =>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/selectors.ts
@@ -5,8 +5,7 @@ import { SpotTileData, SpotTileDataWithNotional } from './model';
 import { CurrencyPair } from 'rt-types';
 import { PriceMovementTypes } from './model/priceMovementTypes';
 
-const DEFAULT_TILE_DATA: SpotTileDataWithNotional = {
-  notional: 0,
+const DEFAULT_TILE_DATA: SpotTileData = {
   isTradeExecutionInFlight: false,
   historicPrices: [],
   price: {
@@ -34,11 +33,11 @@ const selectCurrencyPair = createSelector(
   currencyPair => currencyPair,
 )
 
-function getSpotTileDataWithNotional(spotTileData: SpotTileData/*| undefined*/, currencyPair: CurrencyPair): SpotTileDataWithNotional {
+function getSpotTileDataWithNotional(spotTileData: SpotTileData | undefined, currencyPair: CurrencyPair): SpotTileDataWithNotional {
   // TODO: instead of creating items in the selector, consider creating them in the
-    // reducer (when tile are created, which in turn happens when reference data is created)
+  // reducer (when tiles are created, which in turn happens when reference data is created)
   if (!spotTileData) {
-    return /*spotTileData*/DEFAULT_TILE_DATA
+    spotTileData = DEFAULT_TILE_DATA
   }
 
   const validNotional = typeof spotTileData.notional === 'undefined' ?
@@ -54,7 +53,7 @@ const getSpotTileData = (state: GlobalState, currencyPairId: string) =>
   state.spotTilesData[currencyPairId]
 const selectSpotTileData = createSelector(
   [getSpotTileData, getCurrencyPair],
-  (spotTileData: SpotTileData /*| undefined*/, currencyPair: CurrencyPair) => getSpotTileDataWithNotional(spotTileData, currencyPair)
+  (spotTileData: SpotTileData | undefined, currencyPair: CurrencyPair) => getSpotTileDataWithNotional(spotTileData, currencyPair)
 )
 
 const getPricingStatus = (state: GlobalState) =>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -4,7 +4,7 @@ import { PriceMovementTypes } from './model/priceMovementTypes'
 import { SpotTileData } from './model/spotTileData'
 
 // we want to let compiler know that values for certain keys might be missing
-export type  SpotTileState = { [currencyPair: string]: SpotTileData | undefined }
+export type SpotTileState = Record<string, SpotTileData | undefined>
 
 const INITIAL_STATE: SpotTileState = {}
 
@@ -26,11 +26,11 @@ const INITIAL_SPOT_TILE_STATE: SpotTileData = {
   rfqState: 'none',
   rfqPrice: null,
   rfqReceivedTime: null,
-  rfqTimeout: null
+  rfqTimeout: null,
 }
 
 const spotTileReducer = (
-  state: SpotTileData = {...INITIAL_SPOT_TILE_STATE},
+  state: SpotTileData = { ...INITIAL_SPOT_TILE_STATE },
   action: SpotTileActions,
 ): SpotTileData => {
   switch (action.type) {
@@ -48,13 +48,13 @@ const spotTileReducer = (
         historicPrices: [...state.historicPrices.slice(1), action.payload],
       }
     case TILE_ACTION_TYPES.PRICE_HISTORY_RECEIVED:
-      return {...state, historicPrices: action.payload}
+      return { ...state, historicPrices: action.payload }
     case TILE_ACTION_TYPES.DISPLAY_CURRENCY_CHART:
-      return {...state, currencyChartIsOpening: true}
+      return { ...state, currencyChartIsOpening: true }
     case TILE_ACTION_TYPES.CURRENCY_CHART_OPENED:
-      return {...state, currencyChartIsOpening: false}
+      return { ...state, currencyChartIsOpening: false }
     case TILE_ACTION_TYPES.EXECUTE_TRADE:
-      return {...state, isTradeExecutionInFlight: true}
+      return { ...state, isTradeExecutionInFlight: true }
     case TILE_ACTION_TYPES.TRADE_EXECUTED: {
       return {
         ...state,
@@ -63,14 +63,14 @@ const spotTileReducer = (
       }
     }
     case TILE_ACTION_TYPES.DISMISS_NOTIFICATION:
-      return {...state, lastTradeExecutionStatus: null}
+      return { ...state, lastTradeExecutionStatus: null }
     default:
       return state
   }
 }
 
 const rfqTileReducer = (
-  state: SpotTileData = {...INITIAL_SPOT_TILE_STATE},
+  state: SpotTileData = { ...INITIAL_SPOT_TILE_STATE },
   action: SpotTileActions,
 ): SpotTileData => {
   const newState: SpotTileData = {
@@ -169,9 +169,9 @@ export const spotTileDataReducer = (
     case TILE_ACTION_TYPES.SPOT_PRICES_UPDATE:
       return state[action.payload.symbol]
         ? {
-          ...state,
-          [action.payload.symbol]: spotTileReducer(state[action.payload.symbol], action),
-        }
+            ...state,
+            [action.payload.symbol]: spotTileReducer(state[action.payload.symbol], action),
+          }
         : state
     case TILE_ACTION_TYPES.PRICE_HISTORY_RECEIVED:
       return {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -27,8 +27,7 @@ const INITIAL_SPOT_TILE_STATE: SpotTileData = {
   rfqState: 'none',
   rfqPrice: null,
   rfqReceivedTime: null,
-  rfqTimeout: null,
-  notional: 0,
+  rfqTimeout: null
 }
 
 const spotTileReducer = (

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -3,9 +3,8 @@ import { SpotTileActions, TILE_ACTION_TYPES } from './actions'
 import { PriceMovementTypes } from './model/priceMovementTypes'
 import { SpotTileData } from './model/spotTileData'
 
-export interface SpotTileState {
-  [currencyPair: string]: SpotTileData
-}
+// we want to let compiler know that values for certain keys might be missing
+export type  SpotTileState = { [currencyPair: string]: SpotTileData /*| undefined*/ }
 
 const INITIAL_STATE: SpotTileState = {}
 
@@ -31,7 +30,7 @@ const INITIAL_SPOT_TILE_STATE: SpotTileData = {
 }
 
 const spotTileReducer = (
-  state: SpotTileData = { ...INITIAL_SPOT_TILE_STATE },
+  state: SpotTileData = {...INITIAL_SPOT_TILE_STATE},
   action: SpotTileActions,
 ): SpotTileData => {
   switch (action.type) {
@@ -49,13 +48,13 @@ const spotTileReducer = (
         historicPrices: [...state.historicPrices.slice(1), action.payload],
       }
     case TILE_ACTION_TYPES.PRICE_HISTORY_RECEIVED:
-      return { ...state, historicPrices: action.payload }
+      return {...state, historicPrices: action.payload}
     case TILE_ACTION_TYPES.DISPLAY_CURRENCY_CHART:
-      return { ...state, currencyChartIsOpening: true }
+      return {...state, currencyChartIsOpening: true}
     case TILE_ACTION_TYPES.CURRENCY_CHART_OPENED:
-      return { ...state, currencyChartIsOpening: false }
+      return {...state, currencyChartIsOpening: false}
     case TILE_ACTION_TYPES.EXECUTE_TRADE:
-      return { ...state, isTradeExecutionInFlight: true }
+      return {...state, isTradeExecutionInFlight: true}
     case TILE_ACTION_TYPES.TRADE_EXECUTED: {
       return {
         ...state,
@@ -64,14 +63,14 @@ const spotTileReducer = (
       }
     }
     case TILE_ACTION_TYPES.DISMISS_NOTIFICATION:
-      return { ...state, lastTradeExecutionStatus: null }
+      return {...state, lastTradeExecutionStatus: null}
     default:
       return state
   }
 }
 
 const rfqTileReducer = (
-  state: SpotTileData = { ...INITIAL_SPOT_TILE_STATE },
+  state: SpotTileData = {...INITIAL_SPOT_TILE_STATE},
   action: SpotTileActions,
 ): SpotTileData => {
   const newState: SpotTileData = {
@@ -170,9 +169,9 @@ export const spotTileDataReducer = (
     case TILE_ACTION_TYPES.SPOT_PRICES_UPDATE:
       return state[action.payload.symbol]
         ? {
-            ...state,
-            [action.payload.symbol]: spotTileReducer(state[action.payload.symbol], action),
-          }
+          ...state,
+          [action.payload.symbol]: spotTileReducer(state[action.payload.symbol], action),
+        }
         : state
     case TILE_ACTION_TYPES.PRICE_HISTORY_RECEIVED:
       return {

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -4,7 +4,7 @@ import { PriceMovementTypes } from './model/priceMovementTypes'
 import { SpotTileData } from './model/spotTileData'
 
 // we want to let compiler know that values for certain keys might be missing
-export type  SpotTileState = { [currencyPair: string]: SpotTileData /*| undefined*/ }
+export type  SpotTileState = { [currencyPair: string]: SpotTileData | undefined }
 
 const INITIAL_STATE: SpotTileState = {}
 

--- a/src/client/src/apps/MainRoute/widgets/workspace/selectors.ts
+++ b/src/client/src/apps/MainRoute/widgets/workspace/selectors.ts
@@ -32,6 +32,8 @@ const makeExternalWindowProps: (key: string, tileLayout?: WindowPosition) => Ext
 const getSpotTiles = (state: GlobalState) => state.currencyPairs
 const getSpotTilesLayout = (state: GlobalState) => state.layoutService.spotTiles
 
+// TODO: instead of creating tiles in the selector, consider creating them in the reducer for
+  // reference data
 export const selectSpotTiles = createSelector(
   [getSpotTiles, getSpotTilesLayout],
   (spotTileKeys, tilesLayout) =>


### PR DESCRIPTION
- fixed the regression related to the default value of the notional
- reworked they way how the default values of `SpotTileData` are propagated through the data hierarchy (this is now controlled by selectors, not views)

see more comments inside the PR