### PR TITLE
fix(client): align headers with UX (ARTP-1056)

### DIFF
--- a/src/client/src/apps/MainRoute/Router.tsx
+++ b/src/client/src/apps/MainRoute/Router.tsx
@@ -10,7 +10,7 @@ export const Router: FC = () => (
     <Route
       path="/analytics"
       render={() => (
-        <RouteWrapper windowType="sub" title="Analytics">
+        <RouteWrapper windowType="sub" title="analytics">
           <AnalyticsRoute />
         </RouteWrapper>
       )}
@@ -18,7 +18,7 @@ export const Router: FC = () => (
     <Route
       path="/blotter"
       render={routeProps => (
-        <RouteWrapper windowType="sub" title="Blotter">
+        <RouteWrapper windowType="sub" title="trades">
           <BlotterRoute {...routeProps} />
         </RouteWrapper>
       )}
@@ -26,7 +26,7 @@ export const Router: FC = () => (
     <Route
       path="/tiles/:currency/:tileView"
       render={() => (
-        <RouteWrapper title="Tiles">
+        <RouteWrapper title="live - rates">
           <TileRoute />
         </RouteWrapper>
       )}

--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -5,7 +5,7 @@ import { styled } from 'rt-theme'
 const AnalyticsRouteStyle = styled.div`
   /*height offset is needed for openfin controls*/
   height: calc(100% - 21px);
-  padding: 0.625rem 0.625rem 0rem 0.625rem;
+  padding: 0 0.625rem 0rem 0.625rem;
   overflow-x: scroll;
   margin: auto;
 `

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterHeader.tsx
@@ -79,7 +79,7 @@ const BlotterHeader: FC<Props> = ({ gridApi, canPopout, onExportToExcelClick, on
 
   return (
     <BlotterHeaderStyle>
-      <BlotterLeft>Executed Trades</BlotterLeft>
+      <BlotterLeft>Trades</BlotterLeft>
       <BlotterRight>
         <ExcelButton onClick={onExportToExcelClick} />
         <BlotterToolbar

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -34,10 +34,17 @@ const RouteWrapper: React.FC<RouteWrapperProps> = props => {
 
   const { PlatformHeader, PlatformControls, PlatformRoute, window } = platform
 
+  const isBlotterOrTrade = title === 'trades' || title === 'live - rates'
+
   const Header = windowType === 'main' ? PlatformControls : null
   const subheader =
     windowType === 'sub' ? (
-      <PlatformHeader popIn={window.close} minimize={window.minimize} title={title} />
+      <PlatformHeader
+        popIn={window.close}
+        minimize={window.minimize}
+        title={`Reactive Trader - ${title}`}
+        isBlotterOrTrade={isBlotterOrTrade}
+      />
     ) : null
 
   return (

--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -19,6 +19,7 @@ export interface ControlProps {
   popIn?: () => void
   close?: () => void
   title?: string
+  isBlotterOrTrade?: boolean
 }
 
 export const OpenFinChrome: React.FC = ({ children }) => (
@@ -39,7 +40,7 @@ export const OpenFinChrome: React.FC = ({ children }) => (
 )
 
 export const OpenFinHeader: React.FC<ControlProps> = ({ ...props }) => (
-  <Header>
+  <Header hasBottomBorder={props.isBlotterOrTrade}>
     <OpenFinUndockControl />
     <DragRegion>{props.title}</DragRegion>
     <OpenFinControls {...props} />
@@ -114,12 +115,14 @@ const OpenFinUndockControl: React.FC = () => {
   )
 }
 
-const Header = styled.div`
+const Header = styled.div<{ hasBottomBorder?: boolean }>`
   display: flex;
   width: 100%;
   min-height: 1.5rem;
   font-size: 1rem;
   padding: 0 0.625rem;
+  border-bottom: ${({ hasBottomBorder, theme }) =>
+    hasBottomBorder ? `1px solid ${theme.primary[1]}` : 0};
 `
 
 const DragRegion = styled.div`
@@ -128,8 +131,8 @@ const DragRegion = styled.div`
   align-items: center;
   flex-grow: 1;
   color: rgba(255, 255, 255, 0.58);
-  font-size: 0.75rem;
-  letter-spacing: 0.75px;
+  font-size: 0.625rem;
+  letter-spacing: 0.2px;
   text-transform: uppercase;
 
   -webkit-app-region: drag;

--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -128,7 +128,8 @@ const DragRegion = styled.div`
   align-items: center;
   flex-grow: 1;
   color: rgba(255, 255, 255, 0.58);
-  font-size: 0.625rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.75px;
   text-transform: uppercase;
 
   -webkit-app-region: drag;


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/26205511/76312995-05e58600-62cc-11ea-9240-b3bde31787d8.PNG)
![Capture](https://user-images.githubusercontent.com/26205511/76326028-f2dcb100-62df-11ea-842b-5c21eec9a101.PNG)

This PR fixes the mismatch of the design as in 
https://app.zeplin.io/project/5b4660dc3b1097135eadcc35/screen/5e4d4c0a351535a8738b90d1
