### PR TITLE
fix(openfin): make sure undock icon is available when reloaded (ARTP-1016)

### DIFF
--- a/src/client/src/rt-components/icons/UndockIcon.tsx
+++ b/src/client/src/rt-components/icons/UndockIcon.tsx
@@ -1,35 +1,18 @@
 import React from 'react'
-import { IconStateTypes } from './types'
 interface Props {
   width: number
   height: number
-  iconState: IconStateTypes
 }
 
 const UndockIcon: React.FC<Props> = props => {
-  const { width, height, iconState } = props
-
-  const IconState = {
-    [IconStateTypes.Normal]: {
-      pathFillFirst: "#7E8188",
-      pathFillSecond: "#535760"
-    },
-    [IconStateTypes.Hover]: {
-      pathFillFirst: "#5F94F5",
-      pathFillSecond: "#535760"
-    },
-    [IconStateTypes.Disabled]: {
-      pathFillFirst: "#535760",
-      pathFillSecond: "#3D424C"
-    }
-  }
+  const { width, height } = props
 
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 24 24">
-      <g fill="none" fillRule="evenodd">
+      <g className="icon" fill="none" fillRule="evenodd">
         <path d="M0 0H24V24H0z" />
-        <path fill={IconState[iconState].pathFillFirst} d="M18 5a2 2 0 012 2v4h-6V5h4zm-3 5h4V7a1 1 0 00-.883-.993L18 6h-3v4z" />
-        <path fill={IconState[iconState].pathFillSecond} d="M5 9a2 2 0 012-2h5v6h6v4a3 3 0 01-3 3H7a2 2 0 01-2-2V9zm6 5H6v4a1 1 0 00.883.993L7 19h4v-5zm6 0h-5v5h3a2 2 0 001.995-1.85L17 17v-3zm-6-6H7a1 1 0 00-.993.883L6 9v4h5V8z" />
+        <path fill="#7E8188" d="M18 5a2 2 0 012 2v4h-6V5h4zm-3 5h4V7a1 1 0 00-.883-.993L18 6h-3v4z" />
+        <path fill="#535760" d="M5 9a2 2 0 012-2h5v6h6v4a3 3 0 01-3 3H7a2 2 0 01-2-2V9zm6 5H6v4a1 1 0 00.883.993L7 19h4v-5zm6 0h-5v5h3a2 2 0 001.995-1.85L17 17v-3zm-6-6H7a1 1 0 00-.993.883L6 9v4h5V8z" />
       </g>
     </svg>
   )

--- a/src/client/src/rt-platforms/openFin/adapter/index.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/index.ts
@@ -1,4 +1,4 @@
 export { default as OpenFin } from './openFin'
-export { openDesktopWindow } from './window'
+export { openDesktopWindow, isCurrentWindowDocked } from './window'
 export { createExcelApp } from '../../excelApp'
 export { platformEpics } from './epics'

--- a/src/client/src/rt-platforms/openFin/adapter/openFin.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/openFin.ts
@@ -30,7 +30,6 @@ export default class OpenFin implements Platform {
 
   constructor() {
     window.addEventListener('beforeunload', this.handleWindowUnload)
-
     addEventListener('notification-action', this.handleNotificationAction)
   }
 
@@ -141,6 +140,7 @@ export default class OpenFin implements Platform {
 
   handleWindowUnload = () => {
     removeEventListener('notification-action', this.handleNotificationAction)
+    window.removeEventListener('beforeunload', this.handleWindowUnload)
   }
 
   epics: Array<ApplicationEpic> = platformEpics

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -2,6 +2,7 @@
 import { WindowConfig } from '../../types'
 import { get as _get, last as _last } from 'lodash'
 import { PlatformWindow } from '../../platformWindow'
+import { snapAndDock } from 'openfin-layouts'
 
 const TEAR_OUT_OFFSET_LEFT = 50
 const TEAR_OUT_OFFSET_TOP = 50
@@ -20,7 +21,7 @@ export const openfinWindowStates: { readonly [key: string]: WindowState } = {
   Maximized: 'maximized',
 }
 
-const generateRandomName = function() {
+const generateRandomName = function () {
   let text = ''
   const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
@@ -167,3 +168,28 @@ export const addApplicationEventHandler = (event: string) => (handler: Function)
 
   app.addListener(event, handler as () => any)
 }
+
+
+export async function isCurrentWindowDocked() {
+  const currentWindow = await fin.Window.getCurrent()
+  const dockedWindows = await snapAndDock.getDockedWindows(currentWindow.identity)
+
+  const { name, uuid } = currentWindow.identity
+
+  if (!dockedWindows) {
+    return false
+  }
+
+  return dockedWindows.reduce((hasIdentity, window) => {
+    if (Array.isArray(window)) {
+      return false
+    }
+
+    if (window.name === name && window.uuid === uuid) {
+      hasIdentity = hasIdentity || true
+    }
+
+    return hasIdentity
+  }, false)
+}
+

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -21,7 +21,7 @@ export const openfinWindowStates: { readonly [key: string]: WindowState } = {
   Maximized: 'maximized',
 }
 
-const generateRandomName = function () {
+const generateRandomName = function() {
   let text = ''
   const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
@@ -168,7 +168,6 @@ export const addApplicationEventHandler = (event: string) => (handler: Function)
 
   app.addListener(event, handler as () => any)
 }
-
 
 export async function isCurrentWindowDocked() {
   const currentWindow = await fin.Window.getCurrent()

--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useState, useCallback } from 'react'
 import { Helmet } from 'react-helmet'
 import { snapAndDock } from 'openfin-layouts'
 import { styled, AccentName } from 'rt-theme'
-import { UndockIcon, IconStateTypes } from '../../../rt-components'
 import {
   minimiseNormalIcon,
   maximiseScreenIcon,
   exitNormalIcon,
   popInIcon,
 } from 'apps/SimpleLauncher/icons'
+import { isCurrentWindowDocked } from '../adapter'
+import { UndockIcon } from '../../../rt-components'
 
 export interface ControlProps {
   minimize?: () => void
@@ -69,7 +70,6 @@ export const OpenFinControls: React.FC<ControlProps> = ({ minimize, maximize, cl
 
 const OpenFinUndockControl: React.FC = () => {
   const [isWindowDocked, setIsWindowDocked] = useState(false)
-  const [iconState, setIconState] = useState(IconStateTypes.Normal)
 
   useEffect(() => {
     const handleWindowDocked = () => {
@@ -78,12 +78,20 @@ const OpenFinUndockControl: React.FC = () => {
 
     snapAndDock.addEventListener('window-docked', handleWindowDocked)
 
-    return () => snapAndDock.removeEventListener('window-docked', handleWindowDocked)
+    return () => {
+      snapAndDock.removeEventListener('window-docked', handleWindowDocked)
+    }
+  }, [])
+
+  useEffect(() => {
+    isCurrentWindowDocked()
+      .then(isDocked => {
+        setIsWindowDocked(isDocked)
+      })
   }, [])
 
   const handleUndockClick = useCallback(() => {
     snapAndDock.undockWindow()
-    setIconState(IconStateTypes.Normal)
     setIsWindowDocked(false)
   }, [])
 
@@ -92,10 +100,8 @@ const OpenFinUndockControl: React.FC = () => {
       {isWindowDocked && (
         <UndockButton
           onClick={handleUndockClick}
-          onMouseEnter={() => setIconState(IconStateTypes.Hover)}
-          onMouseLeave={() => setIconState(IconStateTypes.Normal)}
         >
-          <UndockIcon width={24} height={24} iconState={iconState} />
+          <UndockIcon width={24} height={24} />
         </UndockButton>
       )}
     </>
@@ -138,6 +144,28 @@ const UndockButton = styled.button`
   width: max-content;
   padding-left: 0.625rem;
   cursor: pointer;
+
+  &:hover {
+    .icon {
+      path:nth-child(2) {
+        fill: #5F94F5;
+      }
+      path:last-child {
+        fill: #535760;
+      }
+    }
+  }
+
+  &:disabled {
+    .icon {
+      path:nth-child(2) {
+        fill: #535760;
+      }
+      path:last-child {
+        fill: #3D424C;
+      }
+    }
+  }
 `
 
 export const Root = styled.div`


### PR DESCRIPTION
This PR is to fix the behaviour where after the popped out window tile is reloaded and missing the undock button while it is docked.