### PR TITLE
Client - Add yellow accent to trade notification [ARTP-941]

### DIFF
--- a/src/client/src/apps/MainRoute/components/notification/TradeNotification.stories.tsx
+++ b/src/client/src/apps/MainRoute/components/notification/TradeNotification.stories.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { Story, Centered } from 'rt-storybook'
 import { storiesOf } from '@storybook/react'
-import TileNotification from 'apps/MainRoute/widgets/spotTile/components/notifications/TileNotification'
+import TileNotification, {
+  NotificationType,
+} from 'apps/MainRoute/widgets/spotTile/components/notifications/TileNotification'
 import TileExecuted from 'apps/MainRoute/widgets/spotTile/components/notifications/TileExecuted'
 import {
   currencyPair,
@@ -23,10 +25,10 @@ stories.add('Executed', () => (
     <Centered>
       <TileNotification
         style={style}
-        isWarning={false}
         symbols={symbols}
         tradeId={trade.tradeId}
         handleClick={onNotificationDismissedClick}
+        type={NotificationType.Success}
       >
         <TileExecuted
           direction={trade.direction}
@@ -46,10 +48,10 @@ stories.add('Rejected', () => (
     <Centered>
       <TileNotification
         style={style}
-        isWarning={true}
         symbols={symbols}
         tradeId={trade.tradeId}
         handleClick={onNotificationDismissedClick}
+        type={NotificationType.Error}
       >
         Your trade has been rejected
       </TileNotification>
@@ -60,7 +62,7 @@ stories.add('Rejected', () => (
 stories.add('Warning: Execution longer', () => (
   <Story>
     <Centered>
-      <TileNotification style={style} symbols={symbols} isWarning={true}>
+      <TileNotification style={style} symbols={symbols} type={NotificationType.Warning}>
         Trade Execution taking longer then Expected
       </TileNotification>
     </Centered>
@@ -70,7 +72,7 @@ stories.add('Warning: Execution longer', () => (
 stories.add('Warning: Timeout', () => (
   <Story>
     <Centered>
-      <TileNotification style={style} symbols={symbols} isWarning={true}>
+      <TileNotification style={style} symbols={symbols} type={NotificationType.Warning}>
         Trade execution timeout exceeded
       </TileNotification>
     </Centered>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/NotificationContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/NotificationContainer.tsx
@@ -3,7 +3,7 @@ import { Transition } from 'react-spring'
 import { CurrencyPair, TradeStatus } from 'rt-types'
 import { LastTradeExecutionStatus } from '../../model/spotTileData'
 import TileExecuted from './TileExecuted'
-import TileNotification from './TileNotification'
+import TileNotification, { NotificationType } from './TileNotification'
 
 interface Props {
   lastTradeExecutionStatus?: LastTradeExecutionStatus | null
@@ -35,7 +35,7 @@ export default class NotificationContainer extends PureComponent<Props> {
     }
     if (lastTradeExecutionStatus.hasError) {
       return (style: React.CSSProperties) => (
-        <TileNotification style={style} symbols={symbols} isWarning={true}>
+        <TileNotification style={style} symbols={symbols} type={NotificationType.Warning}>
           {lastTradeExecutionStatus.error}
         </TileNotification>
       )
@@ -50,10 +50,10 @@ export default class NotificationContainer extends PureComponent<Props> {
         return (style: React.CSSProperties) => (
           <TileNotification
             style={style}
-            isWarning={false}
             symbols={symbols}
             tradeId={tradeId}
             handleClick={onNotificationDismissed}
+            type={NotificationType.Success}
           >
             <TileExecuted
               direction={direction}
@@ -70,10 +70,10 @@ export default class NotificationContainer extends PureComponent<Props> {
         return (style: React.CSSProperties) => (
           <TileNotification
             style={style}
-            isWarning={true}
             symbols={symbols}
             tradeId={tradeId}
             handleClick={onNotificationDismissed}
+            type={NotificationType.Error}
           >
             Your trade has been rejected
           </TileNotification>

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import { styled } from 'rt-theme'
 import { Button, Icon, TileBaseStyle } from '../styled'
 
-type AccentColor = 'red' | 'green'
+export enum NotificationType {
+  Error = 'red',
+  Success = 'green',
+  Warning = 'yellow',
+}
+
+type AccentColor = NotificationType.Error | NotificationType.Success | NotificationType.Warning
 
 export const TileNotificationStyle = styled(TileBaseStyle)<{ accentColor: AccentColor }>`
   color: ${({ theme }) => theme.template.white.normal};
@@ -51,42 +57,40 @@ const Content = styled.div`
 
 interface Props {
   style: React.CSSProperties
-  isWarning: boolean
   symbols: string
   children: React.ReactNode
   tradeId?: number
   handleClick?: () => void
+  type: NotificationType
 }
 
 const TileNotification: React.FC<Props> = ({
   style,
-  isWarning,
   symbols,
   tradeId,
   handleClick,
   children,
+  type,
 }) => {
-  const accentColor = isWarning ? 'red' : 'green'
-
   return (
     <TileNotificationStyle
-      accentColor={accentColor}
+      accentColor={type}
       style={style}
       data-qa="tile-notification__trade-notification"
     >
       <TradeSymbol>
-        {isWarning ? (
+        {type === NotificationType.Success ? (
+          <CheckIcon
+            className="fas fa-check"
+            aria-hidden="true"
+            data-qa="tile-notification__check-icon"
+          />
+        ) : (
           <Icon
             color="white"
             className="fas fa-lg fa-exclamation-triangle"
             aria-hidden="true"
             data-qa="tile-notification__warning-icon"
-          />
-        ) : (
-          <CheckIcon
-            className="fas fa-check"
-            aria-hidden="true"
-            data-qa="tile-notification__check-icon"
           />
         )}
         <HeavyFont data-qa="tile-notification__symbols">{symbols}</HeavyFont>
@@ -95,7 +99,7 @@ const TileNotification: React.FC<Props> = ({
       <Content data-qa="tile-notification__content">{children}</Content>
       {(handleClick && (
         <PillButton
-          accentColor={accentColor}
+          accentColor={type}
           onClick={handleClick}
           data-qa="tile-notification__pill-button"
         >


### PR DESCRIPTION
* Trades that have an error during execution are now highlighted yellow instead of red e.g a trade taking longer that expected to execute
* Trades that fail remain red
* Trades that succeed remain green

<img width="356" alt="Screenshot 2020-01-30 at 13 49 52" src="https://user-images.githubusercontent.com/156303/73455280-a0ff4d80-4367-11ea-9b79-1f02781f22bb.png">
<img width="345" alt="Screenshot 2020-01-30 at 13 49 58" src="https://user-images.githubusercontent.com/156303/73455286-a361a780-4367-11ea-9ea1-8cba09934722.png">
<img width="341" alt="Screenshot 2020-01-30 at 13 50 03" src="https://user-images.githubusercontent.com/156303/73455297-a78dc500-4367-11ea-8ec8-af2013114b69.png">
