### PR TITLE
Artp 1145/poppedout header not visible in light mode

### DIFF
--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -145,7 +145,7 @@ const DragRegion = styled.div`
   justify-content: center;
   align-items: center;
   flex-grow: 1;
-  color: rgba(255, 255, 255, 0.58);
+  background: rgba(255, 255, 255, 0.58);
   font-size: 0.625rem;
   letter-spacing: 0.2px;
   text-transform: uppercase;


### PR DESCRIPTION
![Screen Shot 2020-05-05 at 8 46 44 AM](https://user-images.githubusercontent.com/38663839/81068423-56352a80-8eae-11ea-87fd-816ce2b8f1d9.png)
