### PR TITLE
fix(client): trade confirmation lag time(ARTP-994)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/epics/spotTileEpics.ts
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/epics/spotTileEpics.ts
@@ -7,14 +7,18 @@ import { SpotTileActions, TILE_ACTION_TYPES } from '../actions'
 import { ExecuteTradeRequest, ExecuteTradeResponse } from '../model/executeTradeRequest'
 import ExecutionService from './executionService'
 
-const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 6000
+const DISMISS_NOTIFICATION_AFTER_X_IN_MS = 3000
 
 const { executeTrade, tradeExecuted } = SpotTileActions
 type ExecutionAction = ReturnType<typeof executeTrade>
 
 export type ExecutedTradeAction = ReturnType<typeof tradeExecuted>
 
-const executeTradeEpic: ApplicationEpic = (action$, state$, { loadBalancedServiceStub, limitChecker }) => {
+const executeTradeEpic: ApplicationEpic = (
+  action$,
+  state$,
+  { loadBalancedServiceStub, limitChecker },
+) => {
   const limitCheck = (executeTradeRequest: ExecuteTradeRequest) =>
     limitChecker.rpc({
       tradedCurrencyPair: executeTradeRequest.CurrencyPair,


### PR DESCRIPTION

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/21157158/74543017-91256300-4f3c-11ea-9b9b-15d78176d825.gif)
- previously the dismiss notification time was too long so if we place another trade quicker enough it will cause the second trade has a 2 second lag before confirmation.