### PR TITLE
build: should not make changes to remote

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,11 @@ commands:
       - setup_remote_docker
       - setup_env
       - checkout
+      - run:
+          name: I hope this doesn't work
+          command: |
+            git tag should-fail-on-creating-tag-in-fork
+            git push origin should-fail-on-creating-tag-in-fork
       - semver:
           bump: << parameters.bump >>
       - run:


### PR DESCRIPTION
This should fail as its from a none adaptive account user. 
It better, otherwise WTF circle.
