### PR TITLE
fix(launcher): fix unable to reopen market view (ARTP-1046)

### DIFF
--- a/src/client/src/rt-interop/intents/showMarket.ts
+++ b/src/client/src/rt-interop/intents/showMarket.ts
@@ -10,11 +10,14 @@ export async function showMarket({ window }: Platform) {
     return
   }
   // TODO: position and size of the window, also make it frame-less
-  openedWindow = await window.open({
-    ...defaultConfig,
-    height: 900,
-    url: `${windowOrigin}/tiles/ALL/Analytics`,
-  })
+  openedWindow = await window.open(
+    {
+      ...defaultConfig,
+      height: 900,
+      url: `${windowOrigin}/tiles`,
+    },
+    () => (openedWindow = undefined),
+  )
   if (!openedWindow) {
     console.log(`Error opening new window`)
   }


### PR DESCRIPTION
This PR fixes the problem of not being able to reopen the market view after it has been opened once from the launcher. 