### PR TITLE
Artp 1147/bugfixes

### DIFF
--- a/src/client/src/rt-interop/intents/showMarket.ts
+++ b/src/client/src/rt-interop/intents/showMarket.ts
@@ -24,7 +24,7 @@ export async function showMarket({ window }: Platform) {
     {
       ...defaultConfig,
       name: 'market',
-      height: 900,
+      height: 600,
       url: `${windowOrigin}/tiles`,
       saveWindowState: true,
       ...updatedPosition,

--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -47,7 +47,7 @@ export const OpenFinHeader: React.FC<ControlProps> = ({ ...props }) => (
 
 export const OpenFinControls: React.FC<ControlProps> = ({ minimize, maximize, close, popIn }) => (
   <React.Fragment>
-    {popIn ? null : <TitleContainer>Reactive Trader</TitleContainer>}
+    {maximize ? <TitleContainer>Reactive Trader</TitleContainer> : null}
     {minimize ? (
       <HeaderControl onClick={minimize} data-qa="openfin-chrome__minimize">
         {minimiseNormalIcon}
@@ -145,7 +145,6 @@ const DragRegion = styled.div`
   justify-content: center;
   align-items: center;
   flex-grow: 1;
-  background: rgba(255, 255, 255, 0.58);
   font-size: 0.625rem;
   letter-spacing: 0.2px;
   text-transform: uppercase;


### PR DESCRIPTION
- remove double titles on torn off components
- remove background color on torn off components
- change default height of market view from launcher

![Screen Shot 2020-05-05 at 10 26 59 AM](https://user-images.githubusercontent.com/38663839/81078263-ffcee880-8ebb-11ea-9069-55527577397b.png)
![Screen Shot 2020-05-05 at 10 27 09 AM](https://user-images.githubusercontent.com/38663839/81078270-02314280-8ebc-11ea-94f9-eeef5c7c2a65.png)
