### PR TITLE
chore(theme): Add divider color, and fix header dividers

### DIFF
--- a/src/client/src/apps/MainRoute/components/app-header/Header.tsx
+++ b/src/client/src/apps/MainRoute/components/app-header/Header.tsx
@@ -43,7 +43,7 @@ const Root = styled.div`
   align-items: center;
 
   background-color: ${({ theme }) => theme.core.darkBackground};
-  border-bottom: 1px solid ${({ theme }) => theme.core.lightBackground};
+  border-bottom: 1px solid ${({ theme }) => theme.core.dividerColor};
   color: ${({ theme }) => theme.core.textColor};
 
   position: relative;

--- a/src/client/src/apps/MainRoute/components/app-header/LoginControls/styled.ts
+++ b/src/client/src/apps/MainRoute/components/app-header/LoginControls/styled.ts
@@ -1,5 +1,4 @@
 import { styled } from 'rt-theme'
-import { dark } from 'rt-theme/colors'
 
 interface DropdownMenuProps {
   showMenu: boolean
@@ -50,8 +49,9 @@ export const UserContainer = styled(Button)`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
-  border-right: 2px solid
-    ${({ theme }) => (theme.name === 'dark' ? theme.core.lightBackground : dark.secondary[4])};
+  border-right: 1px solid ${({ theme }) => theme.core.dividerColor};
+  border-radius: 0;
+  height: 24px;
 `
 
 export const UserAvatar = styled.img`

--- a/src/client/src/rt-theme/colors.ts
+++ b/src/client/src/rt-theme/colors.ts
@@ -107,6 +107,7 @@ interface SemanticColors {
   backgroundHoverColor: Color
   primaryStyleGuideBackground: Color
   secondaryStyleGuideBackground: Color
+  dividerColor: Color
 }
 
 export interface CorePaletteMap {
@@ -123,6 +124,7 @@ const darkPrimary = {
   3: rgb(83, 87, 96),
   4: rgb(104, 109, 116),
   5: rgb(126, 129, 136),
+  6: rgb(52, 58, 71),
 }
 
 const darkSecondary = {
@@ -146,6 +148,7 @@ export const dark: CorePaletteMap = {
     backgroundHoverColor: darkPrimary[2],
     primaryStyleGuideBackground: rgb(32, 36, 45),
     secondaryStyleGuideBackground: rgb(40, 45, 57),
+    dividerColor: darkPrimary[6],
   },
 }
 
@@ -161,6 +164,7 @@ export const light: CorePaletteMap = {
     backgroundHoverColor: darkSecondary[1],
     primaryStyleGuideBackground: rgb(253, 253, 253),
     secondaryStyleGuideBackground: rgb(243, 243, 243),
+    dividerColor: darkSecondary[3],
   },
 }
 


### PR DESCRIPTION
Added a `dividerColor` to core theme
Fix header dividers to spec

![Screen Shot 2020-04-27 at 1 24 43 PM](https://user-images.githubusercontent.com/38663839/80401550-849d7f00-888a-11ea-8d69-fb15d137a096.png)

![Screen Shot 2020-04-27 at 1 24 52 PM](https://user-images.githubusercontent.com/38663839/80401551-849d7f00-888a-11ea-8608-4fcc47740256.png)
