### PR TITLE
Fix/analytics view layout (ARTP-934 & ARTP-958)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
@@ -24,7 +24,8 @@ const PriceMovementStyle = styled.div<{
   isAnalyticsView: boolean
 }>`
   display: flex;
-  padding-right: ${({ isAnalyticsView }) => (isAnalyticsView ? '15%' : '0')};
+  padding-right: ${({ isAnalyticsView }) => (isAnalyticsView ? '12px' : '0')};
+  padding-left: ${({ isAnalyticsView }) => (isAnalyticsView ? '8px' : '0')};
   align-items: center;
   justify-content: center;
   flex-direction: column;

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
@@ -43,7 +43,7 @@ const RejectQuoteButton = styled.button`
 
 const TimerWrapper = styled.div<{ isAnalyticsView: boolean }>`
   display: grid;
-  width: ${({ isAnalyticsView }) => (isAnalyticsView ? '130%' : '100%')};
+  width: ${({ isAnalyticsView }) => (isAnalyticsView ? '120%' : '100%')};
   align-items: center;
   grid-template-columns: 35px auto 55px;
   grid-template-rows: auto;

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -242,7 +242,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -440,7 +440,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -638,7 +638,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -818,7 +818,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
           Awaiting price
         </div>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -1021,7 +1021,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"
@@ -1190,7 +1190,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           </div>
         </button>
         <div
-          className="sc-jzJRlG cxjlMm"
+          className="sc-jzJRlG klXBNG"
         >
           <i
             aria-hidden="true"

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/styled.tsx
@@ -8,7 +8,8 @@ export const AnalyticsTileContent = styled.div`
   justify-content: space-between;
 `
 export const GraphNotionalWrapper = styled.div`
-  width: 44%;
+  min-width: 0; //fixed bug with recharts resizing
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -16,6 +17,7 @@ export const GraphNotionalWrapper = styled.div`
 `
 export const PriceControlWrapper = styled.div`
   display: flex;
+  width: 160px;
   z-index: 1;
 `
 export const LineChartWrapper = styled.div<{ isTimerOn: boolean }>`


### PR DESCRIPTION
- Tile analytics view layout  not broken at large widths
- Add padding to priveMovement in analytics tile
![image](https://user-images.githubusercontent.com/21157158/73179636-b1b38780-410b-11ea-92e2-89a63fef64cc.png)
![image](https://user-images.githubusercontent.com/21157158/73179864-1d95f000-410c-11ea-92fa-c11a293c6b6f.png)
