### PR TITLE
Fix(client): search and tile open in graphic view by default (ARTP-914)

### DIFF
--- a/src/client/src/apps/SimpleLauncher/spotlight/intents/showCurrencyPair.ts
+++ b/src/client/src/apps/SimpleLauncher/spotlight/intents/showCurrencyPair.ts
@@ -28,7 +28,7 @@ async function openNewWindow(
       ...defaultConfig,
       width: 380,
       height: 200,
-      url: `${windowOrigin}/spot/${currencyPair}?tileView=Normal`,
+      url: `${windowOrigin}/spot/${currencyPair}?tileView=Analytics`,
     },
     () => (openedWindow = undefined),
   )


### PR DESCRIPTION
Now the NLP search (currency paid), tile should open in graphic view by default