### PR TITLE
refactor: spotTile chart now displayed by default - ARTP-892

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -32,7 +32,7 @@ const ALL = 'ALL'
 
 const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions }) => {
   const [currency, setCurrencyOption] = useState(ALL)
-  const [tileView, setTileView] = useState(TileViews.Normal)
+  const [tileView, setTileView] = useState(TileViews.Analytics)
 
   return (
     <div data-qa="workspace__tiles-workspace">

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 const tileViews = {
-  [TileViews.Normal]: SpotTileViewIcon,
   [TileViews.Analytics]: AnalyticsViewIcon,
+  [TileViews.Normal]: SpotTileViewIcon,
 }
 
 const WorkspaceHeader: React.FC<Props> = ({


### PR DESCRIPTION
Just a minor refactor:

- spot tile now defaults to analytics view
- thus order of icons in spot tile workspace has flipped