### PR TITLE
fix: fixing e2e test (ARTP-832)

### DIFF
--- a/src/e2e/src/tests/trade.spec.ts
+++ b/src/e2e/src/tests/trade.spec.ts
@@ -82,7 +82,6 @@ describe('UI Tests for Reactive Trader Cloud Web Application', async () => {
 
   it('should validate unavailable streaming', async () => {
     await mainPage.workspace.selectCurrency('nzd')
-    await mainPage.tile.setNotional('NZDToUSD', '10m')
     const textStreaming = await mainPage.tile.tradeType.initiateRFQ.labelTextStreamingUnavailable
     expect(textStreaming.getText()).toEqual('STREAMING PRICE UNAVAILABLE')
     await mainPage.tile.NZDToUSDRFQ()


### PR DESCRIPTION
- we had a bug in notional after recent merge (all notionals were 0 by default)
- while our notional was broken, there was a fix to the test which now manually switched notional for NZDUSD curreny pair to 10,000,000. This was done to switch ticket to RFQ mode and it was working ok
- after we fixed the default value of notional to be 10,000,000 for NZDUSD, this test was still clearing text of notional and populating it with 10,000,000.
- unfortunately due to the structure of the animations in that piece code, we are temporarely having more than one element with the same selector on the screen when switching from and to RFQ quickly
- our e2e test (which is based on certain data-qa selectors) was not identifying elements to click correctly and was failing. 

Solution - just remove explicit setting to 10,000,000 - this work because our notional for NZDUSD pair is fixed now - it is 10,000,00 by default.