### PR TITLE
Fix - reduce memory usage for analytics mode

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -41,10 +41,16 @@ const spotTileReducer = (
     case TILE_ACTION_TYPES.SPOT_TILE_SUBSCRIBE:
       return state
     case TILE_ACTION_TYPES.SPOT_PRICES_UPDATE:
+      const startIndexSlice =
+        state.historicPrices.length < 250 ? 1 : state.historicPrices.length - 250
+
       return {
         ...state,
         price: action.payload,
-        historicPrices: [...state.historicPrices.slice(1), action.payload],
+        historicPrices: [
+          ...state.historicPrices.slice(startIndexSlice, state.historicPrices.length - 1),
+          action.payload,
+        ],
       }
     case TILE_ACTION_TYPES.PRICE_HISTORY_RECEIVED:
       return { ...state, historicPrices: action.payload }
@@ -140,7 +146,7 @@ export const spotTileDataReducer = (
           action,
         ),
       }
-   case TILE_ACTION_TYPES.DISMISS_NOTIFICATION:
+    case TILE_ACTION_TYPES.DISMISS_NOTIFICATION:
     case TILE_ACTION_TYPES.SPOT_TILE_SUBSCRIBE:
       return {
         ...state,

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -7,6 +7,7 @@ import { SpotTileData } from './model/spotTileData'
 export type SpotTileState = Record<string, SpotTileData | undefined>
 
 const INITIAL_STATE: SpotTileState = {}
+const HISTORIC_PRICES_MAX_POINTS = 250
 
 const INITIAL_SPOT_TILE_STATE: SpotTileData = {
   isTradeExecutionInFlight: false,
@@ -42,7 +43,9 @@ const spotTileReducer = (
       return state
     case TILE_ACTION_TYPES.SPOT_PRICES_UPDATE:
       const startIndexSlice =
-        state.historicPrices.length < 250 ? 1 : state.historicPrices.length - 250
+        state.historicPrices.length < HISTORIC_PRICES_MAX_POINTS
+          ? 1
+          : state.historicPrices.length - HISTORIC_PRICES_MAX_POINTS
 
       return {
         ...state,

--- a/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/spotTileDataReducer.ts
@@ -42,10 +42,7 @@ const spotTileReducer = (
     case TILE_ACTION_TYPES.SPOT_TILE_SUBSCRIBE:
       return state
     case TILE_ACTION_TYPES.SPOT_PRICES_UPDATE:
-      const startIndexSlice =
-        state.historicPrices.length < HISTORIC_PRICES_MAX_POINTS
-          ? 1
-          : state.historicPrices.length - HISTORIC_PRICES_MAX_POINTS
+      const startIndexSlice = Math.max(1, state.historicPrices.length - HISTORIC_PRICES_MAX_POINTS)
 
       return {
         ...state,


### PR DESCRIPTION
- Limit graph points to 250
- Use slice indicating start and end index to improve array copy