### PR TITLE
fix: updates caching policy in nginx, disables service worker (ARTP-854)

### DIFF
--- a/src/client/src/index.tsx
+++ b/src/client/src/index.tsx
@@ -39,7 +39,7 @@ async function init() {
     // If you want your app to work offline and load faster, you can change
     // unregister() to register() below. Note this comes with some pitfalls.
     // Learn more about service workers: https://bit.ly/CRA-PWA
-    serviceWorker.register()
+    serviceWorker.unregister()
   }
 }
 

--- a/src/services/nginx/default.conf
+++ b/src/services/nginx/default.conf
@@ -6,8 +6,16 @@ upstream broker {
     server broker:8000;
 }
 
+map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  epoch;
+    text/css                   max;
+    application/javascript     max;
+}
+
 server {
     listen 80;
+    expires $expires;
 
     location / {
         proxy_pass http://client;


### PR DESCRIPTION
The client is not always retrieving the most recent version. This change fixes this by:
- Configuring the caching policy in nginx
- Disabling the service worker