### PR TITLE
fix(laucher): remember position for opened windows (ARTP-1060)

### DIFF
--- a/src/client/src/rt-interop/intents/defaultWindowConfig.ts
+++ b/src/client/src/rt-interop/intents/defaultWindowConfig.ts
@@ -6,8 +6,6 @@ export const defaultConfig: WindowConfig = {
   width: 600,
   height: 400,
   center: 'parent',
-  x: 0,
-  y: 0,
 }
 
 // Safer than location.origin due to browser support

--- a/src/client/src/rt-interop/intents/showBlotter.ts
+++ b/src/client/src/rt-interop/intents/showBlotter.ts
@@ -4,6 +4,15 @@ import { defaultConfig, windowOrigin } from './defaultWindowConfig'
 import { BlotterFilters, validateFilters } from 'apps/MainRoute/widgets/blotter/blotterTradesFilter'
 
 let openedWindow: PlatformWindow | undefined
+let updatedPosition: { x: number | undefined; y: number | undefined } = {
+  x: undefined,
+  y: undefined,
+}
+
+const updatePosition = ({ left, top }: { left: number; top: number }) => {
+  updatedPosition.x = left
+  updatedPosition.y = top
+}
 
 function updatedOpenedWindow(
   blotterWindow: PlatformWindow,
@@ -32,8 +41,11 @@ async function openNewWindow(
       ...defaultConfig,
       width: 1100,
       url,
+      name: 'blotter',
+      ...updatedPosition,
     },
     () => (openedWindow = undefined),
+    updatePosition,
   )
 }
 

--- a/src/client/src/rt-interop/intents/showCurrencyPair.ts
+++ b/src/client/src/rt-interop/intents/showCurrencyPair.ts
@@ -2,6 +2,15 @@ import { PlatformWindow, Platform } from 'rt-platforms'
 import { defaultConfig, windowOrigin } from './defaultWindowConfig'
 
 let openedWindow: PlatformWindow | undefined
+let updatedPosition: { x: number | undefined; y: number | undefined } = {
+  x: undefined,
+  y: undefined,
+}
+
+const updatePosition = ({ left, top }: { left: number; top: number }) => {
+  updatedPosition.x = left
+  updatedPosition.y = top
+}
 
 async function openNewWindow(
   platform: Platform,
@@ -12,10 +21,12 @@ async function openNewWindow(
       ...defaultConfig,
       width: 380,
       height: 200,
-      center: 'screen',
+      name: currencyPair,
       url: `${windowOrigin}/spot/${currencyPair}?tileView=Analytics`,
+      ...updatedPosition,
     },
     () => (openedWindow = undefined),
+    updatePosition,
   )
 }
 

--- a/src/client/src/rt-interop/intents/showMarket.ts
+++ b/src/client/src/rt-interop/intents/showMarket.ts
@@ -2,6 +2,15 @@ import { Platform, PlatformWindow } from 'rt-platforms'
 import { defaultConfig, windowOrigin } from './defaultWindowConfig'
 
 let openedWindow: PlatformWindow | undefined
+let updatedPosition: { x: number | undefined; y: number | undefined } = {
+  x: undefined,
+  y: undefined,
+}
+
+const updatePosition = ({ left, top }: { left: number; top: number }) => {
+  updatedPosition.x = left
+  updatedPosition.y = top
+}
 
 export async function showMarket({ window }: Platform) {
   if (openedWindow) {
@@ -9,14 +18,19 @@ export async function showMarket({ window }: Platform) {
     openedWindow.bringToFront && openedWindow.bringToFront()
     return
   }
+
   // TODO: position and size of the window, also make it frame-less
   openedWindow = await window.open(
     {
       ...defaultConfig,
+      name: 'market',
       height: 900,
       url: `${windowOrigin}/tiles`,
+      saveWindowState: true,
+      ...updatedPosition,
     },
     () => (openedWindow = undefined),
+    updatePosition,
   )
   if (!openedWindow) {
     console.log(`Error opening new window`)

--- a/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/workspaces.ts
@@ -46,6 +46,7 @@ async function appRestoreHandler(
             display: true,
           })
         },
+        () => {},
         { defaultLeft: win.bounds.left, defaultTop: win.bounds.top },
       )
 

--- a/src/client/src/rt-platforms/platformWindow.ts
+++ b/src/client/src/rt-platforms/platformWindow.ts
@@ -1,7 +1,11 @@
 import { WindowConfig } from './types'
 
 export type PlatformWindowApi = {
-  open: (config: WindowConfig, onClose?: () => void) => Promise<PlatformWindow | undefined>
+  open: (
+    config: WindowConfig,
+    onClose?: () => void,
+    onUpdatePosition?: (event: any) => void,
+  ) => Promise<PlatformWindow | undefined>
 }
 
 export type PlatformWindow = {

--- a/src/client/src/rt-platforms/types.ts
+++ b/src/client/src/rt-platforms/types.ts
@@ -23,6 +23,7 @@ export interface WindowConfig {
   center?: 'parent' | 'screen'
   x?: number
   y?: number
+  saveWindowState?: boolean
 }
 
 export interface AppConfig {


### PR DESCRIPTION
- Add an updateposition handler when creating windows on openfin
- Keep updated position for windows opened from launcher
- If it's the first time windows opens, it opens on center of screen

![windows](https://user-images.githubusercontent.com/1596197/77904767-60e41a80-7285-11ea-97f7-cd197f9c7d5e.gif)