### PR TITLE
fix(launcher): reset bound size before unload (ARTP-1028)

### DIFF
--- a/src/client/src/apps/SimpleLauncher/Launcher.tsx
+++ b/src/client/src/apps/SimpleLauncher/Launcher.tsx
@@ -23,6 +23,7 @@ import {
   closeCurrentWindow,
   getCurrentWindowBounds,
   minimiseCurrentWindow,
+  useAppBoundReset,
 } from './windowUtils'
 import { Response, getInlineSuggestionsComponent } from './spotlight'
 import Measure, { ContentRect } from 'react-measure'
@@ -69,15 +70,13 @@ export const Launcher: React.FC = () => {
   const platform = usePlatform()
   const [contacting, response, sendRequest] = useNlpService()
 
+  useAppBoundReset(initialBounds)
+
   useEffect(() => {
     getCurrentWindowBounds()
       .then(setInitialBounds)
       .catch(console.error)
   }, [])
-
-  const showSearch = useCallback(() => {
-    setIsSearchVisible(!isSearchVisible)
-  }, [isSearchVisible])
 
   // if search is made visible - focus on it
   useEffect(() => {
@@ -96,6 +95,10 @@ export const Launcher: React.FC = () => {
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [])
+
+  const showSearch = useCallback(() => {
+    setIsSearchVisible(!isSearchVisible)
+  }, [isSearchVisible])
 
   const handleSearchStateChange = useCallback((isTyping: boolean) => setIsSearchBusy(isTyping), [])
 

--- a/src/client/src/apps/SimpleLauncher/windowUtils.ts
+++ b/src/client/src/apps/SimpleLauncher/windowUtils.ts
@@ -1,4 +1,5 @@
 import { Bounds } from 'openfin/_v2/shapes'
+import { useLayoutEffect } from 'react'
 
 export async function animateCurrentWindowSize(bounds: Bounds, duration: number = 200) {
   const window = await fin.Window.getCurrent()
@@ -30,4 +31,26 @@ export const closeCurrentWindow = async () => {
 export const minimiseCurrentWindow = async () => {
   const window = await fin.Window.getCurrent()
   window.minimize()
+}
+
+export const useAppBoundReset = (bounds: Bounds | undefined) => {
+  const app = fin.desktop.Application.getCurrent()
+
+  useLayoutEffect(() => {
+    if (!bounds) {
+      return
+    }
+
+    const resetAppBound = () => {
+      animateCurrentWindowSize({
+        ...bounds,
+      })
+    }
+
+    app.addEventListener('window-start-load', resetAppBound)
+
+    return () => {
+      app.removeEventListener('window-start-load', resetAppBound)
+    }
+  }, [app, bounds])
 }


### PR DESCRIPTION
before: when reload with result 
![Annotation 2020-02-26 154746](https://user-images.githubusercontent.com/26205511/75361681-99bc5880-58af-11ea-9e87-f9b604034fcd.png)

after: when reload with result 
![Annotation 2020-02-25 163500](https://user-images.githubusercontent.com/26205511/75361683-9a54ef00-58af-11ea-9b5d-068f39d7b067.png)
