### PR TITLE
fix(client): keep blotter row transition consistent

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
@@ -23,6 +23,10 @@ export default styled('div')`
     background-color: ${({ theme }) => theme.core.alternateBackground};
   }
 
+  .ag-row-no-animation .ag-row {
+    transition: background-color 0.2s ease;
+  }
+
   .rt-blotter__row-pending {
     background-color: ${({ theme }) => theme.core.offBackground};
   }


### PR DESCRIPTION
This PR is to allow the row to have the same transition of background colour when the theme changes