### PR TITLE
Restore OpenFin workspace on boot

### DIFF
--- a/src/client/src/rt-actions/index.ts
+++ b/src/client/src/rt-actions/index.ts
@@ -1,19 +1,23 @@
 import {
   ConnectionActions,
   CONNECTION_ACTION_TYPES,
-  ConnectAction,
-  DisconnectAction,
+  ConnectAction as ConnectActionType,
+  DisconnectAction as DisconnectActionType,
 } from './connectionActions'
-import { SetupAction } from './setupActions'
-import { LayoutAction, LayoutActions } from './layoutActions'
+import { SetupAction as SetupActionType } from './setupActions'
+import { LayoutAction as LayoutActionType, LayoutActions } from './layoutActions'
+import { WorkspaceAction as WorkspaceActionType } from './workspaceActions'
+
 export { REF_ACTION_TYPES, ReferenceActions } from './refDataActions'
-export { SetupActions } from './setupActions'
+export { SetupActions, SETUP_ACTION_TYPES } from './setupActions'
+export { WorkspaceActions, WORKSPACE_ACTION_TYPES } from './workspaceActions'
 export { LAYOUT_ACTION_TYPES } from './layoutActions'
 export { LayoutActions }
 export { ConnectionActions, CONNECTION_ACTION_TYPES }
-export type SetupAction = SetupAction
-export type LayoutAction = LayoutAction
-export type ConnectAction = ConnectAction
-export type DisconnectAction = DisconnectAction
-
 export { applicationConnected, applicationDisconnected } from './operators'
+
+export type ConnectAction = ConnectActionType
+export type DisconnectAction = DisconnectActionType
+export type LayoutAction = LayoutActionType
+export type SetupAction = SetupActionType
+export type WorkspaceAction = WorkspaceActionType

--- a/src/client/src/rt-actions/setupActions.ts
+++ b/src/client/src/rt-actions/setupActions.ts
@@ -1,11 +1,11 @@
 import { action, ActionUnion } from 'rt-util'
 
-export enum CONNECTION_ACTION_TYPES {
+export enum SETUP_ACTION_TYPES {
   SETUP = '@ReactiveTraderCloud/SETUP',
 }
 
 export const SetupActions = {
-  setup: action<CONNECTION_ACTION_TYPES.SETUP>(CONNECTION_ACTION_TYPES.SETUP),
+  setup: action<SETUP_ACTION_TYPES.SETUP>(SETUP_ACTION_TYPES.SETUP),
 }
 
 export type SetupAction = ActionUnion<typeof SetupActions>

--- a/src/client/src/rt-actions/workspaceActions.ts
+++ b/src/client/src/rt-actions/workspaceActions.ts
@@ -1,0 +1,17 @@
+import { action, ActionUnion } from 'rt-util'
+
+export enum WORKSPACE_ACTION_TYPES {
+  WORKSPACE_RESTORED = '@ReactiveTraderCloud/WORKSPACE_RESTORED',
+  WORKSPACE_SAVE = '@ReactiveTraderCloud/WORKSPACE_SAVE',
+  WORKSPACE_SAVED = '@ReactiveTraderCloud/WORKSPACE_SAVED',
+}
+
+export const WorkspaceActions = {
+  restored: action<WORKSPACE_ACTION_TYPES.WORKSPACE_RESTORED>(
+    WORKSPACE_ACTION_TYPES.WORKSPACE_RESTORED,
+  ),
+  save: action<WORKSPACE_ACTION_TYPES.WORKSPACE_SAVE>(WORKSPACE_ACTION_TYPES.WORKSPACE_SAVE),
+  saved: action<WORKSPACE_ACTION_TYPES.WORKSPACE_SAVED>(WORKSPACE_ACTION_TYPES.WORKSPACE_SAVED),
+}
+
+export type WorkspaceAction = ActionUnion<typeof WorkspaceActions>

--- a/src/client/src/rt-platforms/openFin/adapter/epics.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/epics.ts
@@ -1,16 +1,102 @@
 import { Action } from 'redux'
-import { map, switchMapTo } from 'rxjs/operators'
-import { ActionsObservable, ofType, StateObservable } from 'redux-observable'
-import { LayoutActions } from 'rt-actions/layoutActions'
-import { setupWorkspaces } from './openFin'
+import { fromEventPattern, merge } from 'rxjs'
+import { map, switchMapTo, mergeMap, delay } from 'rxjs/operators'
+import { ActionsObservable, ofType } from 'redux-observable'
+import flowRight from 'lodash/flowRight'
 import { ApplicationEpic } from 'StoreTypes'
-import { SetupAction, CONNECTION_ACTION_TYPES } from 'rt-actions/setupActions'
+import {
+  SetupAction,
+  SETUP_ACTION_TYPES,
+  WORKSPACE_ACTION_TYPES,
+  LAYOUT_ACTION_TYPES,
+  LayoutAction,
+} from 'rt-actions'
+import { setupWorkspaces, restoreWorkspace, saveWorkspace } from './workspaces'
+import { isMainWindow, addApplicationEventHandler } from './window'
+import { WorkspaceActions, WorkspaceAction, LayoutActions } from 'rt-actions'
+
+const DELAY_SAVING_WORKSPACE = 2_000
+
+// Initialise OpenFin workspace handlers
+const workspacesHandler = setupWorkspaces()
+
+/**
+ * dispatch `updateContainerVisibilityAction` to create child windows
+ * and relevant panels from the main window
+ */
+const initWorkspaceEpic = (action$: ActionsObservable<Action>) =>
+  action$.pipe(
+    ofType<Action, SetupAction>(SETUP_ACTION_TYPES.SETUP),
+    switchMapTo(workspacesHandler.pipe(map(LayoutActions.updateContainerVisibilityAction))),
+  )
+
+/**
+ * Attempt to restore a previously persisted workspace
+ */
+const restoreWorkspaceEpic = (action$: ActionsObservable<Action>) =>
+  action$.pipe(
+    ofType<Action, SetupAction>(SETUP_ACTION_TYPES.SETUP),
+    mergeMap(async () => {
+      if (await isMainWindow()) {
+        restoreWorkspace()
+      }
+
+      return WorkspaceActions.restored()
+    }),
+  )
+
+const saveWorkspaceEpic = (action$: ActionsObservable<Action>) =>
+  action$.pipe(
+    ofType<Action, WorkspaceAction>(WORKSPACE_ACTION_TYPES.WORKSPACE_SAVE),
+    /**
+     * Delay workspace object generation and persisting to
+     * ensure OpenFin windows have finished initialising
+     */
+    delay(DELAY_SAVING_WORKSPACE),
+    mergeMap(async () => {
+      if (await isMainWindow()) {
+        await saveWorkspace()
+      }
+
+      return WorkspaceActions.saved()
+    }),
+  )
+
+/**
+ * List of Application events on which the current workspace
+ * should be persisted to local storage
+ */
+const applicationEvents = [
+  'window-bounds-changed',
+  'window-minimized',
+  'window-maximized',
+  'window-restored',
+]
+const workspaceHandlersEpic = (action$: ActionsObservable<Action>) =>
+  action$.pipe(
+    ofType<Action, SetupAction>(SETUP_ACTION_TYPES.SETUP),
+    switchMapTo(
+      merge(
+        ...applicationEvents.map(event =>
+          flowRight(fromEventPattern, addApplicationEventHandler)(event),
+        ),
+      ).pipe(map(WorkspaceActions.save)),
+    ),
+  )
+
+/**
+ * Persist the workspace when child windows are toggled
+ */
+const workspaceWindowsEpic = (action$: ActionsObservable<Action>) =>
+  action$.pipe(
+    ofType<Action, LayoutAction>(LAYOUT_ACTION_TYPES.CONTAINER_VISIBILITY_UPDATE),
+    map(WorkspaceActions.save),
+  )
 
 export const platformEpics: Array<ApplicationEpic> = [
-  (action$: ActionsObservable<Action>, _: StateObservable<any>) => {
-    return action$.pipe(
-      ofType<Action, SetupAction>(CONNECTION_ACTION_TYPES.SETUP),
-      switchMapTo(setupWorkspaces().pipe(map(LayoutActions.updateContainerVisibilityAction))),
-    )
-  },
+  initWorkspaceEpic,
+  restoreWorkspaceEpic,
+  saveWorkspaceEpic,
+  workspaceHandlersEpic,
+  workspaceWindowsEpic,
 ]

--- a/src/client/src/rt-platforms/openFin/adapter/epics.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/epics.ts
@@ -1,16 +1,15 @@
 import { Action } from 'redux'
 import { map, switchMapTo } from 'rxjs/operators'
 import { ActionsObservable, ofType, StateObservable } from 'redux-observable'
-import { SetupActions } from 'rt-actions'
 import { LayoutActions } from 'rt-actions/layoutActions'
 import { setupWorkspaces } from './openFin'
 import { ApplicationEpic } from 'StoreTypes'
-const setupLayout = ofType<Action>(SetupActions.setup)
+import { SetupAction, CONNECTION_ACTION_TYPES } from 'rt-actions/setupActions'
 
 export const platformEpics: Array<ApplicationEpic> = [
   (action$: ActionsObservable<Action>, _: StateObservable<any>) => {
     return action$.pipe(
-      setupLayout,
+      ofType<Action, SetupAction>(CONNECTION_ACTION_TYPES.SETUP),
       switchMapTo(setupWorkspaces().pipe(map(LayoutActions.updateContainerVisibilityAction))),
     )
   },

--- a/src/client/src/rt-platforms/openFin/adapter/index.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/index.ts
@@ -1,4 +1,4 @@
-export { default as OpenFin, setupWorkspaces } from './openFin'
+export { default as OpenFin } from './openFin'
 export { openDesktopWindow } from './window'
 export { createExcelApp } from '../../excelApp'
 export { platformEpics } from './epics'

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -153,3 +153,17 @@ export const openDesktopWindow = async (
 
   return createPlatformWindow(() => ofWindowPromise)
 }
+
+export const isMainWindow = async () => {
+  const app = await fin.Application.getCurrent()
+
+  const win = await app.getWindow()
+
+  return win.isMainWindow()
+}
+
+export const addApplicationEventHandler = (event: string) => (handler: Function) => {
+  const app = fin.Application.getCurrentSync()
+
+  app.addListener(event, handler as () => any)
+}

--- a/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
@@ -1,0 +1,121 @@
+import { openfinWindowStates, openDesktopWindow } from './window'
+import { workspaces } from 'openfin-layouts'
+import { Observable } from 'rxjs'
+import { WindowConfig } from 'rt-platforms'
+import { Workspace } from 'openfin-layouts/dist/client/workspaces'
+
+interface WinProps {
+  name: string
+  display: boolean
+}
+
+export function setupWorkspaces() {
+  return new Observable<WinProps>(observer => {
+    workspaces
+      .setRestoreHandler((workspace: workspaces.WorkspaceApp) => {
+        console.log('settingRestoreHandler')
+        return appRestoreHandler(workspace, (data: WinProps) => {
+          console.log('appRestoreHandler')
+          observer.next(data)
+        })
+      })
+      .then(workspaces.ready)
+  })
+}
+
+async function appRestoreHandler(
+  workspaceApp: workspaces.WorkspaceApp,
+  callback: (data: WinProps) => void,
+) {
+  const ofApp = await fin.Application.getCurrent()
+  const openWindows = await ofApp.getChildWindows()
+
+  const opened = workspaceApp.childWindows.map(async (win: workspaces.WorkspaceWindow) => {
+    if (!openWindows.some(w => w.identity.name === win.name)) {
+      const config: WindowConfig = {
+        name: win.name,
+        url: win.url,
+        width: win.bounds.width,
+        height: win.bounds.height,
+      }
+      await openDesktopWindow(
+        config,
+        () => {
+          callback({
+            name: win.name,
+            display: true,
+          })
+        },
+        { defaultLeft: win.bounds.left, defaultTop: win.bounds.top },
+      )
+
+      // 'remove' the child window from the main window
+      callback({
+        name: win.name,
+        display: false,
+      })
+    } else {
+      await positionWindow(win)
+    }
+  })
+
+  await Promise.all(opened)
+  return workspaceApp
+}
+
+async function positionWindow(win: workspaces.WorkspaceWindow): Promise<void> {
+  try {
+    const { isShowing, isTabbed } = win
+
+    const ofWin = await fin.Window.wrap(win)
+    await ofWin.setBounds(win.bounds)
+
+    if (isTabbed) {
+      await ofWin.show()
+      return
+    }
+
+    await ofWin.leaveGroup()
+
+    if (isShowing) {
+      if (win.state === openfinWindowStates.Normal) {
+        // Need to both restore and show because the restore function doesn't emit a `shown` or `show-requested` event
+        await ofWin.restore()
+        await ofWin.show()
+      } else if (win.state === openfinWindowStates.Minimized) {
+        await ofWin.minimize()
+      } else if (win.state === openfinWindowStates.Maximized) {
+        await ofWin.maximize()
+      }
+    } else {
+      await ofWin.hide()
+    }
+  } catch (e) {
+    console.error('position window error', e)
+  }
+}
+
+export const saveWorkspace = async () => {
+  const workspace = await workspaces.generate()
+  window.localStorage.setItem('workspace', JSON.stringify(workspace))
+}
+
+export const getWorkspace = (): Workspace | null => {
+  const workspace = window.localStorage.getItem('workspace')
+
+  if (!workspace) {
+    return null
+  }
+
+  return JSON.parse(workspace)
+}
+
+export const restoreWorkspace = () => {
+  const workspace = getWorkspace()
+
+  if (!workspace) {
+    return
+  }
+
+  workspaces.restore(workspace)
+}

--- a/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
@@ -1,8 +1,8 @@
-import { openfinWindowStates, openDesktopWindow } from './window'
 import { workspaces } from 'openfin-layouts'
+import { Workspace } from 'openfin-layouts/dist/client/workspaces'
+import { openfinWindowStates, openDesktopWindow } from './window'
 import { Observable } from 'rxjs'
 import { WindowConfig } from 'rt-platforms'
-import { Workspace } from 'openfin-layouts/dist/client/workspaces'
 
 interface WinProps {
   name: string
@@ -95,13 +95,15 @@ async function positionWindow(win: workspaces.WorkspaceWindow): Promise<void> {
   }
 }
 
+const LS_WORKSPACE_KEY = 'workspace'
+
 export const saveWorkspace = async () => {
   const workspace = await workspaces.generate()
-  window.localStorage.setItem('workspace', JSON.stringify(workspace))
+  window.localStorage.setItem(LS_WORKSPACE_KEY, JSON.stringify(workspace))
 }
 
 export const getWorkspace = (): Workspace | null => {
-  const workspace = window.localStorage.getItem('workspace')
+  const workspace = window.localStorage.getItem(LS_WORKSPACE_KEY)
 
   if (!workspace) {
     return null

--- a/src/client/src/rt-platforms/openFin/index.ts
+++ b/src/client/src/rt-platforms/openFin/index.ts
@@ -1,4 +1,4 @@
-export { OpenFin, setupWorkspaces, openDesktopWindow } from './adapter'
+export { OpenFin, openDesktopWindow } from './adapter'
 export { OpenFinLimitChecker } from './limitChecker/openFin'
 export { OpenFinHeader } from './components'
 export * from './excel'


### PR DESCRIPTION
* Ensures workspace handlers (eg `setRestoreHandler`)  are setup properly on boot
* Persists workspace object to local storage on relevant application events eg resize, move, minimise, etc