### PR TITLE
Feat/pop out for live rates

### DIFF
--- a/src/client/src/apps/MainRoute/Router.tsx
+++ b/src/client/src/apps/MainRoute/Router.tsx
@@ -26,7 +26,7 @@ export const Router: FC = () => (
     <Route
       path="/tiles/:currency/:tileView"
       render={() => (
-        <RouteWrapper title="live - rates">
+        <RouteWrapper windowType="sub" title="live - rates">
           <TileRoute />
         </RouteWrapper>
       )}

--- a/src/client/src/apps/MainRoute/data/connectionStatus/selectors.ts
+++ b/src/client/src/apps/MainRoute/data/connectionStatus/selectors.ts
@@ -1,12 +1,16 @@
 import { createSelector } from 'reselect'
-
 import { ConnectionStatus } from 'rt-system'
 import { GlobalState } from 'StoreTypes'
 
-export const selectState = (state: GlobalState) => state.connectionStatus
+const selectState = (state: GlobalState) => state.connectionStatus
 
-export const selectIsConnected = createSelector([selectState], state => state.status === ConnectionStatus.connected)
+const selectIsConnected = createSelector(
+  [selectState],
+  state => state.status === ConnectionStatus.connected,
+)
 
-export const selectUrl = createSelector([selectState], state => state.url)
+const selectUrl = createSelector([selectState], state => state.url)
 
-export const selectTransportType = createSelector([selectState], state => state.transportType)
+const selectTransportType = createSelector([selectState], state => state.transportType)
+
+export { selectIsConnected, selectUrl, selectTransportType }

--- a/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
+++ b/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
@@ -16,7 +16,7 @@ const AppLayout: React.FC<Props> = ({ before, header, body, footer, after }) => 
     <AppLayoutRoot data-qa="app-layout__root">
       {before}
 
-      <Header>{header}</Header>
+      {header !== null && <Header>{header}</Header>}
 
       <Body>{body}</Body>
 

--- a/src/client/src/apps/MainRoute/layouts/index.ts
+++ b/src/client/src/apps/MainRoute/layouts/index.ts
@@ -1,3 +1,4 @@
 export { default as AppLayout } from './AppLayout'
 export { default as DefaultLayout } from './DefaultLayout'
 export { layoutReducer } from './reducer'
+export { blotterSelector, analyticsSelector, liveRatesSelector } from './selectors'

--- a/src/client/src/apps/MainRoute/layouts/reducer.ts
+++ b/src/client/src/apps/MainRoute/layouts/reducer.ts
@@ -40,7 +40,7 @@ export const layoutReducer = (
             ...state,
             analytics: getWindowPosition(action),
           }
-        case externalWindowDefault.liveRatesRegion.config.name:
+        case externalWindowDefault.liveRatesRegion().config.name:
           return {
             ...state,
             liveRates: getWindowPosition(action),

--- a/src/client/src/apps/MainRoute/layouts/reducer.ts
+++ b/src/client/src/apps/MainRoute/layouts/reducer.ts
@@ -1,11 +1,7 @@
 import { LAYOUT_ACTION_TYPES, LayoutAction } from 'rt-actions'
 import { ContainerVisibility } from 'rt-actions/layoutActions'
-import { externalWindowDefault, WindowPosition } from 'rt-platforms'
+import { externalWindowDefault, WindowPosition, TilesLayout } from 'rt-platforms'
 import { ActionWithPayload } from 'rt-util/ActionHelper'
-
-interface TilesLayout {
-  [key: string]: WindowPosition
-}
 
 export interface LayoutState {
   blotter: WindowPosition
@@ -39,6 +35,14 @@ export const layoutReducer = (
           return {
             ...state,
             analytics: getWindowPosition(action),
+          }
+        case externalWindowDefault.spotTilesRegion.config.name:
+          return {
+            ...state,
+            spotTiles: {
+              ...state.spotTiles,
+              [action.payload.name!]: getWindowPosition(action),
+            },
           }
         default:
           // this is a spot tile

--- a/src/client/src/apps/MainRoute/layouts/reducer.ts
+++ b/src/client/src/apps/MainRoute/layouts/reducer.ts
@@ -7,6 +7,7 @@ export interface LayoutState {
   blotter: WindowPosition
   analytics: WindowPosition
   spotTiles: TilesLayout
+  liveRates: WindowPosition
 }
 
 const INITIAL_STATE: LayoutState = {
@@ -17,6 +18,9 @@ const INITIAL_STATE: LayoutState = {
     visible: true,
   },
   spotTiles: {},
+  liveRates: {
+    visible: true,
+  },
 }
 
 export const layoutReducer = (
@@ -36,13 +40,10 @@ export const layoutReducer = (
             ...state,
             analytics: getWindowPosition(action),
           }
-        case externalWindowDefault.spotTilesRegion.config.name:
+        case externalWindowDefault.liveRatesRegion.config.name:
           return {
             ...state,
-            spotTiles: {
-              ...state.spotTiles,
-              [action.payload.name!]: getWindowPosition(action),
-            },
+            liveRates: getWindowPosition(action),
           }
         default:
           // this is a spot tile

--- a/src/client/src/apps/MainRoute/layouts/selectors.ts
+++ b/src/client/src/apps/MainRoute/layouts/selectors.ts
@@ -7,4 +7,4 @@ export const blotterSelector = createSelector([selectState], state => state.blot
 
 export const analyticsSelector = createSelector([selectState], state => state.analytics)
 
-export const spotTilesSelector = createSelector([selectState], state => state.spotTiles)
+export const liveRatesSelector = createSelector([selectState], state => state.liveRates)

--- a/src/client/src/apps/MainRoute/layouts/selectors.ts
+++ b/src/client/src/apps/MainRoute/layouts/selectors.ts
@@ -1,10 +1,12 @@
-import { GlobalState } from 'StoreTypes'
 import { createSelector } from 'reselect'
+import { GlobalState } from 'StoreTypes'
 
-export const selectState = (state: GlobalState) => state.layoutService
+const selectState = (state: GlobalState) => state.layoutService
 
-export const blotterSelector = createSelector([selectState], state => state.blotter)
+const blotterSelector = createSelector([selectState], state => state.blotter)
 
-export const analyticsSelector = createSelector([selectState], state => state.analytics)
+const analyticsSelector = createSelector([selectState], state => state.analytics)
 
-export const liveRatesSelector = createSelector([selectState], state => state.liveRates)
+const liveRatesSelector = createSelector([selectState], state => state.liveRates)
+
+export { blotterSelector, analyticsSelector, liveRatesSelector }

--- a/src/client/src/apps/MainRoute/layouts/selectors.ts
+++ b/src/client/src/apps/MainRoute/layouts/selectors.ts
@@ -3,12 +3,8 @@ import { createSelector } from 'reselect'
 
 export const selectState = (state: GlobalState) => state.layoutService
 
-export const blotterSelector = createSelector(
-  [selectState],
-  state => state.blotter,
-)
+export const blotterSelector = createSelector([selectState], state => state.blotter)
 
-export const analyticsSelector = createSelector(
-  [selectState],
-  state => state.analytics,
-)
+export const analyticsSelector = createSelector([selectState], state => state.analytics)
+
+export const spotTilesSelector = createSelector([selectState], state => state.spotTiles)

--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -13,7 +13,7 @@ const AnalyticsRouteStyle = styled.div`
 const AnalyticsRoute = () => {
   return (
     <AnalyticsRouteStyle>
-      <AnalyticsContainer inExternalWindow={true} />
+      <AnalyticsContainer inExternalWindow />
     </AnalyticsRouteStyle>
   )
 }

--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -4,7 +4,7 @@ import { styled } from 'rt-theme'
 
 const AnalyticsRouteStyle = styled.div`
   /*height offset is needed for openfin controls*/
-  height: calc(100% - 21px);
+  height: calc(100% - 24px);
   padding: 0 0.625rem 0rem 0.625rem;
   overflow-x: scroll;
   margin: auto;

--- a/src/client/src/apps/MainRoute/routes/BlotterRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/BlotterRoute.tsx
@@ -7,7 +7,7 @@ import { InteropTopics, platformHasFeature, usePlatform } from 'rt-platforms'
 import { Subscription } from 'rxjs'
 
 const BlotterContainerStyle = styled('div')`
-  height: calc(100% - 21px);
+  height: calc(100% - 25px);
   width: 100%;
   padding: 0.625rem;
   margin: auto;
@@ -66,6 +66,7 @@ const BlotterRoute: React.FC<RouteComponentProps<{ symbol: string }>> = ({
   }, [platform])
 
   const filters = (filtersFromInterop && filtersFromInterop[0]) || getFiltersFromQueryStr(search)
+
   return (
     <BlotterContainerStyle>
       <BlotterContainer filters={filters} />

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -11,7 +11,7 @@ import { WorkspaceContainer } from '../widgets/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import DefaultLayout from '../layouts/DefaultLayout'
 import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
-import { analyticsSelector, blotterSelector, spotTilesSelector } from '../layouts/selectors'
+import { analyticsSelector, blotterSelector, liveRatesSelector } from '../layouts/selectors'
 import { useSelector } from 'react-redux'
 
 interface Props {
@@ -32,10 +32,8 @@ const addLayoutToConfig = (windowConfig: ExternalWindow, layout: any) => {
 const ShellRoute: React.FC<Props> = ({ header }) => {
   const blotter = useSelector(blotterSelector)
   const analytics = useSelector(analyticsSelector)
-  const spotTiles = useSelector(spotTilesSelector)
-  console.log(spotTiles)
-  console.log(blotter)
-  console.log(analytics)
+  const liveRates = useSelector(liveRatesSelector)
+
   const body = (
     <Resizer
       defaultHeight={30}
@@ -43,7 +41,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
         <BlotterWrapper data-qa="shell-route__blotter-wrapper">
           <TearOff
             id="blotter"
-            dragTearOff={true}
+            dragTearOff
             externalWindowProps={addLayoutToConfig(externalWindowDefault.blotterRegion, blotter)}
             render={(popOut, tornOff) => (
               <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
@@ -55,9 +53,9 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
       disabled={!blotter.visible}
     >
       <TearOff
-        id="tiles"
-        dragTearOff={true}
-        externalWindowProps={addLayoutToConfig(externalWindowDefault.spotTilesRegion, spotTiles)}
+        id="liveRates"
+        dragTearOff
+        externalWindowProps={addLayoutToConfig(externalWindowDefault.liveRatesRegion, liveRates)}
         render={(popOut, tornOff) => (
           <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
             <OverflowScroll>
@@ -65,13 +63,8 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
             </OverflowScroll>
           </WorkspaceWrapper>
         )}
-        tornOff={!blotter.visible}
+        tornOff={!liveRates.visible}
       />
-      {/* <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
-        <OverflowScroll>
-          <WorkspaceContainer />
-        </OverflowScroll>
-      </WorkspaceWrapper> */}
     </Resizer>
   )
 
@@ -79,7 +72,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
     <AnalyticsWrapper data-qa="shell-route__analytics-wrapper">
       <TearOff
         id="region"
-        dragTearOff={true}
+        dragTearOff
         externalWindowProps={addLayoutToConfig(externalWindowDefault.analyticsRegion, analytics)}
         render={(popOut, tornOff) => (
           <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable />

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,24 +1,21 @@
 import React from 'react'
-
+import { useSelector, useMemo } from 'react-redux'
 import { Resizer, TearOff } from 'rt-components'
-import { externalWindowDefault, ExternalWindow } from 'rt-platforms'
+import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
 import { BlotterContainer } from '../widgets/blotter'
 import StatusBar from '../widgets/status-bar'
 import StatusButton from '../widgets/status-connection'
 import { WorkspaceContainer } from '../widgets/workspace'
-
 import ReconnectModal from '../components/reconnect-modal'
-import DefaultLayout from '../layouts/DefaultLayout'
+import { analyticsSelector, blotterSelector, liveRatesSelector, DefaultLayout } from '../layouts'
 import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
-import { analyticsSelector, blotterSelector, liveRatesSelector } from '../layouts/selectors'
-import { useSelector } from 'react-redux'
 
 interface Props {
   header?: React.ReactChild
 }
 
-const addLayoutToConfig = (windowConfig: ExternalWindow, layout: any) => {
+const addLayoutToConfig = (windowConfig: ExternalWindow, layout: WindowPosition) => {
   return {
     ...windowConfig,
     config: {
@@ -34,6 +31,14 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
   const analytics = useSelector(analyticsSelector)
   const liveRates = useSelector(liveRatesSelector)
 
+  const lastRemainingService = useMemo(() => {
+    const numberOfVisibleService = [blotter.visible, analytics.visible, liveRates.visible].filter(
+      visible => visible === true,
+    ).length
+
+    return numberOfVisibleService === 1
+  }, [blotter.visible, analytics.visible, liveRates.visible])
+
   const body = (
     <Resizer
       defaultHeight={30}
@@ -44,7 +49,12 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
             dragTearOff
             externalWindowProps={addLayoutToConfig(externalWindowDefault.blotterRegion, blotter)}
             render={(popOut, tornOff) => (
-              <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+              <BlotterContainer
+                onPopoutClick={popOut}
+                tornOff={tornOff}
+                tearable
+                lastRemainingService
+              />
             )}
             tornOff={!blotter.visible}
           />

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -11,7 +11,7 @@ import { WorkspaceContainer } from '../widgets/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import DefaultLayout from '../layouts/DefaultLayout'
 import { BlotterWrapper, AnalyticsWrapper, WorkspaceWrapper, OverflowScroll } from './styled'
-import { analyticsSelector, blotterSelector } from '../layouts/selectors'
+import { analyticsSelector, blotterSelector, spotTilesSelector } from '../layouts/selectors'
 import { useSelector } from 'react-redux'
 
 interface Props {
@@ -32,6 +32,7 @@ const addLayoutToConfig = (windowConfig: ExternalWindow, layout: WindowPosition)
 const ShellRoute: React.FC<Props> = ({ header }) => {
   const blotter = useSelector(blotterSelector)
   const analytics = useSelector(analyticsSelector)
+  const spotTiles = useSelector(spotTilesSelector)
 
   const body = (
     <Resizer
@@ -41,12 +42,9 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
           <TearOff
             id="blotter"
             dragTearOff={true}
-            externalWindowProps={addLayoutToConfig(
-              externalWindowDefault.blotterRegion,
-              blotter,
-            )}
+            externalWindowProps={addLayoutToConfig(externalWindowDefault.blotterRegion, blotter)}
             render={(popOut, tornOff) => (
-              <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable/>
+              <BlotterContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
             )}
             tornOff={!blotter.visible}
           />
@@ -54,36 +52,41 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
       )}
       disabled={!blotter.visible}
     >
-      <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
-        <OverflowScroll>
-          <WorkspaceContainer/>
-        </OverflowScroll>
-      </WorkspaceWrapper>
+      <TearOff
+        id="tiles"
+        dragTearOff={true}
+        externalWindowProps={addLayoutToConfig(externalWindowDefault.spotTilesRegion, spotTiles)}
+        render={(popOut, tornOff) => (
+          <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
+            <OverflowScroll>
+              <WorkspaceContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+            </OverflowScroll>
+          </WorkspaceWrapper>
+        )}
+        tornOff={!blotter.visible}
+      />
     </Resizer>
-  );
+  )
 
   const aside = (
     <AnalyticsWrapper data-qa="shell-route__analytics-wrapper">
       <TearOff
         id="region"
         dragTearOff={true}
-        externalWindowProps={addLayoutToConfig(
-          externalWindowDefault.analyticsRegion,
-          analytics,
-        )}
+        externalWindowProps={addLayoutToConfig(externalWindowDefault.analyticsRegion, analytics)}
         render={(popOut, tornOff) => (
-          <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable/>
+          <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
         )}
         tornOff={!analytics.visible}
       />
     </AnalyticsWrapper>
-  );
+  )
 
   const footer = (
     <StatusBar>
-      <StatusButton/>
+      <StatusButton />
     </StatusBar>
-  );
+  )
 
   return (
     <DefaultLayout
@@ -91,7 +94,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
       body={body}
       aside={aside}
       footer={footer}
-      after={<ReconnectModal/>}
+      after={<ReconnectModal />}
     />
   )
 }

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { useSelector, useMemo } from 'react-redux'
+import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import { Resizer, TearOff } from 'rt-components'
 import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
@@ -52,8 +52,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
               <BlotterContainer
                 onPopoutClick={popOut}
                 tornOff={tornOff}
-                tearable
-                lastRemainingService
+                tearable={!lastRemainingService}
               />
             )}
             tornOff={!blotter.visible}
@@ -69,7 +68,11 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
         render={(popOut, tornOff) => (
           <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
             <OverflowScroll>
-              <WorkspaceContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+              <WorkspaceContainer
+                onPopoutClick={popOut}
+                tornOff={tornOff}
+                tearable={!lastRemainingService}
+              />
             </OverflowScroll>
           </WorkspaceWrapper>
         )}
@@ -85,7 +88,11 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
         dragTearOff
         externalWindowProps={addLayoutToConfig(externalWindowDefault.analyticsRegion, analytics)}
         render={(popOut, tornOff) => (
-          <AnalyticsContainer onPopoutClick={popOut} tornOff={tornOff} tearable />
+          <AnalyticsContainer
+            onPopoutClick={popOut}
+            tornOff={tornOff}
+            tearable={!lastRemainingService}
+          />
         )}
         tornOff={!analytics.visible}
       />

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
+import { useParams } from 'react-router'
 import { Resizer, TearOff } from 'rt-components'
 import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
 import { BlotterContainer } from '../widgets/blotter'
 import StatusBar from '../widgets/status-bar'
 import StatusButton from '../widgets/status-connection'
-import { WorkspaceContainer } from '../widgets/workspace'
+import { WorkspaceContainer, TileView } from '../widgets/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import { analyticsSelector, blotterSelector, liveRatesSelector, DefaultLayout } from '../layouts'
 import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
@@ -30,6 +31,8 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
   const blotter = useSelector(blotterSelector)
   const analytics = useSelector(analyticsSelector)
   const liveRates = useSelector(liveRatesSelector)
+
+  const { currency, tileView } = useParams()
 
   const lastRemainingService = useMemo(() => {
     const numberOfVisibleService = [blotter.visible, analytics.visible, liveRates.visible].filter(
@@ -64,7 +67,10 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
       <TearOff
         id="liveRates"
         dragTearOff
-        externalWindowProps={addLayoutToConfig(externalWindowDefault.liveRatesRegion, liveRates)}
+        externalWindowProps={addLayoutToConfig(
+          externalWindowDefault.liveRatesRegion(currency, tileView as TileView),
+          liveRates,
+        )}
         render={(popOut, tornOff) => (
           <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
             <OverflowScroll>

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { Resizer, TearOff } from 'rt-components'
-import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
+import { externalWindowDefault, ExternalWindow } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
 import { BlotterContainer } from '../widgets/blotter'
 import StatusBar from '../widgets/status-bar'
@@ -10,7 +10,7 @@ import { WorkspaceContainer } from '../widgets/workspace'
 
 import ReconnectModal from '../components/reconnect-modal'
 import DefaultLayout from '../layouts/DefaultLayout'
-import { BlotterWrapper, AnalyticsWrapper, WorkspaceWrapper, OverflowScroll } from './styled'
+import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
 import { analyticsSelector, blotterSelector, spotTilesSelector } from '../layouts/selectors'
 import { useSelector } from 'react-redux'
 
@@ -18,7 +18,7 @@ interface Props {
   header?: React.ReactChild
 }
 
-const addLayoutToConfig = (windowConfig: ExternalWindow, layout: WindowPosition) => {
+const addLayoutToConfig = (windowConfig: ExternalWindow, layout: any) => {
   return {
     ...windowConfig,
     config: {
@@ -33,7 +33,9 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
   const blotter = useSelector(blotterSelector)
   const analytics = useSelector(analyticsSelector)
   const spotTiles = useSelector(spotTilesSelector)
-
+  console.log(spotTiles)
+  console.log(blotter)
+  console.log(analytics)
   const body = (
     <Resizer
       defaultHeight={30}
@@ -65,6 +67,11 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
         )}
         tornOff={!blotter.visible}
       />
+      {/* <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
+        <OverflowScroll>
+          <WorkspaceContainer />
+        </OverflowScroll>
+      </WorkspaceWrapper> */}
     </Resizer>
   )
 

--- a/src/client/src/apps/MainRoute/widgets/analytics/AnalyticsContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/AnalyticsContainer.tsx
@@ -63,7 +63,4 @@ const AnalyticsContainer: React.FC<AnalyticsContainerProps> = ({
   )
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(AnalyticsContainer)
+export default connect(mapStateToProps, mapDispatchToProps)(AnalyticsContainer)

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/Analytics.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/Analytics.tsx
@@ -40,9 +40,9 @@ const Analytics: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowSize])
   return (
-    <AnalyticsWrapper canPopout={canPopout}>
+    <AnalyticsWrapper inExternalWindow={inExternalWindow}>
       <AnalyticsHeader>
-        {canPopout ? 'Analytics' : null}
+        Analytics
         <AnalyticsWindowControls canPopout={canPopout} onPopoutClick={onPopoutClick} />
       </AnalyticsHeader>
       <AnalyticsStyle inExternalWindow={inExternalWindow} data-qa="analytics__analytics-content">

--- a/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
+++ b/src/client/src/apps/MainRoute/widgets/analytics/components/styled.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'rt-theme'
 import { transparentColor } from '../globals/variables'
 
-export const AnalyticsWrapper = styled.div<{ canPopout: boolean }>`
+export const AnalyticsWrapper = styled.div<{ inExternalWindow?: boolean }>`
   width: 100%;
   height: 100%;
   max-width: 60rem;
@@ -11,7 +11,7 @@ export const AnalyticsWrapper = styled.div<{ canPopout: boolean }>`
   overflow-x: hidden;
   position: relative;
   display: grid;
-  grid-template-rows: ${({ canPopout }) => (canPopout ? '46px auto' : '0 auto')};
+  grid-template-rows: ${({ inExternalWindow }) => (inExternalWindow ? '0 auto' : '46px auto')};
 `
 
 export const AnalyticsHeader = styled.header`

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/Blotter.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/Blotter.tsx
@@ -120,9 +120,9 @@ const Blotter: React.FC<BlotterProps> = props => {
           columnDefs={columnDefinitions}
           defaultColDef={DEFAULT_COLUMN_DEFINITION}
           rowData={rows}
-          suppressMovableColumns={true}
+          suppressMovableColumns
           rowSelection="multiple"
-          suppressDragLeaveHidesColumns={true}
+          suppressDragLeaveHidesColumns
           getRowClass={getRowClass}
           onRowClicked={params => broadcastContext(params.data.symbol)}
           headerHeight={38}

--- a/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/blotter/components/BlotterHeader.tsx
@@ -1,7 +1,6 @@
+import React, { useCallback, useState, FC, MouseEvent } from 'react'
 import { GridApi } from 'ag-grid-community'
-import React, { useCallback, useState, FC } from 'react'
-import { flexStyle } from 'rt-components'
-import { PopoutIcon } from 'rt-components'
+import { flexStyle, PopoutIcon } from 'rt-components'
 import { styled } from 'rt-theme'
 import { columnDefinitions } from './blotterUtils'
 import BlotterToolbar from './toolbar/BlotterToolbar'
@@ -46,7 +45,7 @@ const Fill = styled.div`
 
 const BlotterHeader: FC<Props> = ({ gridApi, canPopout, onExportToExcelClick, onPopoutClick }) => {
   const popoutClickHandler = useCallback(
-    event => {
+    (event: MouseEvent) => {
       onPopoutClick(event.screenX, event.screenY)
     },
     [onPopoutClick],

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/analyticsTile/AnalyticsTile.tsx
@@ -125,7 +125,7 @@ const AnalyticsTile: React.FC<SpotTileProps> = props => {
               currencyPair={currencyPair}
               disabled={tradingDisabled}
               rfqState={rfqState}
-              isAnalyticsView={true}
+              isAnalyticsView
               rfq={rfq}
               notional={notional}
               lastTradeExecutionStatus={lastTradeExecutionStatus}

--- a/src/client/src/apps/MainRoute/widgets/status-connection/StatusButton.tsx
+++ b/src/client/src/apps/MainRoute/widgets/status-connection/StatusButton.tsx
@@ -62,13 +62,7 @@ export const StatusButton: React.FC<Props> = ({
 
       <ServiceListPopup open={isOpen} onClick={toggleOpen}>
         <ServiceList>
-          <AppUrl
-            title={appUrl}
-            readOnly={true}
-            value={appUrl}
-            onFocus={selectAll}
-            onClick={selectAll}
-          />
+          <AppUrl title={appUrl} readOnly value={appUrl} onFocus={selectAll} onClick={selectAll} />
 
           {services.map(service => (
             <Service key={service.serviceType} service={service} />

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -27,11 +27,12 @@ interface SpotTile {
 interface Props {
   spotTiles: SpotTile[]
   currencyOptions: string[]
+  canPopout: boolean
 }
 
 const ALL = 'ALL'
 
-const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions }) => {
+const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions, canPopout }) => {
   const { currency, tileView } = useParams()
 
   if (!currency || !tileView) {
@@ -41,6 +42,7 @@ const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions }) => {
   return (
     <div data-qa="workspace__tiles-workspace">
       <WorkspaceHeader
+        canPopout={canPopout}
         currencyOptions={currencyOptions}
         currency={currency}
         defaultOption={ALL}

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -28,11 +28,17 @@ interface Props {
   spotTiles: SpotTile[]
   currencyOptions: string[]
   canPopout: boolean
+  onPopoutClick?: () => void
 }
 
 const ALL = 'ALL'
 
-const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions, canPopout }) => {
+const Workspace: React.FC<Props> = ({
+  spotTiles = [],
+  currencyOptions,
+  canPopout,
+  onPopoutClick,
+}) => {
   const { currency, tileView } = useParams()
 
   if (!currency || !tileView) {
@@ -46,6 +52,7 @@ const Workspace: React.FC<Props> = ({ spotTiles = [], currencyOptions, canPopout
         currencyOptions={currencyOptions}
         currency={currency}
         defaultOption={ALL}
+        onPopoutClick={onPopoutClick}
         tileView={tileView as TileView}
       />
       <WorkspaceItems data-qa="workspace__tiles-workspace-items">

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -62,7 +62,7 @@ const Workspace: React.FC<Props> = ({
             <TearOff
               id={key}
               key={key}
-              dragTearOff={true}
+              dragTearOff
               externalWindowProps={appendTileViewToUrl(externalWindowProps, tileView as TileView)}
               render={(popOut, isTornOff) => (
                 <WorkspaceItem>

--- a/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
@@ -23,9 +23,7 @@ type Props = ReturnType<typeof mapStateToProps> & WorkspaceContainerOwnProps
 const WorkspaceContainer: React.FC<Props> = props => {
   const { status, tearable = false, tornOff, onPopoutClick } = props
   const { allowTearOff } = usePlatform()
-  console.log(allowTearOff)
-  console.log(tearable)
-  console.log(!tornOff)
+
   return (
     <Loadable
       status={status}

--- a/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
@@ -21,7 +21,7 @@ const mapStateToProps = (state: GlobalState) => ({
 type Props = ReturnType<typeof mapStateToProps> & WorkspaceContainerOwnProps
 
 const WorkspaceContainer: React.FC<Props> = props => {
-  const { status, tearable = false, tornOff } = props
+  const { status, tearable = false, tornOff, onPopoutClick } = props
   const { allowTearOff } = usePlatform()
   console.log(allowTearOff)
   console.log(tearable)
@@ -29,7 +29,13 @@ const WorkspaceContainer: React.FC<Props> = props => {
   return (
     <Loadable
       status={status}
-      render={() => <Workspace {...props} canPopout={allowTearOff && tearable && !tornOff} />}
+      render={() => (
+        <Workspace
+          {...props}
+          canPopout={allowTearOff && tearable && !tornOff}
+          onPopoutClick={onPopoutClick}
+        />
+      )}
       message="Pricing Disconnected"
     />
   )

--- a/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/WorkspaceContainer.tsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Loadable } from 'rt-components'
+import { usePlatform } from 'rt-platforms'
 import { GlobalState } from 'StoreTypes'
 import { selectExecutionStatus, selectSpotTiles, selectSpotCurrencies } from './selectors'
 import Workspace from './Workspace'
+
+interface WorkspaceContainerOwnProps {
+  onPopoutClick?: () => void
+  tornOff?: boolean
+  tearable?: boolean
+}
 
 const mapStateToProps = (state: GlobalState) => ({
   spotTiles: selectSpotTiles(state),
@@ -11,14 +18,21 @@ const mapStateToProps = (state: GlobalState) => ({
   currencyOptions: selectSpotCurrencies(state),
 })
 
-type Props = ReturnType<typeof mapStateToProps>
+type Props = ReturnType<typeof mapStateToProps> & WorkspaceContainerOwnProps
 
-const WorkspaceContainer: React.FC<Props> = props => (
-  <Loadable
-    status={props.status}
-    render={() => <Workspace {...props} />}
-    message="Pricing Disconnected"
-  />
-)
+const WorkspaceContainer: React.FC<Props> = props => {
+  const { status, tearable = false, tornOff } = props
+  const { allowTearOff } = usePlatform()
+  console.log(allowTearOff)
+  console.log(tearable)
+  console.log(!tornOff)
+  return (
+    <Loadable
+      status={status}
+      render={() => <Workspace {...props} canPopout={allowTearOff && tearable && !tornOff} />}
+      message="Pricing Disconnected"
+    />
+  )
+}
 
 export default connect(mapStateToProps)(WorkspaceContainer)

--- a/src/client/src/apps/MainRoute/widgets/workspace/index.ts
+++ b/src/client/src/apps/MainRoute/widgets/workspace/index.ts
@@ -1,1 +1,2 @@
 export { default as WorkspaceContainer } from './WorkspaceContainer'
+export { TileView } from './workspaceHeader'

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/ToggleView.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/ToggleView.tsx
@@ -7,9 +7,10 @@ import { ChartIcon } from 'rt-components'
 interface Props {
   tileView: TileView
   currency: string
+  canPopout: boolean
 }
 
-const ToggleView: React.FC<Props> = ({ tileView, currency }) => {
+const ToggleView: React.FC<Props> = ({ tileView, currency, canPopout }) => {
   const isAnalyticsViewActive = TileView.Analytics === tileView
   const goToView = isAnalyticsViewActive ? TileView.Normal : TileView.Analytics
 
@@ -19,7 +20,7 @@ const ToggleView: React.FC<Props> = ({ tileView, currency }) => {
       data-qa="workspace-header__nav-item--view"
       data-qa-id={`workspace-view-${tileView.toLowerCase()}`}
     >
-      <NavLink to={`/${currency}/${goToView}`}>
+      <NavLink to={`${canPopout ? '' : '/tiles'}/${currency}/${goToView}`}>
         <ChartIcon active={isAnalyticsViewActive} />
       </NavLink>
     </NavItem>

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceControl.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceControl.tsx
@@ -1,0 +1,30 @@
+import React, { FC, useCallback, MouseEvent } from 'react'
+import { PopoutIcon } from 'rt-components'
+import { styled } from 'rt-theme'
+
+interface WorkspaceControlProps {
+  onPopoutClick?: (x: number, y: number) => void
+}
+
+const WorkspaceControl: FC<WorkspaceControlProps> = props => {
+  const { onPopoutClick } = props
+
+  const handlePopoutClick = useCallback(
+    (e: MouseEvent) => {
+      onPopoutClick && onPopoutClick(e.screenX, e.screenY)
+    },
+    [onPopoutClick],
+  )
+
+  return <PopoutButton onClick={handlePopoutClick}>{PopoutIcon}</PopoutButton>
+}
+
+const PopoutButton = styled('button')`
+  &:hover {
+    .hover-state {
+      fill: #5f94f5;
+    }
+  }
+`
+
+export default WorkspaceControl

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -9,6 +9,7 @@ interface Props {
   tileView: TileView
   currency: string
   defaultOption: string
+  canPopout: boolean
 }
 
 const WorkspaceHeader: React.FC<Props> = ({
@@ -16,8 +17,10 @@ const WorkspaceHeader: React.FC<Props> = ({
   tileView,
   currency,
   currencyOptions,
+  canPopout,
 }) => {
   const options = [defaultOption, ...currencyOptions]
+
   return (
     <Header>
       <LeftNav>
@@ -35,6 +38,7 @@ const WorkspaceHeader: React.FC<Props> = ({
       </LeftNav>
       <RightNav>
         <ToggleView currency={currency} tileView={tileView} />
+        {canPopout && 'HI'}
       </RightNav>
     </Header>
   )

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -35,7 +35,9 @@ const WorkspaceHeader: React.FC<Props> = ({
             data-qa="workspace-header__nav-item"
             data-qa-id={`currency-option-${currencyOption.toLowerCase()}`}
           >
-            <NavLink to={`/${currencyOption}/${tileView}`}>{currencyOption}</NavLink>
+            <NavLink to={`${canPopout ? '' : '/tiles'}/${currencyOption}/${tileView}`}>
+              {currencyOption}
+            </NavLink>
           </NavItem>
         ))}
       </LeftNav>

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -42,7 +42,7 @@ const WorkspaceHeader: React.FC<Props> = ({
         ))}
       </LeftNav>
       <RightNav>
-        <ToggleView currency={currency} tileView={tileView} />
+        <ToggleView canPopout={canPopout} currency={currency} tileView={tileView} />
         {canPopout && (
           <WorkspaceControl onPopoutClick={onPopoutClick} data-qa="tiles-header__pop-out-button" />
         )}

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -42,12 +42,7 @@ const WorkspaceHeader: React.FC<Props> = ({
       <RightNav>
         <ToggleView currency={currency} tileView={tileView} />
         {canPopout && (
-          <>
-            <WorkspaceControl
-              onPopoutClick={onPopoutClick}
-              data-qa="blotter-header__pop-out-button"
-            />
-          </>
+          <WorkspaceControl onPopoutClick={onPopoutClick} data-qa="tiles-header__pop-out-button" />
         )}
       </RightNav>
     </Header>

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom'
 import { Header, LeftNav, LeftNavItemFirst, NavItem, RightNav } from './styled'
 import { TileView } from './types'
 import ToggleView from './ToggleView'
+import WorkspaceControl from './WorkspaceControl'
 
 interface Props {
   currencyOptions: string[]
@@ -10,6 +11,7 @@ interface Props {
   currency: string
   defaultOption: string
   canPopout: boolean
+  onPopoutClick?: (x: number, y: number) => void
 }
 
 const WorkspaceHeader: React.FC<Props> = ({
@@ -18,6 +20,7 @@ const WorkspaceHeader: React.FC<Props> = ({
   currency,
   currencyOptions,
   canPopout,
+  onPopoutClick,
 }) => {
   const options = [defaultOption, ...currencyOptions]
 
@@ -38,7 +41,14 @@ const WorkspaceHeader: React.FC<Props> = ({
       </LeftNav>
       <RightNav>
         <ToggleView currency={currency} tileView={tileView} />
-        {canPopout && 'HI'}
+        {canPopout && (
+          <>
+            <WorkspaceControl
+              onPopoutClick={onPopoutClick}
+              data-qa="blotter-header__pop-out-button"
+            />
+          </>
+        )}
       </RightNav>
     </Header>
   )

--- a/src/client/src/rt-components/flex/Flex.ts
+++ b/src/client/src/rt-components/flex/Flex.ts
@@ -10,21 +10,6 @@ interface Flex {
   alignItems?: 'center' | 'stretch' | 'flex-end' | 'flex-start'
 }
 
-// const bg = (color: string) => {
-//   return css<hhh>`
-//     background-color: ${color}
-//   `;
-// }
-
-// interface ButtonProps {
-//   primary: boolean;
-// }
-// const StyledButton = styled('button')<ButtonProps>`
-// `
-
-// const Button = ({ primary, ...rest }) => (
-//   <StyledButton primary={primary} {...rest} />
-// )
 export const flexStyle = ({ direction, wrap, justifyContent, alignItems }: Flex) =>
   css`
     display: flex;

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -41,7 +41,7 @@ const RouteWrapper: React.FC<RouteWrapperProps> = props => {
         setFromLauncher(isLauncher)
       })
       .catch(() => {
-        console.error('Can not find parent window')
+        console.error('Cannot find parent window')
       })
   }, [])
 

--- a/src/client/src/rt-components/tear-off/ExternalWindow.tsx
+++ b/src/client/src/rt-components/tear-off/ExternalWindow.tsx
@@ -13,15 +13,11 @@ const defaultConfig: WindowConfig = {
 }
 
 export interface ExternalWindowProps {
-  title?: string
-  onBlock?: () => void
   onUnload: () => void
   config?: WindowConfig
 }
 
 const ExternalWindow: FC<ExternalWindowProps> = ({
-  title = '',
-  onBlock = () => undefined,
   onUnload = () => undefined,
   config = defaultConfig,
 }) => {

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -1,9 +1,9 @@
-import React, {useCallback, useRef} from 'react'
-import ExternalWindow, {ExternalWindowProps} from './ExternalWindow'
-import {styled} from 'rt-theme'
-import {useDispatch} from 'react-redux'
-import {usePlatform} from 'rt-platforms'
-import {LayoutActions} from 'rt-actions'
+import React, { useCallback, useRef } from 'react'
+import ExternalWindow, { ExternalWindowProps } from './ExternalWindow'
+import { styled } from 'rt-theme'
+import { useDispatch } from 'react-redux'
+import { usePlatform } from 'rt-platforms'
+import { LayoutActions } from 'rt-actions'
 
 type RenderCB = (popOut: (x?: number, y?: number) => void, tornOff: boolean) => JSX.Element
 
@@ -41,7 +41,7 @@ const createDragImage = (event: React.DragEvent<HTMLDivElement>) => {
     const offsetY = event.clientY - clientRect.top
 
     dt.setDragImage(node, offsetX, offsetY)
-    setTimeout(function () {
+    setTimeout(function() {
       node.remove()
     })
   }
@@ -57,8 +57,8 @@ export interface TearOffProps {
   dragTearOff: boolean
 }
 
-const TearOff: React.FC<TearOffProps> = ({render, externalWindowProps, tornOff, dragTearOff}) => {
-  const {allowTearOff} = usePlatform()
+const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff, dragTearOff }) => {
+  const { allowTearOff } = usePlatform()
   const targetMouseXRef = useRef<number>()
   const targetMouseYRef = useRef<number>()
 
@@ -66,20 +66,29 @@ const TearOff: React.FC<TearOffProps> = ({render, externalWindowProps, tornOff, 
   const windowName = externalWindowProps.config && externalWindowProps.config.name
   const popOut = useCallback(
     (mouseScreenX?: number, mouseScreenY?: number) => {
-      const popOutX = typeof targetMouseXRef.current !== 'undefined' && typeof mouseScreenX !== 'undefined' ?
-        mouseScreenX - targetMouseXRef.current : mouseScreenX
-      const popOutY = typeof targetMouseYRef.current !== 'undefined' && typeof mouseScreenY !== 'undefined' ?
-        mouseScreenY - targetMouseYRef.current : mouseScreenY
+      const popOutX =
+        typeof targetMouseXRef.current !== 'undefined' && typeof mouseScreenX !== 'undefined'
+          ? mouseScreenX - targetMouseXRef.current
+          : mouseScreenX
+      const popOutY =
+        typeof targetMouseYRef.current !== 'undefined' && typeof mouseScreenY !== 'undefined'
+          ? mouseScreenY - targetMouseYRef.current
+          : mouseScreenY
 
       dispatch(
-        LayoutActions.updateContainerVisibilityAction({name: windowName, display: false, x:popOutX, y:popOutY}),
+        LayoutActions.updateContainerVisibilityAction({
+          name: windowName,
+          display: false,
+          x: popOutX,
+          y: popOutY,
+        }),
       )
     },
     [windowName, dispatch],
   )
   const popIn = useCallback(
     () =>
-      dispatch(LayoutActions.updateContainerVisibilityAction({name: windowName, display: true})),
+      dispatch(LayoutActions.updateContainerVisibilityAction({ name: windowName, display: true })),
     [windowName, dispatch],
   )
 
@@ -89,7 +98,7 @@ const TearOff: React.FC<TearOffProps> = ({render, externalWindowProps, tornOff, 
     // calculating mouse position relative to the torn off widget
     const clientRect = eventTarget.getBoundingClientRect()
     targetMouseXRef.current = event.clientX - clientRect.left
-    targetMouseYRef.current =  event.clientY - clientRect.top
+    targetMouseYRef.current = event.clientY - clientRect.top
   }
 
   if (tornOff) {

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -28,7 +28,20 @@ const analyticsRegion: ExternalWindow = {
   },
 }
 
+const spotTilesRegion: ExternalWindow = {
+  title: 'Analytics',
+  config: {
+    name: 'analytics',
+    width: 352, // 332 content + 10 padding
+    height: 800,
+    minWidth: 360,
+    minHeight: 200,
+    url: '/analytics',
+  },
+}
+
 export const externalWindowDefault = {
   blotterRegion,
   analyticsRegion,
+  spotTilesRegion,
 }

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -1,4 +1,5 @@
 import { WindowConfig } from './'
+import { TileView } from '../apps/MainRoute/widgets/workspace'
 export interface ExternalWindow {
   title: string
   config: WindowConfig
@@ -28,7 +29,7 @@ const analyticsRegion: ExternalWindow = {
   },
 }
 
-const liveRatesRegion: ExternalWindow = {
+const liveRatesRegion = (currency?: string, tileView?: TileView): ExternalWindow => ({
   title: 'LiveRates',
   config: {
     name: 'LiveRates',
@@ -36,9 +37,9 @@ const liveRatesRegion: ExternalWindow = {
     height: 617,
     minWidth: 664,
     minHeight: 617,
-    url: '/tiles/ALL/Analytics',
+    url: `/tiles/${currency ? currency : 'ALL'}/${tileView ? tileView : 'Analytics'}`,
   },
-}
+})
 
 export const externalWindowDefault = {
   blotterRegion,

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -29,14 +29,14 @@ const analyticsRegion: ExternalWindow = {
 }
 
 const spotTilesRegion: ExternalWindow = {
-  title: 'Analytics',
+  title: 'SpotTiles',
   config: {
-    name: 'analytics',
-    width: 352, // 332 content + 10 padding
-    height: 800,
-    minWidth: 360,
-    minHeight: 200,
-    url: '/analytics',
+    name: 'spotTiles',
+    width: 664,
+    height: 617,
+    minWidth: 664,
+    minHeight: 617,
+    url: '/tiles/:currency/:tileView',
   },
 }
 

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -28,20 +28,20 @@ const analyticsRegion: ExternalWindow = {
   },
 }
 
-const spotTilesRegion: ExternalWindow = {
-  title: 'SpotTiles',
+const liveRatesRegion: ExternalWindow = {
+  title: 'LiveRates',
   config: {
-    name: 'spotTiles',
+    name: 'LiveRates',
     width: 664,
     height: 617,
     minWidth: 664,
     minHeight: 617,
-    url: '/tiles/:currency/:tileView',
+    url: '/tiles/ALL/Analytics',
   },
 }
 
 export const externalWindowDefault = {
   blotterRegion,
   analyticsRegion,
-  spotTilesRegion,
+  liveRatesRegion,
 }

--- a/src/client/src/rt-platforms/index.ts
+++ b/src/client/src/rt-platforms/index.ts
@@ -3,6 +3,7 @@ import * as externalWindowDefault from './externalWindowDefault'
 
 export type WindowConfig = types.WindowConfig
 export type WindowPosition = types.WindowPosition
+export type TilesLayout = types.TilesLayout
 export type PlatformName = types.PlatformName
 
 export { InteropTopics } from './types'

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -21,7 +21,7 @@ export const openfinWindowStates: { readonly [key: string]: WindowState } = {
   Maximized: 'maximized',
 }
 
-const generateRandomName = function() {
+function generateRandomName() {
   let text = ''
   const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 

--- a/src/client/src/rt-platforms/types.ts
+++ b/src/client/src/rt-platforms/types.ts
@@ -7,6 +7,10 @@ export interface WindowPosition {
   y?: number
 }
 
+export interface TilesLayout {
+  [key: string]: WindowPosition
+}
+
 export interface WindowConfig {
   name: string
   url: string


### PR DESCRIPTION
This PR is to add the functionality of letting the live rates to be popped out as the other services.
However, the last service remaining in the main window will not be allowed to be popped out.

Openfin
![Mar-16-2020 12-36-47](https://user-images.githubusercontent.com/26205511/76759137-00cc7f00-6783-11ea-8d2c-a30cc55bcd17.gif)
Web
![Mar-16-2020 12-36-58](https://user-images.githubusercontent.com/26205511/76759161-075af680-6783-11ea-84f1-df25d92219d5.gif)
