### PR TITLE
fix: triggering build on PR branches on commit to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,105 @@ references:
     client pricehistory bot nlp servers broker eventstore nginx
 
 commands:
+
+  # rewriting internal 'checkout' command to solve the issue with triggering forked PRs build with API
+  checkout:
+    steps:
+      - run:
+          name: Set up HOME environment variable
+          command: |
+            # Workaround old docker images with incorrect $HOME
+            # check https://github.com/docker/docker/issues/2968 for details
+            if [ "${HOME}" = "/" ]
+            then
+              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
+            fi
+
+      - run:
+          name: Set up SSH access
+          command: |
+            mkdir -p ~/.ssh
+
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+            bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+            ' >> ~/.ssh/known_hosts
+
+            (umask 077; touch ~/.ssh/id_rsa)
+            chmod 0600 ~/.ssh/id_rsa
+            (cat $CHECKOUT_KEY > ~/.ssh/id_rsa)
+
+      - run:
+          name: Set up git configuration
+          command: |
+            # use git+ssh instead of https
+            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
+            git config --global gc.auto 0 || true
+
+      - run:
+          name: Set up git repository
+          command: |
+            if [ -e /home/circleci/project/.git ]
+            then
+                cd /home/circleci/project
+                git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+            else
+                mkdir -p /home/circleci/project
+                cd /home/circleci/project
+                git clone "$CIRCLE_REPOSITORY_URL" .
+             fi
+
+      - run:
+          name: Fetch git origin remote
+          command: |
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git fetch --force origin "refs/tags/${CIRCLE_TAG}"
+            elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]
+            then
+              # For PR from Fork
+              echo "Value of CIRCLE_BRANCH env var for current pull request branch: " $CIRCLE_BRANCH
+
+              # This is a fix for an edge case:
+              # We always need to trigger a build on all PRs once we have a new commit in master. We use CircleCi API to trigger
+              # those builds (see a job "notify_about_merge_to_master"). That job uses a branch name for opened PR
+              # to trigger the build. But there is a special case for PRs raised from forks - there are no branch names that
+              # builds can be identified with (since branches are in forks), so CircleCi crates a special branch for them in
+              # format "pull/123". Then we use such number in CircleCi API to trigger a build on those PRs.
+              # (see a job "notify_about_merge_to_master")
+              # Unfortunately it looks like there is a bug in CircleCi API:
+              # their API does not allow to trigger builds for fork PRs (where branch is "pull/123").
+              # We found that instead of calling API with "pull/123", we need to call it with "pull/123/head" - then the
+              # build can be triggered. This looks great, but then unfortunately such build fails on the step where CircleCi
+              # checks out the code from the repo. It says that it can't find a branch with name "pull/123/head/head" -
+              # clearly it adds "head" into the branch name that we passed to it with API ("pull/123/head" + "/head").
+              # So the trick here is next: before checking out the code, validate the environment variable
+              # "CIRCLE_BRANCH" to make sure it does not have "head" in the end, so turn "pull/123/head" into "pull/123"
+              FIXED_PR_BRANCH_NAME=$( grep -oP "(?=pull\/).*(?=\/head)" \<<< $CIRCLE_BRANCH ) || true
+              if [ ! -z "$FIXED_PR_BRANCH_NAME" ]; then
+                echo "Fixing branch name: " $CIRCLE_BRANCH " => " $FIXED_PR_BRANCH_NAME
+                CIRCLE_BRANCH=$FIXED_PR_BRANCH_NAME
+              fi
+
+              git fetch --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+            else
+              git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+            fi
+
+      - run:
+          name: Checkout branch
+          command: |
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+
+            git reset --hard "$CIRCLE_SHA1"
+
   setup_env:
     steps:
       - run:
@@ -12,11 +111,12 @@ commands:
           command: |
             sudo npm i -g semver@6.3.0
             sudo apt-get install gettext-base
+            sudo apt-get install jq
       - run:
           name: Setup git
           command: |
-            git config --global user.email "${GIT_AUTHOR_NAME}"
-            git config --global user.name “${GIT_EMAIL}”
+            git config --global user.email "${GIT_EMAIL}"
+            git config --global user.name “${GIT_AUTHOR_NAME}”
       - run:
           name: Default docker user
           command: |
@@ -126,6 +226,9 @@ commands:
   main_pipeline:
     description: "Main pipeline"
     parameters:
+      rebase_with_master:
+        type: boolean
+        default: false
       bump:
         description: The semver bump type. Must be one of "major", "minor", "patch".
         type: enum
@@ -136,6 +239,13 @@ commands:
       - setup_remote_docker
       - setup_env
       - checkout
+      - when:
+          condition: <<parameters.rebase_with_master>>
+          steps:
+            - run:
+                name: Rebase with master
+                command: |
+                  git rebase origin master
       - semver:
           bump: << parameters.bump >>
       - run:
@@ -181,6 +291,56 @@ jobs:
       - main_pipeline:
           bump: prerelease
           environment: none
+          rebase_with_master: true
+
+  notify_about_merge_to_master:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - run:
+          name: "Trigger build on branches with PRs (because master had a commit)"
+          command: |
+            TARGET_USER="AdaptiveConsulting"
+            TARGET_BRANCH="master"
+
+            # Fetching info about opened pull requests (using github API)
+            # PLEASE NOTE: calling GitHub API with token restricts amount of calls to 60 per hour:
+            # https://developer.github.com/v3/#rate-limiting
+            pr_info=$(curl https://api.github.com/repos/AdaptiveConsulting/ReactiveTraderCloud/pulls\?state=open\?access_token\=${GIT_API_USER_TOKEN})
+
+            # Iterating through the list of opened PRs and mapping records to objects that only have info about PR number and full branch name
+            for pr_item in $(jq -c 'map( {pr_number: .number, branch_label: .head.label} ) | .[]' \<<< $pr_info); do
+
+              # Extracting PR number and PR label from JSON object into separate variables
+              pr_number=$(jq -c '.pr_number' \<<< $pr_item)
+              branch_label=$(jq -c '.branch_label' \<<< $pr_item)
+
+              # regex-ing $branch_label to see if it is located in original repo (not in a fork).
+              # For this we are testing if it starts with the main repo org name ("AdaptiveConsulting" in our case)
+              NON_FORKED_BRANCH_NAME=$( grep -oP "(?<=\"${TARGET_USER}:).*?(?=\")" \<<< $branch_label) || true
+              if [ ! -z "$NON_FORKED_BRANCH_NAME" ]
+              then
+                echo "Using non-forked CircleCi branch: ${NON_FORKED_BRANCH_NAME}"
+
+                # If it is non-forked branch, org name will be removed with Regex:
+                # "AdaptiveConsulting:some-branch" => "some-branch"
+                # ^ this is how CircleCi API wants us to trigger builds on non-forked branches (by branch name only)
+                CIRCLE_BRANCH_TO_TRIGGER_BUILD=$NON_FORKED_BRANCH_NAME
+              else
+                # if it's a forked branch, create a branch name based on the PR number.
+                # Please note that we are adding extra "head" suffix to work around existing bug in CircleCi API v2
+                # (see description in "Fetch git origin remote" command above)
+                FORKED_BRANCH_NAME="pull/"$pr_number"/head"
+                echo "Using forked CircleCi branch: ${FORKED_BRANCH_NAME}"
+                CIRCLE_BRANCH_TO_TRIGGER_BUILD=$FORKED_BRANCH_NAME
+              fi
+
+              echo "Triggering build: ${CIRCLE_BRANCH_TO_TRIGGER_BUILD}"
+
+              curl -u ${CIRCLE_API_USER_TOKEN}: -X POST --header "Content-Type: application/json" -d "{
+                \"branch\": \"${CIRCLE_BRANCH_TO_TRIGGER_BUILD}\"
+              }" https://circleci.com/api/v2/project/github/AdaptiveConsulting/ReactiveTraderCloud/pipeline
+            done
 
   deploy_last_build:
     docker:
@@ -248,28 +408,34 @@ workflows:
           filters:
             branches:
               only: /^release\/.*/
+
       - release_build:
           filters:
             branches:
               only: master
+
       - deploy_last_build:
           requires:
             - release_build
           filters:
             branches:
               only: master
+
+      - notify_about_merge_to_master:
+          filters:
+            branches:
+              only: master
+
       - feature_build:
           filters:
             branches:
               ignore:
                 - master
                 - /^release\/.*/
+
       - deploy_version_from_env_tag:
           filters:
             branches:
               ignore: /.*/  # only run on matching tag
             tags:
               only: /^env-.*/
-
-
-


### PR DESCRIPTION
This PR introduces a few things to fix our CI process:

1) when building branches in PRs, we need to rebase with master first. This is to make sure that we do not allow false-positive build cases (this is when PR looks green, but after merging with master, it fails because master had changes that were not taken into account when PR was built)

2) when a PR gets merged into master, we need to rebuild all other opened PRs to make sure their status is correctly representing the latest code. This is solved by default in a lot of CI products but unfortunately in CircleCi we had to do this manually using a some API magic (call GitHub API, then CircleCI API). See details in the code 

PLEASE NOTE: for now it only works for PRs that have been opened for branches that are in the original repo (not forks)