### PR TITLE
feat: show indicator when pricing unavailable (ARTP-840)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/SpotTile.tsx
@@ -53,6 +53,7 @@ export default class SpotTile extends PureComponent<SpotTileProps> {
       (isRfqStateNone || isRfqStateCanRequest || isRfqStateExpired)
     const showTimer = isRfqStateReceived && rfqTimeout
     const priceData = (isRfqStateReceived || isRfqStateExpired) && rfqPrice ? rfqPrice : price
+    const {priceStale} = priceData;
 
     if ((isRfqStateReceived || isRfqStateExpired) && !rfqPrice) {
       console.error(`Unexpected state - rfq price should be displayed but it is not defined`)
@@ -90,7 +91,7 @@ export default class SpotTile extends PureComponent<SpotTileProps> {
                 resetNotional={resetNotional}
                 validationMessage={inputValidationMessage}
                 showResetButton={showResetButton}
-                disabled={inputDisabled}
+                disabled={inputDisabled || Boolean(priceStale)}
               />
             </NotionalInputWrapper>
             {showTimer && rfqTimeout !== null && rfqReceivedTime !== null && (

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -94,7 +94,6 @@ const TileSwitch: React.FC<Props> = ({
             RFQ
           </TileBooking>
           <NotificationContainer
-            isPriceStale={!spotTileData.lastTradeExecutionStatus && spotTileData.price.priceStale}
             lastTradeExecutionStatus={spotTileData.lastTradeExecutionStatus}
             currencyPair={currencyPair}
             onNotificationDismissed={onNotificationDismissed}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/NotificationContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/NotificationContainer.tsx
@@ -6,7 +6,6 @@ import TileExecuted from './TileExecuted'
 import TileNotification from './TileNotification'
 
 interface Props {
-  isPriceStale?: boolean
   lastTradeExecutionStatus?: LastTradeExecutionStatus | null
   currencyPair: CurrencyPair
   onNotificationDismissed: () => void
@@ -29,20 +28,8 @@ export default class NotificationContainer extends PureComponent<Props> {
   }
 
   private renderNotifications: () => (style: React.CSSProperties) => JSX.Element | null = () => {
-    const {
-      lastTradeExecutionStatus,
-      currencyPair,
-      onNotificationDismissed,
-      isPriceStale,
-    } = this.props
+    const { lastTradeExecutionStatus, currencyPair, onNotificationDismissed } = this.props
     const symbols = `${currencyPair.base}/${currencyPair.terms}`
-    if (isPriceStale) {
-      return (style: React.CSSProperties) => (
-        <TileNotification style={style} symbols={symbols} isWarning={true}>
-          Pricing is unavailable
-        </TileNotification>
-      )
-    }
     if (!lastTradeExecutionStatus || !hasNotification(lastTradeExecutionStatus)) {
       return () => null
     }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/stories/PriceControls.stories.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/stories/PriceControls.stories.tsx
@@ -1,0 +1,56 @@
+import { Centered, stories, Story } from "./Initialise.stories";
+import React from "react";
+import PriceControls from "../PriceControls";
+import { action } from "@storybook/addon-actions";
+import { boolean, select } from "@storybook/addon-knobs";
+import { RfqState } from "../types";
+
+stories.add('Price controls', () => {
+  const rfqStates = {
+    none: 'none',
+    canRequest: 'canRequest',
+    requested: 'requested',
+    received: 'received',
+    expired: 'expired'
+  }
+
+  const onTradeExecute = action('execute trade')
+  const isDisabled = boolean('disabled', false)
+  const isPricingStale = boolean('Stale prices', false)
+  const isTradeExecutionInFlight = boolean('isTradeExecutionInFlight', false)
+  const isAnalyticsView = boolean('isAnalyticsView', false)
+  const rfqSatesSelector = select('Rfq State', rfqStates, 'none')
+
+  const currencyPair = {
+    symbol: 'USDYAN',
+    ratePrecision: 1.5,
+    pipsPosition: 1.0,
+    base: 'USD',
+    terms: 'YAN',
+  }
+
+  const spotTick = {
+    ask: 10.6,
+    bid: 10.1,
+    mid: 10.2 ,
+    creationTimestamp: 1000,
+    symbol: 'USDYAN',
+    valueDate: '2019-01-02',
+    priceStale: isPricingStale
+  }
+
+  return(
+    <Story>
+      <Centered>
+        <PriceControls
+          currencyPair={currencyPair}
+          priceData={spotTick}
+          executeTrade={onTradeExecute}
+          disabled={isDisabled}
+          rfqState={rfqSatesSelector as RfqState}
+          isTradeExecutionInFlight={isTradeExecutionInFlight}
+          isAnalyticsView={isAnalyticsView} />
+      </Centered>
+    </Story>
+  )
+})


### PR DESCRIPTION
This PR shows icons in the pricing buttons instead of the red warning tile

![ARTP-840-PricingUnavailable 90](https://user-images.githubusercontent.com/120547/69865099-3e6ed000-1298-11ea-80c3-c07443a75bb6.png)

