### PR TITLE
fix(client): add decorator knobs in spottile storybook

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/stories/Initialise.stories.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/stories/Initialise.stories.tsx
@@ -14,12 +14,12 @@ export const Centered = styled('div')`
 
 export const Story: React.FC = ({ children }) => <BaseStory>{children}</BaseStory>
 
-export const stories = storiesOf('Spot Tile', module)
-export const priceStories = storiesOf('Spot Tile.Components.Price', module)
-export const rfqStories = storiesOf('Spot Tile.Components.RFQ', module)
-export const notionalStories = storiesOf('Spot Tile.Components.Notional', module)
-export const analyticsTileStories = storiesOf('Spot Tile.Vertical', module)
-export const spotTileStories = storiesOf('Spot Tile.Horizontal', module)
-export const componentStories = storiesOf('Spot Tile.Components', module)
-
-stories.addDecorator(withKnobs)
+export const stories = storiesOf('Spot Tile', module).addDecorator(withKnobs)
+export const priceStories = storiesOf('Spot Tile.Components.Price', module).addDecorator(withKnobs)
+export const rfqStories = storiesOf('Spot Tile.Components.RFQ', module).addDecorator(withKnobs)
+export const notionalStories = storiesOf('Spot Tile.Components.Notional', module).addDecorator(
+  withKnobs,
+)
+export const analyticsTileStories = storiesOf('Spot Tile.Vertical', module).addDecorator(withKnobs)
+export const spotTileStories = storiesOf('Spot Tile.Horizontal', module).addDecorator(withKnobs)
+export const componentStories = storiesOf('Spot Tile.Components', module).addDecorator(withKnobs)

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -8,7 +8,7 @@ import { ExternalWindowProps } from './selectors'
 
 const WorkspaceItems = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   grid-gap: 0.25rem;
 `
 


### PR DESCRIPTION
change from 

![image](https://user-images.githubusercontent.com/21157158/73259728-50012500-41c0-11ea-9136-8cf4734a284a.png)

to:

![image](https://user-images.githubusercontent.com/21157158/73259767-627b5e80-41c0-11ea-9c5c-5adeea6cd153.png)

