### PR TITLE
fix(finsemble): conditionally load openfinFDC3 (ARTP-1013)

### DIFF
--- a/src/client/src/rt-interop/util/getProvider.ts
+++ b/src/client/src/rt-interop/util/getProvider.ts
@@ -1,10 +1,14 @@
-import { OpenFinFDC3, FDC3 } from '../fdc3'
-
-const isOpenFin = 'fin' in window
+const isFinsemble = 'FSBL' in window
+// TODO: We should not need to negate `isFinsemble` to check for OpenFin.
+// Somewhere, `fin` is being added to the `window` object even in electron/finsemble versions.
+const isOpenFin = 'fin' in window && !isFinsemble
 
 export const getProvider = () => {
   if (isOpenFin) {
+    // @ts-ignore
+    const { OpenFinFDC3, FDC3 } = require('../fdc3')
     const openFinFDC3 = new OpenFinFDC3()
+
     return new FDC3(openFinFDC3)
   }
 


### PR DESCRIPTION
Loading this was causing issues on initializing when running in a non-openfin environment. This change prevents those errors.