### PR TITLE
Forward host to openfingconfig [ARTP-877]

### DIFF
--- a/src/services/nginx/default.conf
+++ b/src/services/nginx/default.conf
@@ -35,6 +35,7 @@ server {
 
     location /openfin {
         proxy_pass http://openfinconfig;
+        proxy_set_header X-Forwarded-Host $host;
         include  /etc/nginx/mime.types;
     }
 }


### PR DESCRIPTION
The openfin-config server requires the host(name) to decide which config to generate.