### PR TITLE
fix: handles service disconnections

### DIFF
--- a/src/client/src/rt-system/ServiceStubWithLoadBalancer.ts
+++ b/src/client/src/rt-system/ServiceStubWithLoadBalancer.ts
@@ -105,15 +105,17 @@ export default class ServiceStubWithLoadBalancer {
               },
             })
 
-            // There must be a way to do this without an inner-subsribe
+            // There must be a way to do this without an inner-subscribe
             const subscription = subscribeTopic$.subscribe(obs)
 
+            // This will detect when a service has gone down an emit an error on to stream. This allows any subscribers
+            // to handle the timeout and `retryWhen` would be good option
             const detectInstanceTimout = this.serviceInstanceDictionaryStream
               .pipe(
                 map(currentStatus => currentStatus.getServiceInstanceStatus(service, serviceInstanceStatus.serviceId)),
                 filter(currentStatus => !(currentStatus && currentStatus.isConnected)),
               )
-              .subscribe(() => console.log('Topic timed out: ' + topicName))
+              .subscribe(() => obs.error('Topic timed out: ' + topicName))
 
             return () => {
               subscription.unsubscribe()


### PR DESCRIPTION
This change fixes a bug in handling service disconnections whereby the client fails to re-subscribe to a service after a network disconnection. This is what causes the pricing service to show the "pricing unavailable" message as the prices are now stale.