### PR TITLE
ARTP-1114: Fix blotter to fill space when live rates are popped out

### DIFF
--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -34,7 +34,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
 
   const lastRemainingService = useMemo(() => {
     const numberOfVisibleService = [blotter.visible, analytics.visible, liveRates.visible].filter(
-      visible => visible === true,
+      (visible) => visible === true,
     ).length
 
     return numberOfVisibleService === 1
@@ -61,6 +61,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
         </BlotterWrapper>
       )}
       disabled={!blotter.visible}
+      isLiveRatesVisible={liveRates.visible}
     >
       <TearOff
         id="liveRates"

--- a/src/client/src/rt-components/resizer/Resizer.tsx
+++ b/src/client/src/rt-components/resizer/Resizer.tsx
@@ -42,9 +42,16 @@ interface Props {
   minHeight?: number
   defaultHeight: number
   disabled?: boolean
+  isLiveRatesVisible?: boolean
 }
 
-const Resizer: React.FC<Props> = ({ component, defaultHeight, children, disabled }) => {
+const Resizer: React.FC<Props> = ({
+  component,
+  defaultHeight,
+  children,
+  disabled,
+  isLiveRatesVisible,
+}) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [height, setHeight] = useState(defaultHeight)
   const [dragging, setDragging] = useState<Boolean>(false)
@@ -105,7 +112,7 @@ const Resizer: React.FC<Props> = ({ component, defaultHeight, children, disabled
 
   return (
     <ResizerStyle ref={wrapperRef}>
-      <ResizableSection height={100 - height}>
+      <ResizableSection height={isLiveRatesVisible ? 100 - height : 0}>
         <ResizableContent>{children}</ResizableContent>
       </ResizableSection>
       <ResizableSection height={height}>


### PR DESCRIPTION
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/38663839/79504155-61f4a600-8000-11ea-83c5-90edd0be9eae.gif)

Fill space with blotter when live rates are popped out