### PR TITLE
Feat/styleguide theme

### DIFF
--- a/src/client/src/apps/MainRoute/components/notification/styled.tsx
+++ b/src/client/src/apps/MainRoute/components/notification/styled.tsx
@@ -23,7 +23,7 @@ export const Traded = styled('div')<{ isDone: boolean }>`
 `
 
 export const Status = styled('div')<{ isDone: boolean }>`
-  color: ${({ theme, isDone }) => !isDone && theme.accents.bad.base};
+  color: ${({ theme, isDone }) => !isDone && theme.accents.error.base};
 `
 
 export const Bottom = styled(Flex)``

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/LastPosition.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/LastPosition.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import numeral from 'numeral'
 import { styled } from 'rt-theme'
 
-type Accents = 'good' | 'bad'
+type Accents = 'success' | 'error'
 
 const USDspan = styled.span`
   opacity: 0.6;
@@ -24,7 +24,7 @@ interface FormattedLastPosition {
 
 const lastPositionColor: (lastPos: number) => FormattedLastPosition = (lastPos: number) => {
   const lastPosition = lastPos >= 0 ? '+' + numeral(lastPos).format() : numeral(lastPos).format()
-  const color: Accents = lastPos >= 0 ? 'good' : 'bad'
+  const color: Accents = lastPos >= 0 ? 'success' : 'error'
   return { color, lastPosition }
 }
 

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/LastPosition.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/LastPosition.tsx
@@ -2,16 +2,16 @@ import React from 'react'
 import numeral from 'numeral'
 import { styled } from 'rt-theme'
 
-type Colors = 'green' | 'red'
+type Accents = 'good' | 'bad'
 
 const USDspan = styled.span`
   opacity: 0.6;
   font-size: 14px;
   margin-right: 10px;
 `
-const LastPositionStyle = styled.span<{ color: Colors }>`
+const LastPositionStyle = styled.span<{ color: Accents }>`
   font-size: 14px;
-  color: ${({ theme, color }) => theme.template[color].normal};
+  color: ${({ theme, color }) => theme.accents[color].base};
 `
 interface LastPositionProps {
   lastPos?: number | undefined
@@ -19,12 +19,12 @@ interface LastPositionProps {
 
 interface FormattedLastPosition {
   lastPosition: string
-  color: Colors
+  color: Accents
 }
 
 const lastPositionColor: (lastPos: number) => FormattedLastPosition = (lastPos: number) => {
   const lastPosition = lastPos >= 0 ? '+' + numeral(lastPos).format() : numeral(lastPos).format()
-  const color: Colors = lastPos >= 0 ? 'green' : 'red'
+  const color: Accents = lastPos >= 0 ? 'good' : 'bad'
   return { color, lastPosition }
 }
 

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
@@ -28,7 +28,7 @@ const getLogRatio: (max: number, numb: number) => number = (max, numb) => {
 
 const PNLBar: React.FC<PNLBarProps> = ({ symbol, basePnl, maxVal }) => {
   const [hovering, setHovering] = useState(false)
-  const color = basePnl >= 0 ? 'green' : 'red'
+  const color = basePnl >= 0 ? 'good' : 'bad'
   const distance = getLogRatio(maxVal, basePnl) * TRANSLATION_WIDTH * (basePnl >= 0 ? 1 : -1)
   const price = numeral(Math.abs(basePnl)).format('0a')
   const hoverPrice = numeral(basePnl).format('0,0.00')

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/PNLBar.tsx
@@ -28,7 +28,7 @@ const getLogRatio: (max: number, numb: number) => number = (max, numb) => {
 
 const PNLBar: React.FC<PNLBarProps> = ({ symbol, basePnl, maxVal }) => {
   const [hovering, setHovering] = useState(false)
-  const color = basePnl >= 0 ? 'good' : 'bad'
+  const color = basePnl >= 0 ? 'success' : 'error'
   const distance = getLogRatio(maxVal, basePnl) * TRANSLATION_WIDTH * (basePnl >= 0 ? 1 : -1)
   const price = numeral(Math.abs(basePnl)).format('0a')
   const hoverPrice = numeral(basePnl).format('0,0.00')

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsBarChart/styled.tsx
@@ -33,7 +33,7 @@ export const PriceLabel = styled.div<{ color: string; distance: number }>`
   align-self: center;
   height: 1.1rem;
   transition: transform 0.2s;
-  color: ${({ theme, color }) => theme.template[color].normal};
+  color: ${({ theme, color }) => theme.accents[color].base};
   padding-bottom: 0px;
 
   &:hover {
@@ -46,7 +46,7 @@ export const DiamondShape = styled.div<{ color: string }>`
   width: 6px;
   height: 6px;
   transform: rotate(45deg);
-  background-color: ${({ theme, color }) => theme.template[color].normal};
+  background-color: ${({ theme, color }) => theme.accents[color].base};
 `
 export const Label = styled.div`
   flex: 0 0 60px;

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/analyticsLineChart/styled.tsx
@@ -29,10 +29,10 @@ export const ToolTipChildLeft = styled.div`
   width: 70px;
   opacity: 0.6;
   font-size: 10px;
-  color: ${({ theme }) => theme.template.white.dark};
+  color: ${({ theme }) => theme.white};
 `
 export const ToolTipChildRight = styled.div`
   width: 30px;
   font-size: 10px;
-  color: ${({ theme }) => theme.template.white.normal};
+  color: ${({ theme }) => theme.white};
 `

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/positions-chart/PositionsBubbleChart.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/positions-chart/PositionsBubbleChart.tsx
@@ -122,7 +122,7 @@ export class PositionsBubbleChart extends Component<
     const positionsData: CCYPosition[] = getPositionsDataFromSeries(data, this.props.currencyPairs)
     nodes = map(positionsData, (dataObj: CCYPosition, index: number) => {
       const color =
-        dataObj.baseTradedAmount > 0 ? colors.accents.good.base : colors.accents.bad.base
+        dataObj.baseTradedAmount > 0 ? colors.accents.success.base : colors.accents.error.base
       // update an existing node:
       const existingNode = find(nodes, (node: BubbleChartNode) => node.id === dataObj.symbol)
       if (existingNode) {

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
@@ -80,23 +80,23 @@ export const AnalyticsStyle = styled.div<{ inExternalWindow?: boolean }>`
 
   .stop1,
   .lineStop1 {
-    stop-color: ${({ theme }) => theme.accents.good.base};
+    stop-color: ${({ theme }) => theme.accents.success.base};
     stop-opacity: 0.5;
   }
 
   .stop1End,
   .lineStop1End {
-    stop-color: ${({ theme }) => theme.accents.good.base};
+    stop-color: ${({ theme }) => theme.accents.success.base};
   }
 
   .stop2,
   .lineStop2 {
-    stop-color: ${({ theme }) => theme.accents.bad.base};
+    stop-color: ${({ theme }) => theme.accents.error.base};
   }
 
   .stop2End,
   .lineStop2End {
-    stop-color: ${({ theme }) => theme.accents.bad.base};
+    stop-color: ${({ theme }) => theme.accents.error.base};
     stop-opacity: 0.5;
   }
 `

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
@@ -7,9 +7,11 @@ export const AnalyticsWrapper = styled.div`
   max-width: 60rem;
   min-width: 20rem;
   margin: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   position: relative;
+  display: grid;
+  grid-template-rows: 46px auto;
 `
 
 export const AnalyticsHeader = styled.header`
@@ -62,7 +64,7 @@ export const AnalyticsStyle = styled.div<{ inExternalWindow?: boolean }>`
   }
 
   .analytics__positions-label {
-    fill: ${({ theme }) => theme.template.white.normal};
+    fill: ${({ theme }) => theme.white};
     font-size: 0.6875rem;
     pointer-events: none;
     user-select: none;
@@ -78,23 +80,23 @@ export const AnalyticsStyle = styled.div<{ inExternalWindow?: boolean }>`
 
   .stop1,
   .lineStop1 {
-    stop-color: ${({ theme }) => theme.template.green.normal};
+    stop-color: ${({ theme }) => theme.accents.good.base};
     stop-opacity: 0.5;
   }
 
   .stop1End,
   .lineStop1End {
-    stop-color: ${({ theme }) => theme.template.green.normal};
+    stop-color: ${({ theme }) => theme.accents.good.base};
   }
 
   .stop2,
   .lineStop2 {
-    stop-color: ${({ theme }) => theme.template.red.normal};
+    stop-color: ${({ theme }) => theme.accents.bad.base};
   }
 
   .stop2End,
   .lineStop2End {
-    stop-color: ${({ theme }) => theme.template.red.normal};
+    stop-color: ${({ theme }) => theme.accents.bad.base};
     stop-opacity: 0.5;
   }
 `

--- a/src/client/src/apps/MainRoute/widgets/analytics/globals/variables.ts
+++ b/src/client/src/apps/MainRoute/widgets/analytics/globals/variables.ts
@@ -5,8 +5,8 @@ export const transparentColor = rgba(colors.spectrum.offblack.base, 0)
 export const strokeColor = transparentColor
 export const gray = rgba(transparentColor, 0.5)
 
-export const positiveColor = colors.accents.good.base
-export const negativeColor = colors.accents.bad.base
+export const positiveColor = colors.accents.success.base
+export const negativeColor = colors.accents.error.base
 export const barBgColor = 'currentColor'
 export const pointerColor = 'currentColor'
 

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
@@ -39,14 +39,14 @@ export default styled('div')`
     width: 0.3125rem !important;
     padding: 0;
     margin: 0;
-    background-color: ${({ theme }) => theme.accents.good.base};
+    background-color: ${({ theme }) => theme.accents.success.base};
   }
 
   .rt-blotter__status-indicator--rejected {
     width: 0.3125rem !important;
     padding: 0;
     margin: 0;
-    background-color: ${({ theme }) => theme.accents.bad.base};
+    background-color: ${({ theme }) => theme.accents.error.base};
   }
 
   .rt-blotter__cell-rejected,
@@ -60,7 +60,7 @@ export default styled('div')`
     position: absolute;
     top: 50%;
     left: 0;
-    border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.bad.base};
+    border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.error.base};
     width: 100%;
   }
 
@@ -145,7 +145,7 @@ export default styled('div')`
       outline: none;
 
       &:focus {
-        border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.dominant.base};
+        border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.primary.base};
       }
     }
 

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterGrid.tsx
@@ -39,14 +39,14 @@ export default styled('div')`
     width: 0.3125rem !important;
     padding: 0;
     margin: 0;
-    background-color: ${({ theme }) => theme.template.green.normal};
+    background-color: ${({ theme }) => theme.accents.good.base};
   }
 
   .rt-blotter__status-indicator--rejected {
     width: 0.3125rem !important;
     padding: 0;
     margin: 0;
-    background-color: ${({ theme }) => theme.template.red.normal};
+    background-color: ${({ theme }) => theme.accents.bad.base};
   }
 
   .rt-blotter__cell-rejected,
@@ -60,7 +60,7 @@ export default styled('div')`
     position: absolute;
     top: 50%;
     left: 0;
-    border-bottom: 0.0625rem solid ${({ theme }) => theme.template.red.normal};
+    border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.bad.base};
     width: 100%;
   }
 
@@ -145,7 +145,7 @@ export default styled('div')`
       outline: none;
 
       &:focus {
-        border-bottom: 0.0625rem solid ${({ theme }) => theme.template.blue.normal};
+        border-bottom: 0.0625rem solid ${({ theme }) => theme.accents.dominant.base};
       }
     }
 

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/toolbar/QuickFilter.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/toolbar/QuickFilter.tsx
@@ -28,11 +28,11 @@ const QuickFilterInput = styled('input')`
 
   &:hover {
     opacity: 1;
-    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.dominant.lighter};
+    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.primary.lighter};
   }
 
   &:focus {
-    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.dominant.base};
+    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.primary.base};
     color: ${({ theme }) => theme.core.textColor};
     opacity: 1;
   }

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/toolbar/QuickFilter.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/toolbar/QuickFilter.tsx
@@ -28,11 +28,11 @@ const QuickFilterInput = styled('input')`
 
   &:hover {
     opacity: 1;
-    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.template.blue.light};
+    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.dominant.lighter};
   }
 
   &:focus {
-    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.template.blue.normal};
+    box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.accents.dominant.base};
     color: ${({ theme }) => theme.core.textColor};
     opacity: 1;
   }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceButton/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceButton/styled.tsx
@@ -2,11 +2,6 @@ import { styled, Theme } from 'rt-theme'
 import { Direction } from 'rt-types'
 import { keyframes, css } from 'styled-components'
 
-const hoverColors = {
-  [Direction.Buy]: 'blue',
-  [Direction.Sell]: 'red',
-}
-
 const backgroundEffectKeyframes = ({
   direction,
   theme,
@@ -15,11 +10,11 @@ const backgroundEffectKeyframes = ({
   theme: Theme
 }) => keyframes`
   5% {
-    background-color: ${theme.template[hoverColors[direction]].normal};
+    background-color: ${theme.colors.spectrum.uniqueCollections[direction].base};
     color: white;
   }
   80% {
-    background-color: ${theme.template[hoverColors[direction]].normal};
+    background-color: ${theme.colors.spectrum.uniqueCollections[direction].base};
     color: white;
   }
 `
@@ -40,7 +35,7 @@ export const TradeButton = styled.button<{
   background-color: ${({ theme }) => theme.core.lightBackground};
   border-radius: 3px;
   color: ${({ theme, priceAnnounced, direction }) =>
-    priceAnnounced ? theme.template[hoverColors[direction]].normal : 'inherit'};
+    priceAnnounced ? theme.colors.spectrum.uniqueCollections[direction].base : 'inherit'};
   transition: background-color 0.2s ease;
   cursor: pointer;
   border: none;
@@ -63,12 +58,12 @@ export const TradeButton = styled.button<{
     background-color: ${theme.core.darkBackground};
   }
   .spot-tile:hover &:hover {
-    background-color: ${theme.template[hoverColors[direction]].normal};
-    color: ${theme.template.white.normal};
+    background-color: ${theme.colors.spectrum.uniqueCollections[direction].base};
+    color: ${theme.white};
   }
   &:hover {
-    background-color: ${theme.template[hoverColors[direction]].normal};
-    color: ${theme.template.white.normal};
+    background-color: ${theme.colors.spectrum.uniqueCollections[direction].base};
+    color: ${theme.white};
   }
   `};
 `
@@ -117,7 +112,7 @@ export const BigWrapper = styled.div`
 `
 
 export const ExpiredPrice = styled.div`
-  color: ${({ theme }) => theme.template.red.normal};
+  color: ${({ theme }) => theme.colors.spectrum.uniqueCollections.Sell.base};
   font-size: 9px;
   text-transform: uppercase;
 `

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceControls/TileBookingSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceControls/TileBookingSwitch.tsx
@@ -31,7 +31,7 @@ const TileBookingSwitch: FC<Props> = ({
     <>
       <TileBooking
         show={isTradeExecutionInFlight}
-        color="blue"
+        color="dominant"
         showLoader
         isAnalyticsView={isAnalyticsView}
       >
@@ -39,7 +39,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={!isTradeExecutionInFlight && isRfqStateCanRequest}
-        color="blue"
+        color="dominant"
         showLoader={false}
         onBookingPillClick={() => rfq.request({ notional, currencyPair })}
         disabled={hasUserError}
@@ -49,7 +49,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={!isTradeExecutionInFlight && isRfqStateExpired}
-        color="blue"
+        color="dominant"
         showLoader={false}
         onBookingPillClick={() => rfq.requote({ notional, currencyPair })}
         isAnalyticsView={isAnalyticsView}
@@ -58,7 +58,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={isRfqStateRequested}
-        color="red"
+        color="bad"
         showLoader={false}
         onBookingPillClick={() => rfq.cancel({ currencyPair })}
         isAnalyticsView={isAnalyticsView}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceControls/TileBookingSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceControls/TileBookingSwitch.tsx
@@ -31,7 +31,7 @@ const TileBookingSwitch: FC<Props> = ({
     <>
       <TileBooking
         show={isTradeExecutionInFlight}
-        color="dominant"
+        color="primary"
         showLoader
         isAnalyticsView={isAnalyticsView}
       >
@@ -39,7 +39,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={!isTradeExecutionInFlight && isRfqStateCanRequest}
-        color="dominant"
+        color="primary"
         showLoader={false}
         onBookingPillClick={() => rfq.request({ notional, currencyPair })}
         disabled={hasUserError}
@@ -49,7 +49,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={!isTradeExecutionInFlight && isRfqStateExpired}
-        color="dominant"
+        color="primary"
         showLoader={false}
         onBookingPillClick={() => rfq.requote({ notional, currencyPair })}
         isAnalyticsView={isAnalyticsView}
@@ -58,7 +58,7 @@ const TileBookingSwitch: FC<Props> = ({
       </TileBooking>
       <TileBooking
         show={isRfqStateRequested}
-        color="bad"
+        color="error"
         showLoader={false}
         onBookingPillClick={() => rfq.cancel({ currencyPair })}
         isAnalyticsView={isAnalyticsView}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
@@ -13,7 +13,7 @@ interface Props {
 const MovementIcon = styled('i')<{ show: boolean; color: string }>`
   text-align: center;
   color: ${({ theme, color }) =>
-    color === 'none' ? theme.colors.light.secondary[4] : theme.template[color].normal};
+    color === 'none' ? theme.colors.light.secondary[4] : theme.accents[color].base};
   visibility: ${({ show }) => (show ? 'visible' : 'hidden')};
 `
 
@@ -46,7 +46,7 @@ const PriceMovement: React.FC<Props> = ({
     <MovementIcon
       data-qa="price-movement__movement-icon--up"
       show={show && priceMovementType === PriceMovementTypes.Up}
-      color={isInitiateRFQ ? 'none' : 'green'}
+      color={isInitiateRFQ ? 'none' : 'good'}
       className="fas fa-caret-up"
       aria-hidden="true"
     />
@@ -54,7 +54,7 @@ const PriceMovement: React.FC<Props> = ({
     <MovementIcon
       data-qa="price-movement__movement-icon--down"
       show={show && priceMovementType === PriceMovementTypes.Down}
-      color={isInitiateRFQ ? 'none' : 'red'}
+      color={isInitiateRFQ ? 'none' : 'bad'}
       className="fas fa-caret-down"
       aria-hidden="true"
     />

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/PriceMovement.tsx
@@ -46,7 +46,7 @@ const PriceMovement: React.FC<Props> = ({
     <MovementIcon
       data-qa="price-movement__movement-icon--up"
       show={show && priceMovementType === PriceMovementTypes.Up}
-      color={isInitiateRFQ ? 'none' : 'good'}
+      color={isInitiateRFQ ? 'none' : 'success'}
       className="fas fa-caret-up"
       aria-hidden="true"
     />
@@ -54,7 +54,7 @@ const PriceMovement: React.FC<Props> = ({
     <MovementIcon
       data-qa="price-movement__movement-icon--down"
       show={show && priceMovementType === PriceMovementTypes.Down}
-      color={isInitiateRFQ ? 'none' : 'bad'}
+      color={isInitiateRFQ ? 'none' : 'error'}
       className="fas fa-caret-down"
       aria-hidden="true"
     />

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
@@ -31,7 +31,7 @@ const ProgressBarWrapper = styled.div<{ isAnalyticsView: boolean }>`
 `
 
 const ProgressBar = styled.div`
-  background-color: ${({ theme }) => theme.template.blue.normal};
+  background-color: ${({ theme }) => theme.accents.dominant.base};
   border-radius: 3px;
   transition: width ${UPDATE_FREQ_MS}ms linear;
   height: 100%;

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/RfqTimer.tsx
@@ -31,7 +31,7 @@ const ProgressBarWrapper = styled.div<{ isAnalyticsView: boolean }>`
 `
 
 const ProgressBar = styled.div`
-  background-color: ${({ theme }) => theme.accents.dominant.base};
+  background-color: ${({ theme }) => theme.accents.primary.base};
   border-radius: 3px;
   transition: width ${UPDATE_FREQ_MS}ms linear;
   height: 100%;

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -123,13 +123,13 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 
 .c15 {
   text-align: center;
-  color: #28c988;
+  color: #01c38d;
   visibility: hidden;
 }
 
 .c17 {
   text-align: center;
-  color: #f94c4c;
+  color: #ff274b;
   visibility: visible;
 }
 
@@ -231,7 +231,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -253,7 +253,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c18 {
@@ -348,7 +348,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="green"
+            color="good"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -360,7 +360,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="red"
+            color="bad"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -479,7 +479,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -561,13 +561,13 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 
 .c15 {
   text-align: center;
-  color: #a1a5af;
+  color: #686d74;
   visibility: hidden;
 }
 
 .c17 {
   text-align: center;
-  color: #a1a5af;
+  color: #686d74;
   visibility: visible;
 }
 
@@ -659,11 +659,11 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 }
 
 .c19 rect {
-  fill: #ffffff;
+  fill: #fff;
 }
 
 .c20 {
-  color: #ffffff;
+  color: #fff;
   font-size: 0.6875rem;
 }
 
@@ -721,7 +721,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -743,7 +743,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c21 {
@@ -876,7 +876,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
         >
           <div
             className="c19"
-            color="blue"
+            color="dominant"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -1004,7 +1004,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -1085,20 +1085,20 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 }
 
 .c14 {
-  color: #f94c4c;
+  color: #ff274b;
   font-size: 9px;
   text-transform: uppercase;
 }
 
 .c16 {
   text-align: center;
-  color: #28c988;
+  color: #01c38d;
   visibility: hidden;
 }
 
 .c18 {
   text-align: center;
-  color: #f94c4c;
+  color: #ff274b;
   visibility: hidden;
 }
 
@@ -1190,11 +1190,11 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 }
 
 .c20 rect {
-  fill: #ffffff;
+  fill: #fff;
 }
 
 .c21 {
-  color: #ffffff;
+  color: #fff;
   font-size: 0.6875rem;
 }
 
@@ -1252,7 +1252,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1274,7 +1274,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c22 {
@@ -1387,7 +1387,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           <i
             aria-hidden="true"
             className="c16 fas fa-caret-up"
-            color="green"
+            color="good"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -1399,7 +1399,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           <i
             aria-hidden="true"
             className="c18 fas fa-caret-down"
-            color="red"
+            color="bad"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -1413,7 +1413,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
         >
           <div
             className="c20"
-            color="blue"
+            color="dominant"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -1548,9 +1548,9 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
-  color: #f94c4c;
+  color: #ff274b;
   -webkit-transition: background-color 0.2s ease;
   transition: background-color 0.2s ease;
   cursor: pointer;
@@ -1560,28 +1560,28 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   min-width: 125px;
   padding: 0.55rem 1.5rem 0.6rem 1.5rem;
   margin-bottom: 2px;
-  -webkit-animation: eJClnE 5s;
-  animation: eJClnE 5s;
+  -webkit-animation: dnMAbE 5s;
+  animation: dnMAbE 5s;
 }
 
 .spot-tile:hover .c7 {
-  background-color: #272d3a;
+  background-color: #282e39;
 }
 
 .spot-tile:hover .c7:hover {
-  background-color: #f94c4c;
-  color: #ffffff;
+  background-color: #ff274b;
+  color: #fff;
 }
 
 .c7:hover {
-  background-color: #f94c4c;
-  color: #ffffff;
+  background-color: #ff274b;
+  color: #fff;
 }
 
 .c18 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
-  color: #5f94f5;
+  color: #2d95ff;
   -webkit-transition: background-color 0.2s ease;
   transition: background-color 0.2s ease;
   cursor: pointer;
@@ -1591,22 +1591,22 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   min-width: 125px;
   padding: 0.55rem 1.5rem 0.6rem 1.5rem;
   margin-bottom: 2px;
-  -webkit-animation: eNgZhw 5s;
-  animation: eNgZhw 5s;
+  -webkit-animation: dQmnms 5s;
+  animation: dQmnms 5s;
 }
 
 .spot-tile:hover .c18 {
-  background-color: #272d3a;
+  background-color: #282e39;
 }
 
 .spot-tile:hover .c18:hover {
-  background-color: #5f94f5;
-  color: #ffffff;
+  background-color: #2d95ff;
+  color: #fff;
 }
 
 .c18:hover {
-  background-color: #5f94f5;
-  color: #ffffff;
+  background-color: #2d95ff;
+  color: #fff;
 }
 
 .c10 {
@@ -1674,13 +1674,13 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 
 .c15 {
   text-align: center;
-  color: #28c988;
+  color: #01c38d;
   visibility: hidden;
 }
 
 .c17 {
   text-align: center;
-  color: #f94c4c;
+  color: #ff274b;
   visibility: hidden;
 }
 
@@ -1782,7 +1782,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1804,7 +1804,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c19 {
@@ -1899,7 +1899,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="green"
+            color="good"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -1911,7 +1911,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="red"
+            color="bad"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -2032,13 +2032,13 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
 
 .c14 {
   text-align: center;
-  color: #a1a5af;
+  color: #686d74;
   visibility: hidden;
 }
 
 .c16 {
   text-align: center;
-  color: #a1a5af;
+  color: #686d74;
   visibility: visible;
 }
 
@@ -2138,7 +2138,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   -webkit-flex-flow: column;
   -ms-flex-flow: column;
   flex-flow: column;
-  border: 2px solid #272d3a;
+  border: 2px solid #282e39;
   border-radius: 3px;
   font-size: 10px;
   -webkit-transition: background-color 0.2s ease;
@@ -2195,18 +2195,18 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   padding-top: 8px;
   position: absolute;
   border-radius: 3px;
-  background: #f94c4c;
+  background: #ff274b;
   pointer-events: auto;
   width: 58px;
   cursor: pointer;
 }
 
 .c18 rect {
-  fill: #ffffff;
+  fill: #fff;
 }
 
 .c19 {
-  color: #ffffff;
+  color: #fff;
   font-size: 0.6875rem;
 }
 
@@ -2264,7 +2264,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2286,7 +2286,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c20 {
@@ -2430,7 +2430,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
         >
           <div
             className="c18"
-            color="red"
+            color="bad"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -2569,7 +2569,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -2584,21 +2584,21 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 }
 
 .spot-tile:hover .c7 {
-  background-color: #272d3a;
+  background-color: #282e39;
 }
 
 .spot-tile:hover .c7:hover {
-  background-color: #f94c4c;
-  color: #ffffff;
+  background-color: #ff274b;
+  color: #fff;
 }
 
 .c7:hover {
-  background-color: #f94c4c;
-  color: #ffffff;
+  background-color: #ff274b;
+  color: #fff;
 }
 
 .c18 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -2613,17 +2613,17 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 }
 
 .spot-tile:hover .c18 {
-  background-color: #272d3a;
+  background-color: #282e39;
 }
 
 .spot-tile:hover .c18:hover {
-  background-color: #5f94f5;
-  color: #ffffff;
+  background-color: #2d95ff;
+  color: #fff;
 }
 
 .c18:hover {
-  background-color: #5f94f5;
-  color: #ffffff;
+  background-color: #2d95ff;
+  color: #fff;
 }
 
 .c10 {
@@ -2691,13 +2691,13 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 
 .c15 {
   text-align: center;
-  color: #28c988;
+  color: #01c38d;
   visibility: hidden;
 }
 
 .c17 {
   text-align: center;
-  color: #f94c4c;
+  color: #ff274b;
   visibility: visible;
 }
 
@@ -2799,7 +2799,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2821,7 +2821,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c19 {
@@ -2916,7 +2916,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="green"
+            color="good"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -2928,7 +2928,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="red"
+            color="bad"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -3048,7 +3048,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
 }
 
 .c7 {
-  background-color: #2e3543;
+  background-color: #343a47;
   border-radius: 3px;
   color: inherit;
   -webkit-transition: background-color 0.2s ease;
@@ -3130,13 +3130,13 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
 
 .c15 {
   text-align: center;
-  color: #28c988;
+  color: #01c38d;
   visibility: hidden;
 }
 
 .c17 {
   text-align: center;
-  color: #f94c4c;
+  color: #ff274b;
   visibility: hidden;
 }
 
@@ -3264,11 +3264,11 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
 }
 
 .c19 rect {
-  fill: #ffffff;
+  fill: #fff;
 }
 
 .c25 {
-  color: #ffffff;
+  color: #fff;
   font-size: 0.8125rem;
 }
 
@@ -3331,7 +3331,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
   border-radius: 3px;
   padding: 1.25rem;
   box-sizing: border-box;
-  background-color: #2e3543;
+  background-color: #343a47;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3353,7 +3353,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
 }
 
 .c1:hover {
-  background-color: #3d4455;
+  background-color: #343a47;
 }
 
 .c26 {
@@ -3460,7 +3460,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="green"
+            color="good"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -3472,7 +3472,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="red"
+            color="bad"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -3486,7 +3486,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
         >
           <div
             className="c19"
-            color="blue"
+            color="dominant"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="good"
+            color="success"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -360,7 +360,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="bad"
+            color="error"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -876,7 +876,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
         >
           <div
             className="c19"
-            color="dominant"
+            color="primary"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -1387,7 +1387,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           <i
             aria-hidden="true"
             className="c16 fas fa-caret-up"
-            color="good"
+            color="success"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -1399,7 +1399,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           <i
             aria-hidden="true"
             className="c18 fas fa-caret-down"
-            color="bad"
+            color="error"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -1413,7 +1413,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
         >
           <div
             className="c20"
-            color="dominant"
+            color="primary"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -1899,7 +1899,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="good"
+            color="success"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -1911,7 +1911,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="bad"
+            color="error"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -2430,7 +2430,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
         >
           <div
             className="c18"
-            color="bad"
+            color="error"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}
@@ -2916,7 +2916,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="good"
+            color="success"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -2928,7 +2928,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="bad"
+            color="error"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -3460,7 +3460,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           <i
             aria-hidden="true"
             className="c15 fas fa-caret-up"
-            color="good"
+            color="success"
             data-qa="price-movement__movement-icon--up"
           />
           <div
@@ -3472,7 +3472,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           <i
             aria-hidden="true"
             className="c17 fas fa-caret-down"
-            color="bad"
+            color="error"
             data-qa="price-movement__movement-icon--down"
           />
         </div>
@@ -3486,7 +3486,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
         >
           <div
             className="c19"
-            color="dominant"
+            color="primary"
             data-qa="tile-booking__booking-pill"
             disabled={false}
             onClick={[Function]}

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileBooking.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileBooking.tsx
@@ -37,13 +37,12 @@ const BookingPill = styled.div<{
   top: ${({ isAnalyticsView, isExecutingStatus }) =>
     isAnalyticsView && !isExecutingStatus ? '2.8rem' : isAnalyticsView ? '2.3rem' : ''};
   border-radius: ${({ isExecutingStatus }) => (isExecutingStatus ? '17px' : '3px')};
-  background: ${({ theme, color, disabled }) =>
-    theme.template[color][disabled ? 'dark' : 'normal']};
+  background: ${({ theme, color, disabled }) => theme.accents[color][disabled ? 'dark' : 'base']};
   pointer-events: auto; /* restore the click on this child */
   width: ${({ isExecutingStatus, isAnalyticsView }) =>
     isAnalyticsView && !isExecutingStatus ? '82px' : isExecutingStatus ? '125px' : '58px'};
   rect {
-    fill: ${({ theme }) => theme.template.white.normal};
+    fill: ${({ theme }) => theme.white};
   }
 
   ${({ onClick, disabled }) =>
@@ -63,7 +62,7 @@ const BookingPill = styled.div<{
 `
 
 const BookingStatus = styled.span<{ isExecutingStatus: boolean }>`
-  color: ${({ theme }) => theme.template.white.normal};
+  color: ${({ theme }) => theme.white};
   font-size: ${({ isExecutingStatus }) => (isExecutingStatus ? '0.8125rem' : '0.6875rem')};
 `
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileExecuted.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileExecuted.tsx
@@ -13,8 +13,8 @@ const HeavyItalicsFont = styled(HeavyFont)`
 `
 
 const InverseFont = styled(HeavyFont)`
-  background-color: ${({ theme }) => theme.template.white.normal};
-  color: ${({ theme }) => theme.template.green.normal};
+  background-color: ${({ theme }) => theme.white};
+  color: ${({ theme }) => theme.accents.good.base};
   border-radius: 2px;
   padding: 0 0.0625rem;
 `

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileExecuted.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileExecuted.tsx
@@ -14,7 +14,7 @@ const HeavyItalicsFont = styled(HeavyFont)`
 
 const InverseFont = styled(HeavyFont)`
   background-color: ${({ theme }) => theme.white};
-  color: ${({ theme }) => theme.accents.good.base};
+  color: ${({ theme }) => theme.accents.success.base};
   border-radius: 2px;
   padding: 0 0.0625rem;
 `

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
@@ -33,7 +33,7 @@ const TradeSymbol = styled.div`
 `
 
 const CheckIcon = styled(Icon)`
-  background-color: ${({ theme }) => theme.accents.good.base};
+  background-color: ${({ theme }) => theme.accents.success.base};
   border-radius: 50%;
   padding: 0.3125rem;
 `

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
@@ -3,16 +3,16 @@ import { styled } from 'rt-theme'
 import { Button, Icon, TileBaseStyle } from '../styled'
 
 export enum NotificationType {
-  Error = 'red',
-  Success = 'green',
-  Warning = 'yellow',
+  Error = 'bad',
+  Success = 'good',
+  Warning = 'aware',
 }
 
 type AccentColor = NotificationType.Error | NotificationType.Success | NotificationType.Warning
 
 export const TileNotificationStyle = styled(TileBaseStyle)<{ accentColor: AccentColor }>`
-  color: ${({ theme }) => theme.template.white.normal};
-  background-color: ${({ theme, accentColor }) => theme.template[accentColor].dark};
+  color: ${({ theme }) => theme.white};
+  background-color: ${({ theme, accentColor }) => theme.accents[accentColor].darker};
   font-size: 0.8125rem;
   text-align: center;
   line-height: 1.5;
@@ -33,7 +33,7 @@ const TradeSymbol = styled.div`
 `
 
 const CheckIcon = styled(Icon)`
-  background-color: ${({ theme }) => theme.template.green.normal};
+  background-color: ${({ theme }) => theme.accents.good.base};
   border-radius: 50%;
   padding: 0.3125rem;
 `
@@ -43,8 +43,8 @@ const HeavyFont = styled('span')`
 `
 
 const PillButton = styled(Button)<{ accentColor: AccentColor }>`
-  color: ${({ theme }) => theme.template.white.normal};
-  background-color: ${({ theme, accentColor }) => theme.template[accentColor].normal};
+  color: ${({ theme }) => theme.white};
+  background-color: ${({ theme, accentColor }) => theme.accents[accentColor].base};
   border-radius: 17px;
   padding: 0.5rem 0.625rem;
   font-weight: 900;

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notifications/TileNotification.tsx
@@ -3,8 +3,8 @@ import { styled } from 'rt-theme'
 import { Button, Icon, TileBaseStyle } from '../styled'
 
 export enum NotificationType {
-  Error = 'bad',
-  Success = 'good',
+  Error = 'error',
+  Success = 'success',
   Warning = 'aware',
 }
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/__snapshots__/NotionalInput.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/__snapshots__/NotionalInput.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`NotionalInput default 2`] = `
 }
 
 .spot-tile:hover .c2 {
-  box-shadow: 0px 1px 0px #333333;
+  box-shadow: 0px 1px 0px #282e39;
 }
 
 .spot-tile:hover .c2:focus,
@@ -216,7 +216,7 @@ exports[`NotionalInput disabled 2`] = `
 }
 
 .spot-tile:hover .c2 {
-  box-shadow: 0px 1px 0px #333333;
+  box-shadow: 0px 1px 0px #282e39;
 }
 
 .spot-tile:hover .c2:focus,
@@ -286,8 +286,8 @@ exports[`NotionalInput show reset button 1`] = `
 }
 
 .c3 {
-  background-color: #2e3543;
-  border: 2px solid #272d3a;
+  background-color: #343a47;
+  border: 2px solid #282e39;
   border-radius: 3px;
   margin-left: 8px;
   grid-area: ResetInputValue;
@@ -357,7 +357,7 @@ exports[`NotionalInput show reset button 2`] = `
 }
 
 .spot-tile:hover .c2 {
-  box-shadow: 0px 1px 0px #333333;
+  box-shadow: 0px 1px 0px #282e39;
 }
 
 .spot-tile:hover .c2:focus,
@@ -366,8 +366,8 @@ exports[`NotionalInput show reset button 2`] = `
 }
 
 .c3 {
-  background-color: #fff;
-  border: 2px solid #f4f6f9;
+  background-color: #f9f9f9;
+  border: 2px solid #fff;
   border-radius: 3px;
   margin-left: 8px;
   grid-area: ResetInputValue;
@@ -415,7 +415,7 @@ exports[`NotionalInput with error 1`] = `
 }
 
 .c3 {
-  color: #f94c4c;
+  color: #ff274b;
   grid-area: Message;
   font-size: 0.6rem;
   line-height: normal;
@@ -443,7 +443,7 @@ exports[`NotionalInput with error 1`] = `
   font-size: 0.75rem;
   width: 80px;
   padding: 2px 0;
-  box-shadow: 0px 1px 0px #f94c4c;
+  box-shadow: 0px 1px 0px #ff274b;
 }
 
 <div
@@ -483,7 +483,7 @@ exports[`NotionalInput with error 2`] = `
 }
 
 .c3 {
-  color: #f94c4c;
+  color: #ff274b;
   grid-area: Message;
   font-size: 0.6rem;
   line-height: normal;
@@ -511,7 +511,7 @@ exports[`NotionalInput with error 2`] = `
   font-size: 0.75rem;
   width: 80px;
   padding: 2px 0;
-  box-shadow: 0px 1px 0px #f94c4c;
+  box-shadow: 0px 1px 0px #ff274b;
 }
 
 <div
@@ -687,7 +687,7 @@ exports[`NotionalInput with warning 1`] = `
 }
 
 .c3 {
-  color: #F7D036;
+  color: #ff8d00;
   grid-area: Message;
   font-size: 0.6rem;
   line-height: normal;
@@ -715,7 +715,7 @@ exports[`NotionalInput with warning 1`] = `
   font-size: 0.75rem;
   width: 80px;
   padding: 2px 0;
-  box-shadow: 0px 1px 0px #F7D036;
+  box-shadow: 0px 1px 0px #ff8d00;
 }
 
 <div
@@ -755,7 +755,7 @@ exports[`NotionalInput with warning 2`] = `
 }
 
 .c3 {
-  color: #F7D036;
+  color: #ff8d00;
   grid-area: Message;
   font-size: 0.6rem;
   line-height: normal;
@@ -783,7 +783,7 @@ exports[`NotionalInput with warning 2`] = `
   font-size: 0.75rem;
   width: 80px;
   padding: 2px 0;
-  box-shadow: 0px 1px 0px #F7D036;
+  box-shadow: 0px 1px 0px #ff8d00;
 }
 
 <div

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/styled.tsx
@@ -18,12 +18,12 @@ const getValidationMessageStyles = ({
 }) => {
   switch (validationMessageType) {
     case 'error':
-      return theme.accents.bad.base
+      return theme.accents.error.base
     case 'warning':
       return theme.accents.aware.base
     case 'info':
     default:
-      return theme.accents.dominant.base
+      return theme.accents.primary.base
   }
 }
 
@@ -45,7 +45,7 @@ const getInputBoxShadowStyles = ({
   }
 
   .spot-tile:hover &:focus, &:focus {
-    box-shadow: 0px 1px 0px ${theme.accents.dominant.base};
+    box-shadow: 0px 1px 0px ${theme.accents.primary.base};
   }
 `
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/notional/styled.tsx
@@ -18,12 +18,12 @@ const getValidationMessageStyles = ({
 }) => {
   switch (validationMessageType) {
     case 'error':
-      return theme.template.red.normal
+      return theme.accents.bad.base
     case 'warning':
-      return theme.template.yellow.normal
+      return theme.accents.aware.base
     case 'info':
     default:
-      return theme.template.blue.normal
+      return theme.accents.dominant.base
   }
 }
 
@@ -45,7 +45,7 @@ const getInputBoxShadowStyles = ({
   }
 
   .spot-tile:hover &:focus, &:focus {
-    box-shadow: 0px 1px 0px ${theme.template.blue.normal};
+    box-shadow: 0px 1px 0px ${theme.accents.dominant.base};
   }
 `
 

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/styled.tsx
@@ -37,7 +37,7 @@ export const TileBaseStyle = styled.div`
 `
 
 export const Icon = styled('i')`
-  color: ${({ theme }) => theme.template.white.normal};
+  color: ${({ theme }) => theme.white};
 `
 
 export const Button = styled('button')`

--- a/src/client/src/apps/MainRoute/widgets/status-connection/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/status-connection/styled.tsx
@@ -37,10 +37,10 @@ export const StatusCircle = styled(StatusCircleCore)<{ status?: ServiceConnectio
   circle {
     fill: ${({ theme, status }) =>
       status === ServiceConnectionStatus.CONNECTED
-        ? theme.template.green.normal
+        ? theme.accents.good.base
         : status === ServiceConnectionStatus.CONNECTING
-        ? theme.template.yellow.normal
-        : theme.template.red.normal};
+        ? theme.accents.aware.base
+        : theme.accents.bad.base};
   }
 `
 

--- a/src/client/src/apps/MainRoute/widgets/status-connection/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/status-connection/styled.tsx
@@ -37,10 +37,10 @@ export const StatusCircle = styled(StatusCircleCore)<{ status?: ServiceConnectio
   circle {
     fill: ${({ theme, status }) =>
       status === ServiceConnectionStatus.CONNECTED
-        ? theme.accents.good.base
+        ? theme.accents.success.base
         : status === ServiceConnectionStatus.CONNECTING
         ? theme.accents.aware.base
-        : theme.accents.bad.base};
+        : theme.accents.error.base};
   }
 `
 

--- a/src/client/src/apps/StyleguideRoute/StyleguideRoute.tsx
+++ b/src/client/src/apps/StyleguideRoute/StyleguideRoute.tsx
@@ -3,18 +3,16 @@ import Helmet from 'react-helmet'
 import { styled, ThemeProvider } from 'rt-theme'
 import FloatingTools from './components/FloatingsTools'
 import OnePageNavBar from './components/OnePageNavBar'
-import { Block, SectionBlock } from './styled'
+import { Block } from './styled'
 
 import Atoms from './sections/Atoms'
-import ColorSpectrum from './sections/ColorSpectrum'
 import CoreBranding from './sections/CoreBranding'
 import FontFamilies from './sections/FontFamilies'
 import Introduction from './sections/Introduction'
 import Iconography from './sections/Iconography'
 
 const sections: Array<{ path: string; Section: React.ComponentType; title: string }> = [
-  { path: 'color-spectrum', Section: ColorSpectrum, title: 'Colour' },
-  { path: 'core-branding', Section: CoreBranding, title: 'Color branding' },
+  { path: 'core-branding', Section: CoreBranding, title: 'Colour' },
   { path: 'font-families', Section: FontFamilies, title: 'Typography' },
   { path: 'icons-family', Section: Iconography, title: 'Iconography' },
   { path: 'atoms-molecules', Section: Atoms, title: 'Atoms' },
@@ -45,7 +43,6 @@ const StyleguideRoute: React.FC = () => {
               </ScrollableContainer>
             ))}
           </React.Fragment>
-          <SectionBlock mh={5} colorScheme="inverted" />
         </Root>
       </ThemeProvider>
     </React.Fragment>

--- a/src/client/src/apps/StyleguideRoute/components/ButtonGrid.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/ButtonGrid.tsx
@@ -56,7 +56,7 @@ const ButtonVariants: React.FC<ButtonStyleProps & TitleButtonProp> = props => (
 
 const GridColumn = styled.div`
   display: grid;
-  grid-template-rows: 3rem repeat(2, 2rem);
+  grid-template-rows: auto;
   grid-row-gap: 0.5rem;
   align-items: center;
   margin-bottom: 2rem;
@@ -70,7 +70,7 @@ const LabelColumn = styled(GridColumn)`
 const ColumnTitle = styled.div``
 const ButtonRow = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   grid-column-gap: 0.5rem;
 `
 const ButtonColumn = styled(GridColumn)`
@@ -81,7 +81,7 @@ const Root = styled.div`
   max-width: 60rem;
 
   display: grid;
-  grid-template-columns: 5rem 1fr 1fr 1fr 1fr ;
+  grid-template-columns: repeat(5, 100px) ;
   grid-column-gap: 2rem;
 
   ${ButtonColumn} + ${ButtonColumn} {

--- a/src/client/src/apps/StyleguideRoute/components/ConfirmationGrid.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/ConfirmationGrid.tsx
@@ -29,7 +29,7 @@ const ConfirmationBlock = styled.div<{ rejected?: boolean }>`
   min-height: 60px;
   border-radius: 3px;
   background-color: ${({ theme, rejected }) =>
-    rejected ? theme.accents.bad.base : theme.accents.good.base};
+    rejected ? theme.accents.error.base : theme.accents.success.base};
 `
 
 const GridColumn = styled.div`

--- a/src/client/src/apps/StyleguideRoute/components/FormGrid.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/FormGrid.tsx
@@ -6,16 +6,17 @@ import { keyframes } from 'styled-components'
 
 const Grid = styled.div`
   display: grid;
-  grid-template-columns: 5rem 1fr 1fr 1fr 1fr;
-  gap: 20px;
+  grid-template-columns: repeat(5, 100px);
+  grid-column-gap: 2rem;
+  grid-row-gap: 0.5rem;
   align-items: center;
-  margin-top: 2rem;
+  margin-top: 1rem;
 `
 
 const HoveredInput = styled(Input)`
   & input {
     border-bottom: ${({ theme }) =>
-      `1px solid ${theme.name === 'light' ? '#beccdc' : theme.colors.light.secondary[1]}`};
+      `1px solid ${theme.name === 'light' ? '#beccdc' : theme.colors.light.secondary[4]}`};
   }
 `
 

--- a/src/client/src/apps/StyleguideRoute/components/FormGrid.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/FormGrid.tsx
@@ -31,15 +31,15 @@ const blink = keyframes`
 
 const ActiveInput = styled(Input)`
   & input {
-    border-bottom: ${({ theme }) => `1px solid ${theme.accents.dominant.darker}`};
+    border-bottom: ${({ theme }) => `1px solid ${theme.accents.primary.darker}`};
   }
   & input:hover {
-    border-bottom: ${({ theme }) => `1px solid ${theme.accents.dominant.base}`};
+    border-bottom: ${({ theme }) => `1px solid ${theme.accents.primary.base}`};
   }
   & label::before {
     content: '';
     position: absolute;
-    background-color: ${({ theme }) => theme.accents.dominant.base};
+    background-color: ${({ theme }) => theme.accents.primary.base};
     width: 1px;
     animation: ${blink} 1s infinite;
     height: 12px;

--- a/src/client/src/apps/StyleguideRoute/components/OnePageNavBar.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/OnePageNavBar.tsx
@@ -153,7 +153,7 @@ const OnePageNavLink = styled(Link)`
     border-bottom: 3px solid white;
     ${({ theme }) =>
       css({
-        borderBottom: `3px solid ${theme.secondary[4]}`,
+        borderBottom: `3px solid ${theme.accents.dominant.base}`,
       })};
   }
 `
@@ -174,8 +174,8 @@ const NavBarBleed = styled(NavBar)`
   ${({ theme }) =>
     css({
       transition: 'background-color ease-out 0.15s',
-      backgroundColor: theme.primary.base,
-      borderBottom: `2px solid ${theme.primary[1]}`,
+      backgroundColor: theme.core.secondaryStyleGuideBackground,
+      borderBottom: `2px solid ${theme.core.primaryStyleGuideBackground}`,
     })};
 
   display: flex;
@@ -226,10 +226,11 @@ const NavBarBleed = styled(NavBar)`
 
 const TitleHeading = styled(H2)`
   text-transform: uppercase;
+  font-weight: normal;
   margin: 0.5rem 0;
   ${({ theme }) =>
     css({
-      color: theme.secondary[4],
+      color: theme.accents.dominant.base,
     })};
 `
 

--- a/src/client/src/apps/StyleguideRoute/components/OnePageNavBar.tsx
+++ b/src/client/src/apps/StyleguideRoute/components/OnePageNavBar.tsx
@@ -153,7 +153,7 @@ const OnePageNavLink = styled(Link)`
     border-bottom: 3px solid white;
     ${({ theme }) =>
       css({
-        borderBottom: `3px solid ${theme.accents.dominant.base}`,
+        borderBottom: `3px solid ${theme.accents.primary.base}`,
       })};
   }
 `
@@ -230,7 +230,7 @@ const TitleHeading = styled(H2)`
   margin: 0.5rem 0;
   ${({ theme }) =>
     css({
-      color: theme.accents.dominant.base,
+      color: theme.accents.primary.base,
     })};
 `
 

--- a/src/client/src/apps/StyleguideRoute/sections/Atoms.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/Atoms.tsx
@@ -15,7 +15,7 @@ export const props = {}
 export default () => {
   return (
     <React.Fragment>
-      <SectionBlock py={0} pt={2} mh={0} colorScheme="secondary">
+      <SectionBlock py={0} pt={2} mh={0}>
         <H2 pt={4}>Atoms</H2>
         <Paragraph>
           Atoms are the lowest level of a UI such as a button, text link, input field etc. Atoms are
@@ -24,14 +24,14 @@ export default () => {
         </Paragraph>
       </SectionBlock>
 
-      <SectionBlock py={0} pt={2} mh={0} colorScheme="secondary">
+      <SectionBlock py={0} pt={2} mh={0}>
         <H3>Buttons</H3>
         <ButtonGrid />
-        <H3>Form Elements</H3>
+        <H3>Input Fields</H3>
         <FormGrid />
       </SectionBlock>
 
-      <SectionBlock colorScheme="secondary" py={2} bleeds>
+      <SectionBlock py={2} bleeds>
         <Separator />
         <H3>Pricing Tiles</H3>
         <AtomsContainer>

--- a/src/client/src/apps/StyleguideRoute/sections/CoreBranding.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/CoreBranding.tsx
@@ -6,7 +6,7 @@ import { Block, BlockProps, Paragraph, SectionBlock, Text } from '../styled'
 import { colors, styled, Theme, AccentName } from 'rt-theme'
 import { StyledComponent, css, FlattenSimpleInterpolation } from 'styled-components'
 
-const { dominant, ...others } = colors.accents
+const { primary, ...others } = colors.accents
 
 export default () => (
   <React.Fragment>
@@ -34,7 +34,7 @@ export default () => (
             Brand colors aim to communicate a companies visual ownership of the digital product.
           </Paragraph>
         </span>
-        <DominantAccentPalettes dominant={dominant} />
+        <DominantAccentPalettes dominant={primary} />
       </QuadrantLayout>
     </SectionBlock>
 
@@ -296,7 +296,7 @@ const DominantAccentPalettes: React.FC<{ dominant: object }> = ({ dominant, ...p
       <PaletteLayout
         key="dominant"
         grid={DominantAccentSwatchGrid}
-        label="dominant"
+        label="primary"
         palette={dominant}
         fg="#FFF"
         include={['base', 'darker', 'lighter']}

--- a/src/client/src/apps/StyleguideRoute/sections/CoreBranding.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/CoreBranding.tsx
@@ -1,70 +1,51 @@
 import { rgba } from 'polished'
 import React from 'react'
 
-import { H2, H3, H5, NumberedLayout } from '../elements'
+import { H2, H3 } from '../elements'
 import { Block, BlockProps, Paragraph, SectionBlock, Text } from '../styled'
-import { colors, styled, Theme, AccentPaletteMap, AccentName } from 'rt-theme'
+import { colors, styled, Theme, AccentName } from 'rt-theme'
 import { StyledComponent, css, FlattenSimpleInterpolation } from 'styled-components'
+
+const { dominant, ...others } = colors.accents
 
 export default () => (
   <React.Fragment>
     <SectionBlock colorScheme="secondary" mh={3}>
-      <NumberedLayout number="1">
-        <H5>Design Systems</H5>
-        <H3>Adaptive UI Library</H3>
-        <Paragraph>
-          Sets the visual tone of the user interface defining the color and font styles to be used.
-        </Paragraph>
-      </NumberedLayout>
-    </SectionBlock>
-
-    <SectionBlock mh={0} py={0}>
-      <Paragraph>
-        <i>
-          <strong>Tip</strong>: Colors used can and will change in a UI therefore resist the
-          temptation to reference the color in the style name. Instead name the color according to
-          its hierarchy in the UI. For example primary, secondary, tertiary, accent-usage-type etc.
-        </i>
-      </Paragraph>
-    </SectionBlock>
-    <div>
-      <SectionBlock colorScheme="secondary" mh={0.125 / 5} py={0} />
-    </div>
-
-    <SectionBlock mh={3}>
-      <H2 pt={4}>Brand Colors</H2>
-      <Paragraph>
-        Brand colors aim to communicate a companies visual ownership of the digital product.
-      </Paragraph>
-      <Swatch
-        is={LargeSwatchColor}
-        label="Brand Primary"
-        value={colors.spectrum.brand.base}
-        bg={(theme: Theme) => theme.colors.spectrum.brand.base}
-        fg={(theme: Theme) => theme.colors.static.white}
-        code="Base"
-      />
-    </SectionBlock>
-
-    <SectionBlock mh={3}>
-      <H2>Core UI</H2>
+      <H2 pt={4}>COLOUR</H2>
+      <H3>Core UI</H3>
       <Paragraph>
         Core color control the general look and feel of the application and make up 90% of the
         overall UI aesthetic. When switching from a light to a dark theme these are the key color
         that change.
       </Paragraph>
 
-      <H3 mt={4}>Light</H3>
-      <ThemePalettes theme={colors.light} />
-
-      <H3 mt={4}>Dark</H3>
       <ThemePalettes theme={colors.dark} />
     </SectionBlock>
 
-    <SectionBlock mh={3}>
+    <SectionBlock colorScheme="secondary" py={0} pt={0} mh={0}>
+      <Separator />
+    </SectionBlock>
+
+    <SectionBlock colorScheme="secondary" mh={3}>
       <QuadrantLayout>
         <span>
-          <H2>Accents & Functional colors</H2>
+          <H3>Brand / Accent Colours</H3>
+          <Paragraph mb={3}>
+            Brand colors aim to communicate a companies visual ownership of the digital product.
+          </Paragraph>
+        </span>
+        <DominantAccentPalettes dominant={dominant} />
+      </QuadrantLayout>
+    </SectionBlock>
+
+    <SectionBlock colorScheme="secondary" py={0} pt={0} mh={0}>
+      <Separator />
+    </SectionBlock>
+
+    <SectionBlock colorScheme="secondary" mh={3}>
+      <QuadrantLayout>
+        <span>
+          <H3>Accents & Functional colors</H3>
           <Paragraph mb={3}>
             Accent colors inject focus points in to the UI and are used to give the UI character and
             guide users attention. These colors often work with the brand helping to retain the
@@ -72,26 +53,57 @@ export default () => (
           </Paragraph>
         </span>
 
-        <AccentPalettes accents={colors.accents} />
+        <AccentPalettes accents={others} />
+      </QuadrantLayout>
+    </SectionBlock>
 
+    <SectionBlock colorScheme="secondary" py={0} pt={0} mh={0}>
+      <Separator />
+    </SectionBlock>
+
+    <SectionBlock colorScheme="secondary" mh={3}>
+      <QuadrantLayout>
         <span>
-          <H2>Unique Collections</H2>
+          <H3>Unique Collections</H3>
           <Paragraph>
-            Create separate references for key areas of the application such as trading directions
-            shown below.
+            Create separate references for key areas of the application such as trading directions.
+          </Paragraph>
+          <Paragraph>
+            <i>
+              Note: Why are some colours the same but named differently? Answer: These colours will
+              be chosen and used in different situations allowing key functional colours and
+              branding to be changed independantly of one another.
+            </i>
           </Paragraph>
         </span>
 
-        <UniquePalettes
-          palettes={{
-            'Trading Buy': { base: colors.accents.dominant.base },
-            'Trading Sell': { base: colors.accents.bad.base },
-          }}
-        />
+        <span>
+          <UniquePalettes
+            palettes={{
+              'Trading Sell': {
+                base: colors.spectrum.uniqueCollections.Sell.base,
+                1: colors.spectrum.uniqueCollections.Sell.lighter,
+              },
+            }}
+          />
+          <UniquePalettes
+            palettes={{
+              'Trading Buy': {
+                base: colors.spectrum.uniqueCollections.Buy.base,
+                1: colors.spectrum.uniqueCollections.Buy.lighter,
+              },
+            }}
+          />
+        </span>
       </QuadrantLayout>
     </SectionBlock>
   </React.Fragment>
 )
+
+const Separator = styled.div`
+  height: 2px;
+  background-color: ${({ theme }) => theme.core.primaryStyleGuideBackground};
+`
 
 const PaletteLayout: React.FC<{
   grid?: StyledComponent<React.ComponentType<any>, Theme, any>
@@ -105,24 +117,27 @@ const PaletteLayout: React.FC<{
   fg,
   label: paletteLabel,
   palette,
-  include = ['base', 1, 2, 3, 4],
+  include = ['base', 1, 2, 3, 4, 5],
   codes = {},
 }) => {
   if (!SwatchGrid) {
     return <></>
   }
   return (
-    <SwatchGrid style={{ boxShadow: `0 0 0 4px ${rgba(fg, 0.05)}` }}>
+    <SwatchGrid style={{ boxShadow: `0px 0px 20px 0px ${rgba(0, 0, 0, 0.2)}` }}>
       {include.map((key, i) => {
         const color = palette[key]
 
         const themeForCss: any = {}
+
         if (key === 'base') {
           themeForCss.gridArea = key
         }
-        if (i < 1) {
-          themeForCss.boxShadow = `0 0 2rem ${rgba(palette[include[include.length - 1]], 0.5)}`
+
+        if (key === 1) {
+          themeForCss.gridArea = 'base1'
         }
+
         return (
           <Swatch
             key={key}
@@ -164,10 +179,10 @@ export const Swatch: React.FC<SwatchProps> = ({
   ...props
 }) => (
   <SwatchElement p={2} bg={bg} fg={fg} {...props}>
-    <Text fontSize={0.8125} fontWeight="bold" textTransform="capitalize">
+    <Text fontSize={0.75} fontWeight="bold" textTransform="capitalize">
       {label}
     </Text>
-    <Text fontSize={0.8125} textTransform="uppercase">
+    <Text fontSize={0.75} textTransform="uppercase">
       {value}
     </Text>
     {/* <Text fontSize={0.75} textTransform="uppercase" opacity={0.75}>
@@ -182,6 +197,7 @@ export const SwatchColor = styled(Block)<SwatchColorProps>`
   display: flex;
   justify-content: flex-end;
   flex-flow: column nowrap;
+  padding-right: 5px;
 
   ${({ extra }) => extra};
 `
@@ -203,10 +219,10 @@ const CoreSwatchGrid = styled.div`
   grid-template-columns: 1fr 1fr;
   grid-template-rows: repeat(4, 5rem);
   grid-template-areas:
-    'base 1'
     'base 2'
     'base 3'
-    'base 4';
+    'base1 4'
+    'base1 5';
 
   overflow: hidden;
   border-radius: 0.5rem;
@@ -217,24 +233,25 @@ const CoreSwatchGrid = styled.div`
 
   @media all and (min-width: 640px) {
     grid-template-columns: 1fr 1fr 1fr 1fr;
-    grid-template-rows: auto;
+    grid-template-rows: 14rem 7rem;
     grid-template-areas:
-      'base base base base'
-      '1 2 3 4';
-
-    ${SwatchColor} {
-      min-height: 14rem;
-    }
+      'base base base1 base1'
+      '2 3 4 5';
   }
 `
 
 const ThemePalettes: React.FC<{ theme: any }> = ({ theme: { primary, secondary }, ...props }) => {
   return (
     <ThemeRow>
-      <PaletteLayout grid={CoreSwatchGrid} label="Primary" palette={primary} fg={secondary.base} />
       <PaletteLayout
         grid={CoreSwatchGrid}
-        label="Secondary"
+        label="Core-Primary"
+        palette={primary}
+        fg={secondary.base}
+      />
+      <PaletteLayout
+        grid={CoreSwatchGrid}
+        label="Core-Secondary"
         palette={secondary}
         fg={primary.base}
       />
@@ -251,11 +268,11 @@ const ThemeRow = styled.div`
     grid-template-columns: 1fr 1fr;
 
     ${CoreSwatchGrid}:first-child {
-      border-radius: 0.5rem 0 0.5rem 0.5rem !important;
+      border-radius: 0.5rem 0.5rem 0.5rem 0.5rem !important;
     }
 
     ${CoreSwatchGrid}:last-child {
-      border-radius: 0 0.5rem 0.5rem 0.5rem !important;
+      border-radius: 0.5rem 0.5rem 0.5rem 0.5rem !important;
     }
   }
 `
@@ -266,36 +283,29 @@ const QuadrantLayout = styled.div`
   grid-column-gap: 2rem;
 
   grid-template-rows: auto;
-  grid-template-columns: minmax(50%, 1fr) auto;
-  grid-template-areas:
-    'a1 b1'
-    'a2 b2 ';
-
-  & > :nth-child(1) {
-    grid-area: a1;
-  }
-  & > :nth-child(2) {
-    grid-area: a2;
-  }
-  & > :nth-child(3) {
-    grid-area: b1;
-  }
-  & > :nth-child(4) {
-    grid-area: b2;
-  }
+  grid-template-columns: 1fr 1fr;
 
   @media all and (max-width: 800px) {
     grid-template-columns: auto;
-    grid-template-areas:
-      'a1'
-      'a2'
-      'b1'
-      'b2';
-    grid-row-gap: 2rem;
   }
 `
 
-const AccentPalettes: React.FC<{ accents: AccentPaletteMap }> = ({ accents, ...props }) => {
+const DominantAccentPalettes: React.FC<{ dominant: object }> = ({ dominant, ...props }) => {
+  return (
+    <AccentRowGrid>
+      <PaletteLayout
+        key="dominant"
+        grid={DominantAccentSwatchGrid}
+        label="dominant"
+        palette={dominant}
+        fg="#FFF"
+        include={['base', 'darker', 'lighter']}
+      />
+    </AccentRowGrid>
+  )
+}
+
+const AccentPalettes: React.FC<{ accents: object }> = ({ accents, ...props }) => {
   return (
     <AccentRowGrid>
       {(Object.keys(accents) as AccentName[]).map(accentName => (
@@ -304,8 +314,8 @@ const AccentPalettes: React.FC<{ accents: AccentPaletteMap }> = ({ accents, ...p
           grid={AccentSwatchGrid}
           label={accentName}
           palette={accents[accentName]}
-          fg="#FFF"
-          include={['base', 'darker', 'lighter']}
+          fg="#000"
+          include={['base', 'darker', 'medium', 'lighter']}
         />
       ))}
     </AccentRowGrid>
@@ -314,21 +324,26 @@ const AccentPalettes: React.FC<{ accents: AccentPaletteMap }> = ({ accents, ...p
 
 const AccentRowGrid = styled.div`
   max-width: 30rem;
-
   display: grid;
   grid-gap: 0.5rem;
-  grid-template-columns: repeat(4, minmax(calc(25% - 0.5rem), 7rem));
+  grid-template-columns: 1fr;
+  grid-template-rows: 6rem;
 `
 
 const AccentSwatchGrid = styled.div`
-  border-radius: 0.5rem;
+  border-radius: 1rem;
   overflow: hidden;
   display: grid;
-  grid-template-rows: repeat(3, 8rem);
-  grid-template-areas:
-    'base'
-    'darker'
-    'lighter';
+  grid-template-rows: 6rem;
+  grid-template-areas: 'base darker medium lighter';
+`
+
+const DominantAccentSwatchGrid = styled.div`
+  border-radius: 1rem;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 6rem;
+  grid-template-areas: 'base base darker lighter';
 `
 
 const UniquePalettes: React.FC<{ palettes: any }> = ({ palettes, ...props }) => {
@@ -340,8 +355,8 @@ const UniquePalettes: React.FC<{ palettes: any }> = ({ palettes, ...props }) => 
           grid={UniqueSwatchGrid}
           label={label}
           palette={palettes[label]}
-          fg="#FFF"
-          include={['base']}
+          fg="#000"
+          include={['base', '1']}
         />
       ))}
     </UniqueRowGrid>
@@ -351,14 +366,15 @@ const UniquePalettes: React.FC<{ palettes: any }> = ({ palettes, ...props }) => 
 const UniqueRowGrid = styled.div`
   display: grid;
   grid-gap: 0.5rem;
-  grid-template-columns: repeat(2, minmax(calc(25% - 0.5rem), 7rem));
+  grid-template-columns: 70%;
+  margin: 1rem;
 `
 
 const UniqueSwatchGrid = styled.div`
-  border-radius: 0.5rem;
+  border-radius: 1rem;
   overflow: hidden;
   height: min-content;
   display: grid;
-  grid-template-rows: 8rem;
-  grid-template-areas: 'base';
+  grid-template-rows: 6rem;
+  grid-template-areas: 'base 1';
 `

--- a/src/client/src/apps/StyleguideRoute/sections/FontFamilies.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/FontFamilies.tsx
@@ -60,7 +60,7 @@ const ROBOTO = {
 
 export const FontFamilies: React.FC = () => (
   <React.Fragment>
-    <SectionBlock colorScheme="secondary">
+    <SectionBlock>
       <H2 pt={4}>Tipography</H2>
       <H3>Roboto</H3>
 
@@ -94,7 +94,7 @@ export const FontFamilies: React.FC = () => (
         </FontSizeGrid>
       ))}
     </SectionBlock>
-    <SectionBlock colorScheme="secondary" mh={0} py={0}>
+    <SectionBlock mh={0} py={0}>
       <Paragraph>
         <i>
           *Means there will often be regular, bold, medium, italic, underline styles available The

--- a/src/client/src/apps/StyleguideRoute/sections/Iconography.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/Iconography.tsx
@@ -18,7 +18,7 @@ import { Paragraph, SectionBlock, Text, TextProps } from '../styled'
 
 export const FontFamilies: React.FC = () => (
   <React.Fragment>
-    <SectionBlock py={0} pt={2} mh={0}>
+    <SectionBlock colorScheme="secondary" py={0} pt={2} mh={0}>
       <H2 pt={4}>Iconography</H2>
 
       <Paragraph>
@@ -27,7 +27,7 @@ export const FontFamilies: React.FC = () => (
         to their container size.
       </Paragraph>
     </SectionBlock>
-    <SectionBlock py={2} pt={2} mh={0}>
+    <SectionBlock colorScheme="secondary" py={2} pt={2} mh={0}>
       <H3>Generic</H3>
       <IconGrid>
         <div></div>

--- a/src/client/src/apps/StyleguideRoute/sections/Introduction.tsx
+++ b/src/client/src/apps/StyleguideRoute/sections/Introduction.tsx
@@ -7,7 +7,7 @@ import { Paragraph, SectionBlock } from '../styled'
 
 export const Introduction: React.FC = props => (
   <React.Fragment>
-    <SectionBlock colorScheme="secondary" {...props}>
+    <SectionBlock {...props}>
       <Flex>
         <Content>
           <Logo />

--- a/src/client/src/apps/StyleguideRoute/styled/SectionBlock.tsx
+++ b/src/client/src/apps/StyleguideRoute/styled/SectionBlock.tsx
@@ -4,6 +4,7 @@ import { rules } from 'rt-styleguide'
 import { Block, BlockProps } from '../styled'
 import { mapMarginPaddingProps, MarginPaddingProps } from './mapMarginPaddingProps'
 import { styled, ColorProps as ThemeSelectorPair } from 'rt-theme'
+import { H2 } from '../elements'
 import { css } from 'styled-components'
 
 type ColorSchemeName = 'primary' | 'secondary' | 'inverted'
@@ -16,8 +17,8 @@ export interface SectionProps extends BlockProps, MarginPaddingProps {
 }
 
 const colorSchemes: { [scheme in ColorSchemeName]: ThemeSelectorPair } = {
-  primary: { bg: t => t.primary.base, fg: t => t.secondary.base },
-  secondary: { bg: t => t.primary[1], fg: t => t.secondary[1] },
+  primary: { bg: t => t.core.primaryStyleGuideBackground, fg: t => t.secondary.base },
+  secondary: { bg: t => t.core.secondaryStyleGuideBackground, fg: t => t.secondary[1] },
   inverted: { bg: t => t.secondary[3], fg: t => t.primary[1] },
 }
 
@@ -125,4 +126,10 @@ export const SectionBody = styled.div`
     margin-top: 2rem;
     margin-bottom: 2rem;
   }
+  ${H2} {
+    font-weight: normal;
+    color: ${({ theme }) => theme.accents.dominant.base}
+  }
+
+
 `

--- a/src/client/src/apps/StyleguideRoute/styled/SectionBlock.tsx
+++ b/src/client/src/apps/StyleguideRoute/styled/SectionBlock.tsx
@@ -128,7 +128,7 @@ export const SectionBody = styled.div`
   }
   ${H2} {
     font-weight: normal;
-    color: ${({ theme }) => theme.accents.dominant.base}
+    color: ${({ theme }) => theme.accents.primary.base}
   }
 
 

--- a/src/client/src/rt-styleguide/components/Button.tsx
+++ b/src/client/src/rt-styleguide/components/Button.tsx
@@ -26,13 +26,16 @@ function getButtonColors({
   const buttonStyleSet = typeof intent !== 'undefined' && theme.button[intent]
   let fg = (buttonStyleSet && buttonStyleSet.textColor) || theme.textColor
   let bg = (buttonStyleSet && buttonStyleSet.backgroundColor) || theme.backgroundColor
+  console.log(intent, buttonStyleSet)
 
   if (active && buttonStyleSet) {
     bg = buttonStyleSet.active.backgroundColor
   }
 
-  if (disabled) {
+  if (disabled && buttonStyleSet) {
     // Disabled flag only affects to opacity and pointer events - colors don't change
+    bg = buttonStyleSet.disabled.backgroundColor
+    fg = buttonStyleSet.textColor || theme.textColor
   }
 
   if (invert) {
@@ -41,7 +44,7 @@ function getButtonColors({
 
   if (outline && buttonStyleSet) {
     if (active) {
-      bg = buttonStyleSet.backgroundColor
+      bg = buttonStyleSet.active.backgroundColor
       fg = buttonStyleSet.textColor || theme.textColor
     } else {
       bg = theme.colors.static.transparent
@@ -49,6 +52,7 @@ function getButtonColors({
     }
   }
 
+  console.log(intent, buttonStyleSet, `active:${active} disabled:${disabled}`, bg, fg)
   return {
     ...theme,
     bg,
@@ -66,7 +70,6 @@ class BaseButtonThemeProvider extends React.Component<ButtonStyleProps & { theme
 
   render() {
     const { children, theme } = this.props
-
     return <ThemeProvider theme={theme}>{children as ReactChild}</ThemeProvider>
   }
 }

--- a/src/client/src/rt-styleguide/components/Input.tsx
+++ b/src/client/src/rt-styleguide/components/Input.tsx
@@ -2,8 +2,8 @@ import React, { useRef } from 'react'
 import { styled } from 'rt-theme'
 
 const inputColors = {
-  error: 'bad',
-  info: 'dominant',
+  error: 'error',
+  info: 'primary',
 }
 
 export interface InputStyleProps extends React.HTMLAttributes<HTMLInputElement> {
@@ -62,11 +62,11 @@ const StyledInput = styled.input<InputStyleProps>`
   }
   &:focus {
     caret-color: ${({ status, theme }) =>
-      `${status ? theme.accents[inputColors[status]].darker : theme.accents.dominant.darker}`};
+      `${status ? theme.accents[inputColors[status]].darker : theme.accents.primary.darker}`};
     outline: none;
     border-bottom: ${({ status, theme }) =>
       `1px solid ${
-        status ? theme.accents[inputColors[status]].darker : theme.accents.dominant.darker
+        status ? theme.accents[inputColors[status]].darker : theme.accents.primary.darker
       }`};
   }
   &:disabled {

--- a/src/client/src/rt-theme/colors.ts
+++ b/src/client/src/rt-theme/colors.ts
@@ -1,4 +1,5 @@
 import { mix, rgb, rgba } from 'polished'
+import { Direction } from 'rt-types'
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////// 1. Colors ///////////////////////////////////
@@ -35,43 +36,14 @@ const TRANSPARENT: Color = rgba(255, 255, 255, 0)
 // between elements.
 const OFFWHITE = rgb(244, 246, 249)
 const OFFBLACK = rgb(68, 76, 95) // sRGB
-const DARKGREY = '#333333' // For text over light background
 const BRAND = rgb(42, 87, 141) // Adaptive blue a.k.a. #2A578D
-
-/*---------------------------- 1.2 Template colors ---------------------------*/
-
-// TODO: Kept for backward compatibility purposes. Consider unifying as accent palettes
-
-export const template = {
-  green: {
-    dark: '#23b47a',
-    normal: '#28c988',
-    light: '#93e4c3',
-  },
-  red: {
-    dark: '#e04444',
-    normal: '#f94c4c',
-    light: '#fca5a5',
-  },
-  white: {
-    dark: '#dfdfdf',
-    normal: '#ffffff',
-  },
-  blue: {
-    dark: '#4c76c4',
-    normal: '#5f94f5',
-    light: '#aec9f9',
-  },
-  yellow: {
-    dark: '#A38D00',
-    normal: '#F7D036',
-    light: '#F4E0A4',
-  },
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////// 2. Palettes //////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+
+//Kept for backward compatibility purposes. Current palette is not generated from one color
+
 interface BasePalette {
   base: Color
 }
@@ -117,9 +89,10 @@ const brand = createPalette(BRAND)
 
 /*---------------------------- 2.2 Core palettes -----------------------------*/
 
-type CorePaletteVariant = 'base' | 1 | 2 | 3 | 4
+type CorePaletteVariant = 'base' | 1 | 2 | 3 | 4 | 5
+
 /**
- * A palette consisting of a `base` and 4 variants
+ * A palette consisting of a `base` and 5 variants
  */
 
 export type CorePalette = { [variant in CorePaletteVariant]: Color }
@@ -132,6 +105,8 @@ interface SemanticColors {
   offBackground: Color
   textColor: Color
   backgroundHoverColor: Color
+  primaryStyleGuideBackground: Color
+  secondaryStyleGuideBackground: Color
 }
 
 export interface CorePaletteMap {
@@ -140,53 +115,52 @@ export interface CorePaletteMap {
   core: SemanticColors
 }
 
-export const light: CorePaletteMap = {
-  primary: {
-    base: WHITE,
-    1: blue.L95,
-    2: blue.L9,
-    3: blue.L8,
-    4: blue.L7,
-  },
-  secondary: {
-    base: offblack.base,
-    1: offblack.L1,
-    2: offblack.L3,
-    3: offblack.D4,
-    4: offblack.L5,
-  },
-  core: {
-    lightBackground: WHITE,
-    darkBackground: blue.L95,
-    alternateBackground: blue.L8,
-    offBackground: blue.L9,
-    textColor: DARKGREY,
-    backgroundHoverColor: WHITE,
-  },
+// New color definition based on custom rgb colors, not from colorPalettes generated before
+const darkPrimary = {
+  base: rgb(40, 46, 57),
+  1: rgb(52, 58, 71),
+  2: rgb(61, 66, 76),
+  3: rgb(83, 87, 96),
+  4: rgb(104, 109, 116),
+  5: rgb(126, 129, 136),
+}
+
+const darkSecondary = {
+  base: WHITE,
+  1: rgb(249, 249, 249),
+  2: rgb(243, 243, 244),
+  3: rgb(228, 229, 230),
+  4: rgb(207, 208, 211),
+  5: rgb(189, 190, 195),
 }
 
 export const dark: CorePaletteMap = {
-  primary: {
-    base: offblack.D3,
-    1: offblack.D4,
-    2: offblack.base,
-    3: offblack.D1,
-    4: offblack.D7,
-  },
-  secondary: {
-    base: WHITE,
-    1: blue.L95,
-    2: blue.L9,
-    3: blue.L8,
-    4: blue.L5,
-  },
+  primary: darkPrimary,
+  secondary: darkSecondary,
   core: {
-    lightBackground: offblack.D3,
-    darkBackground: offblack.D4,
-    alternateBackground: offblack.D1,
-    offBackground: offblack.base,
-    textColor: WHITE,
-    backgroundHoverColor: offblack.D1,
+    lightBackground: darkPrimary[1],
+    darkBackground: darkPrimary.base,
+    alternateBackground: darkPrimary[3],
+    offBackground: darkPrimary[3],
+    textColor: darkSecondary.base,
+    backgroundHoverColor: darkPrimary[1],
+    primaryStyleGuideBackground: rgb(32, 36, 45),
+    secondaryStyleGuideBackground: rgb(40, 45, 57),
+  },
+}
+
+export const light: CorePaletteMap = {
+  primary: darkSecondary,
+  secondary: darkPrimary,
+  core: {
+    lightBackground: darkSecondary[1],
+    darkBackground: darkSecondary.base,
+    alternateBackground: darkSecondary[3],
+    offBackground: darkSecondary[3],
+    textColor: darkPrimary.base,
+    backgroundHoverColor: darkSecondary[1],
+    primaryStyleGuideBackground: rgb(253, 253, 253),
+    secondaryStyleGuideBackground: rgb(243, 243, 243),
   },
 }
 
@@ -198,6 +172,11 @@ export const dark: CorePaletteMap = {
 interface AccentPalette extends BasePalette {
   darker: Color
   lighter: Color
+  medium?: Color
+}
+
+interface TradingAccentPalette extends BasePalette {
+  lighter: Color
 }
 
 export type AccentName = 'dominant' | 'good' | 'aware' | 'bad'
@@ -208,24 +187,39 @@ export type AccentPaletteMap = { [accent in AccentName]: AccentPalette }
 
 const accents: AccentPaletteMap = {
   dominant: {
-    base: blue.base,
-    darker: blue.D2,
-    lighter: blue.L5,
+    base: rgb(95, 148, 245),
+    darker: rgb(76, 118, 196),
+    lighter: rgb(127, 169, 247),
   },
   good: {
-    base: green.base,
-    darker: green.D1,
-    lighter: green.L5,
+    base: rgb(1, 195, 141),
+    darker: rgb(3, 160, 119),
+    lighter: rgb(12, 150, 116),
+    medium: rgb(153, 231, 209),
   },
   aware: {
-    base: yellow.base,
-    darker: yellow.D1,
-    lighter: yellow.L5,
+    base: rgb(255, 141, 0),
+    darker: rgb(229, 126, 0),
+    lighter: rgb(255, 232, 204),
+    medium: rgb(255, 197, 127),
   },
   bad: {
-    base: red.base,
-    darker: red.D1,
-    lighter: red.L5,
+    base: rgb(255, 39, 75),
+    darker: rgb(230, 35, 67),
+    lighter: rgb(255, 211, 219),
+    medium: rgb(255, 146, 164),
+  },
+}
+
+export type TradingPaletteMap = { [direction in Direction]: TradingAccentPalette }
+const uniqueCollections: TradingPaletteMap = {
+  [Direction.Sell]: {
+    base: rgb(255, 39, 75),
+    lighter: rgb(255, 211, 219),
+  },
+  [Direction.Buy]: {
+    base: rgb(45, 149, 255),
+    lighter: rgb(191, 222, 255),
   },
 }
 
@@ -236,6 +230,7 @@ const spectrum = {
   green,
   yellow,
   blue,
+  uniqueCollections,
 }
 
 export const colors = {

--- a/src/client/src/rt-theme/colors.ts
+++ b/src/client/src/rt-theme/colors.ts
@@ -179,19 +179,19 @@ interface TradingAccentPalette extends BasePalette {
   lighter: Color
 }
 
-export type AccentName = 'dominant' | 'good' | 'aware' | 'bad'
+export type AccentName = 'primary' | 'success' | 'aware' | 'error'
 /**
  * A set of theme-agnostic palettes
  */
 export type AccentPaletteMap = { [accent in AccentName]: AccentPalette }
 
 const accents: AccentPaletteMap = {
-  dominant: {
+  primary: {
     base: rgb(95, 148, 245),
     darker: rgb(76, 118, 196),
     lighter: rgb(127, 169, 247),
   },
-  good: {
+  success: {
     base: rgb(1, 195, 141),
     darker: rgb(3, 160, 119),
     lighter: rgb(12, 150, 116),
@@ -203,7 +203,7 @@ const accents: AccentPaletteMap = {
     lighter: rgb(255, 232, 204),
     medium: rgb(255, 197, 127),
   },
-  bad: {
+  error: {
     base: rgb(255, 39, 75),
     darker: rgb(230, 35, 67),
     lighter: rgb(255, 211, 219),

--- a/src/client/src/rt-theme/themes.ts
+++ b/src/client/src/rt-theme/themes.ts
@@ -2,15 +2,7 @@ import { darken } from 'polished'
 import { mapValues } from 'lodash'
 import { keyframes } from 'styled-components'
 
-import {
-  colors,
-  template,
-  AccentPaletteMap,
-  Color,
-  CorePalette,
-  CorePaletteMap,
-  AccentName,
-} from './colors'
+import { colors, AccentPaletteMap, Color, CorePalette, CorePaletteMap, AccentName } from './colors'
 
 interface BaseTheme {
   white: Color
@@ -81,7 +73,6 @@ const createTheme = (
   accents: AccentPaletteMap,
 ) => ({
   name,
-  template,
   core,
   white: colors.static.white,
   black: colors.static.black,
@@ -151,25 +142,25 @@ const createTheme = (
 
     primary: {
       backgroundColor: accents.dominant.base,
-      textColor: colors.light.primary.base,
+      textColor: secondary.base,
 
       active: {
         backgroundColor: accents.dominant.darker,
       },
       disabled: {
-        backgroundColor: accents.dominant.lighter,
+        backgroundColor: primary[1],
       },
     },
 
     secondary: {
-      backgroundColor: secondary.base,
-      textColor: primary.base,
+      backgroundColor: primary[1],
+      textColor: secondary.base,
 
       active: {
-        backgroundColor: secondary[3],
+        backgroundColor: accents.dominant.darker,
       },
       disabled: {
-        backgroundColor: secondary[4],
+        backgroundColor: primary[1],
       },
     },
 
@@ -203,8 +194,6 @@ const createTheme = (
 
 const lightTheme = createTheme('light', colors.light, colors.accents)
 const darkTheme = createTheme('dark', colors.dark, colors.accents)
-// Manual overrides
-darkTheme.button.secondary.textColor = darkTheme.primary.base
 
 export const themes = {
   light: lightTheme,

--- a/src/client/src/rt-theme/themes.ts
+++ b/src/client/src/rt-theme/themes.ts
@@ -120,7 +120,7 @@ const createTheme = (
       background-color: ${primary.base};
     }
     50% {
-      background-color: ${accents.dominant.darker};
+      background-color: ${accents.primary.darker};
     }
     100% {
       background-color: ${primary.base};
@@ -141,11 +141,11 @@ const createTheme = (
     },
 
     primary: {
-      backgroundColor: accents.dominant.base,
+      backgroundColor: accents.primary.base,
       textColor: secondary.base,
 
       active: {
-        backgroundColor: accents.dominant.darker,
+        backgroundColor: accents.primary.darker,
       },
       disabled: {
         backgroundColor: primary[1],
@@ -157,7 +157,7 @@ const createTheme = (
       textColor: secondary.base,
 
       active: {
-        backgroundColor: accents.dominant.darker,
+        backgroundColor: accents.primary.darker,
       },
       disabled: {
         backgroundColor: primary[1],


### PR DESCRIPTION
Changes to theme color palette acording to desings:
- Clean up and refactor old color values to point to right current theme colors
- Update styleguide with new color palette and color section
- Update Reactive trader app with new color palette
- Fix height on analytics section of reactive trader

![styleguide-theme](https://user-images.githubusercontent.com/1596197/75558438-1d0db380-5a42-11ea-9d8e-718ccf832d45.gif)
![RT-theme](https://user-images.githubusercontent.com/1596197/75558445-1ed77700-5a42-11ea-9029-4d4a34126c44.gif)
