### PR TITLE
Fix opening a spot tile in glue

### DIFF
--- a/src/client/src/rt-platforms/glue/window.ts
+++ b/src/client/src/rt-platforms/glue/window.ts
@@ -79,7 +79,7 @@ export const openGlueWindow = async (config: BrowserWindowProps, onClose?: () =>
     relativeTo,
     relativeDirection,
   } = calculatePosition(myWindow, width, height, url)
-  const fullUrl = `${location.href.slice(0, -1)}${url}`
+  const fullUrl = `${location.origin}${url}`
   const isTabWindow = isSpot(url)
 
   const win = await window.glue.windows.open(name, fullUrl, {


### PR DESCRIPTION
External spot tiles where showing as blank because of the way URLs were created, which appears to have been broken when the app started loading on a non-root path (it seems that / has started redirecting to /ALL/Analytics)