### PR TITLE
fix(tiles): return to clean url for tiles state (ARTP-1075)

### DIFF
--- a/src/client/src/apps/MainRoute/Router.tsx
+++ b/src/client/src/apps/MainRoute/Router.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react'
-import { Route, Switch, Redirect } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 import { RouteWrapper } from 'rt-components'
 import { currencyFormatter } from 'rt-util'
 import { AnalyticsRoute, BlotterRoute, SpotRoute, ShellRoute, TileRoute } from './routes'
 
 export const Router: FC = () => (
   <Switch>
-    <Redirect exact from="/" to="/ALL/Analytics" />
     <Route
       path="/analytics"
       render={() => (
@@ -24,7 +23,7 @@ export const Router: FC = () => (
       )}
     />
     <Route
-      path="/tiles/:currency/:tileView"
+      path="/tiles"
       render={() => (
         <RouteWrapper windowType="sub" title="live - rates">
           <TileRoute />
@@ -41,7 +40,7 @@ export const Router: FC = () => (
     />
     <Route
       exact
-      path="/:currency/:tileView"
+      path="/"
       render={() => (
         <RouteWrapper>
           <ShellRoute />

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { useParams } from 'react-router'
 import { Resizer, TearOff } from 'rt-components'
 import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
 import { BlotterContainer } from '../widgets/blotter'
 import StatusBar from '../widgets/status-bar'
 import StatusButton from '../widgets/status-connection'
-import { WorkspaceContainer, TileView } from '../widgets/workspace'
+import { WorkspaceContainer } from '../widgets/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import { analyticsSelector, blotterSelector, liveRatesSelector, DefaultLayout } from '../layouts'
 import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
@@ -31,8 +30,6 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
   const blotter = useSelector(blotterSelector)
   const analytics = useSelector(analyticsSelector)
   const liveRates = useSelector(liveRatesSelector)
-
-  const { currency, tileView } = useParams()
 
   const lastRemainingService = useMemo(() => {
     const numberOfVisibleService = [blotter.visible, analytics.visible, liveRates.visible].filter(
@@ -67,10 +64,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
       <TearOff
         id="liveRates"
         dragTearOff
-        externalWindowProps={addLayoutToConfig(
-          externalWindowDefault.liveRatesRegion(currency, tileView as TileView),
-          liveRates,
-        )}
+        externalWindowProps={addLayoutToConfig(externalWindowDefault.liveRatesRegion(), liveRates)}
         render={(popOut, tornOff) => (
           <WorkspaceWrapper data-qa="shell-route__workspace-wrapper">
             <OverflowScroll>

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { TearOff } from 'rt-components'
-import { useParams } from 'react-router'
 import { styled } from 'rt-theme'
 import SpotTileContainer from '../spotTile/SpotTileContainer'
 import { WorkspaceHeader, TileView } from './workspaceHeader'
@@ -39,11 +38,8 @@ const Workspace: React.FC<Props> = ({
   canPopout,
   onPopoutClick,
 }) => {
-  const { currency, tileView } = useParams()
-
-  if (!currency || !tileView) {
-    return null
-  }
+  const [currency, setCurrencyOption] = useState(ALL)
+  const [tileView, setTileView] = useState(TileView.Analytics)
 
   return (
     <div data-qa="workspace__tiles-workspace">
@@ -53,11 +49,13 @@ const Workspace: React.FC<Props> = ({
         currency={currency}
         defaultOption={ALL}
         onPopoutClick={onPopoutClick}
+        onCurrencyChange={setCurrencyOption}
+        onTileViewChange={setTileView}
         tileView={tileView as TileView}
       />
       <WorkspaceItems data-qa="workspace__tiles-workspace-items">
         {spotTiles
-          .filter(({ key }) => key.includes(currency) || currency === 'ALL')
+          .filter(({ key }) => key.includes(currency) || currency === ALL)
           .map(({ key, externalWindowProps, tornOff }) => (
             <TearOff
               id={key}

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/ToggleView.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/ToggleView.tsx
@@ -1,29 +1,52 @@
 import React from 'react'
-import { NavLink } from 'react-router-dom'
-import { NavItem } from './styled'
-import { TileView } from './types'
+import { styled } from 'rt-theme'
 import { ChartIcon } from 'rt-components'
+import { TileView } from './types'
+import { NavItem } from './styled'
 
 interface Props {
   tileView: TileView
-  currency: string
-  canPopout: boolean
+  onTileViewChange: (tileView: TileView) => void
 }
 
-const ToggleView: React.FC<Props> = ({ tileView, currency, canPopout }) => {
-  const isAnalyticsViewActive = TileView.Analytics === tileView
-  const goToView = isAnalyticsViewActive ? TileView.Normal : TileView.Analytics
+const ToggleItem = styled(NavItem)<{ active: boolean }>`
+  list-style-type: none;
+  margin-left: 15px;
+
+  svg {
+    color: ${({ theme }) => theme.secondary.base};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-content: center;
+    height: 34px;
+    line-height: 34px;
+    opacity: ${({ active }) => (active ? '1' : '0.52')};
+    background: ${({ active, theme }) => (active ? theme.core.lightBackground : 'none')};
+    text-decoration: none;
+    padding: 5px;
+    min-width: 34px;
+    min-height: 34px;
+    text-align: center;
+    border-radius: 2px;
+  }
+`
+
+const ToggleView: React.FC<Props> = ({ tileView, onTileViewChange }) => {
+  const handleToggleView = () => {
+    const newView = TileView.Analytics === tileView ? TileView.Normal : TileView.Analytics
+    onTileViewChange(newView)
+  }
 
   return (
-    <NavItem
-      active={isAnalyticsViewActive}
+    <ToggleItem
+      active={TileView.Analytics === tileView}
       data-qa="workspace-header__nav-item--view"
       data-qa-id={`workspace-view-${tileView.toLowerCase()}`}
+      onClick={handleToggleView}
     >
-      <NavLink to={`${canPopout ? '' : '/tiles'}/${currency}/${goToView}`}>
-        <ChartIcon active={isAnalyticsViewActive} />
-      </NavLink>
-    </NavItem>
+      <ChartIcon active={TileView.Analytics === tileView} />
+    </ToggleItem>
   )
 }
 

--- a/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/workspaceHeader/WorkspaceHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { NavLink } from 'react-router-dom'
 import { Header, LeftNav, LeftNavItemFirst, NavItem, RightNav } from './styled'
 import { TileView } from './types'
 import ToggleView from './ToggleView'
@@ -12,6 +11,8 @@ interface Props {
   defaultOption: string
   canPopout: boolean
   onPopoutClick?: (x: number, y: number) => void
+  onCurrencyChange: (currency: string) => void
+  onTileViewChange: (tileView: TileView) => void
 }
 
 const WorkspaceHeader: React.FC<Props> = ({
@@ -21,6 +22,8 @@ const WorkspaceHeader: React.FC<Props> = ({
   currencyOptions,
   canPopout,
   onPopoutClick,
+  onCurrencyChange,
+  onTileViewChange,
 }) => {
   const options = [defaultOption, ...currencyOptions]
 
@@ -34,15 +37,14 @@ const WorkspaceHeader: React.FC<Props> = ({
             active={currencyOption === currency}
             data-qa="workspace-header__nav-item"
             data-qa-id={`currency-option-${currencyOption.toLowerCase()}`}
+            onClick={() => onCurrencyChange(currencyOption)}
           >
-            <NavLink to={`${canPopout ? '' : '/tiles'}/${currencyOption}/${tileView}`}>
-              {currencyOption}
-            </NavLink>
+            {currencyOption}
           </NavItem>
         ))}
       </LeftNav>
       <RightNav>
-        <ToggleView canPopout={canPopout} currency={currency} tileView={tileView} />
+        <ToggleView tileView={tileView} onTileViewChange={onTileViewChange} />
         {canPopout && (
           <WorkspaceControl onPopoutClick={onPopoutClick} data-qa="tiles-header__pop-out-button" />
         )}

--- a/src/client/src/rt-components/icons/ChartIcon.tsx
+++ b/src/client/src/rt-components/icons/ChartIcon.tsx
@@ -6,7 +6,7 @@ interface Props {
   width?: number
 }
 
-const ChartIcon: React.FC<Props> = ({ active = false, height, width }) => (
+const ChartIcon: React.FC<Props> = ({ active = false, height = 24, width = 24 }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 8" height={height} width={width}>
     <g fill="none" fillRule="evenodd">
       <path d="M0 0H24V24H0z" transform="translate(-4 -8)" />

--- a/src/client/src/rt-interop/intents/showMarket.ts
+++ b/src/client/src/rt-interop/intents/showMarket.ts
@@ -14,7 +14,7 @@ export async function showMarket({ window }: Platform) {
     {
       ...defaultConfig,
       height: 900,
-      url: `${windowOrigin}/tiles/ALL/Analytics`,
+      url: `${windowOrigin}/tiles`,
     },
     () => (openedWindow = undefined),
   )

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -1,5 +1,5 @@
 import { WindowConfig } from './'
-import { TileView } from '../apps/MainRoute/widgets/workspace'
+
 export interface ExternalWindow {
   title: string
   config: WindowConfig
@@ -29,7 +29,7 @@ const analyticsRegion: ExternalWindow = {
   },
 }
 
-const liveRatesRegion = (currency?: string, tileView?: TileView): ExternalWindow => ({
+const liveRatesRegion = (): ExternalWindow => ({
   title: 'LiveRates',
   config: {
     name: 'LiveRates',
@@ -37,7 +37,7 @@ const liveRatesRegion = (currency?: string, tileView?: TileView): ExternalWindow
     height: 617,
     minWidth: 664,
     minHeight: 617,
-    url: `/tiles/${currency ? currency : 'ALL'}/${tileView ? tileView : 'Analytics'}`,
+    url: '/tiles',
   },
 })
 

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -11,7 +11,7 @@ services:
     image: ${DOCKER_USER}/e2ebase:${BUILD_VERSION}
     hostname: e2e
     container_name: e2e
-    command: 'npm run e2e -- --chromeDriver=/usr/bin/chromedriver --baseUrl=http://nginx/ALL/Normal'
+    command: 'npm run e2e -- --chromeDriver=/usr/bin/chromedriver --baseUrl=http://nginx'
     depends_on:
       - e2ebase
       - client


### PR DESCRIPTION
Url keeps the same when currencies or tile view is changed. However, when we pop out spot tiles it starts from default values.

![cleanurl](https://user-images.githubusercontent.com/1596197/77537188-f0f91d00-6e9d-11ea-8698-c8592d81a5c9.gif)
