### PR TITLE
bug(finsemble): fixes bug preventing finsemble from loading (ARTP-1136)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
@@ -16,7 +16,7 @@ const prevState: TileState = {
 
 const defaultParams: Parameters<typeof getDerivedStateFromUserInput>[0] = {
   actions: {
-    setTradingMode: (tradingMode: TradingMode) => {},
+    setTradingMode: (tradingMode: TradingMode) => { },
   },
   prevState,
   spotTileData: {
@@ -44,20 +44,20 @@ const defaultParams: Parameters<typeof getDerivedStateFromUserInput>[0] = {
 const defaultTileProps: TileProps = {
   children: jest.fn(),
   currencyPair,
-  executeTrade: () => {},
-  setTradingMode: () => {},
+  executeTrade: () => { },
+  setTradingMode: () => { },
   executionStatus: 'CONNECTED' as ServiceConnectionStatus,
   rfq: {
-    cancel: () => {},
-    expired: () => {},
-    reject: () => {},
-    request: () => {},
-    requote: () => {},
-    reset: () => {},
+    cancel: () => { },
+    expired: () => { },
+    reject: () => { },
+    request: () => { },
+    requote: () => { },
+    reset: () => { },
   },
   spotTileData: defaultParams.spotTileData,
   tileView: 'Normal' as TileView,
-  updateNotional: () => {},
+  updateNotional: () => { },
 }
 
 test('Snapshot, state derived from props, defaults, RFQ none, should be able to excute', () => {
@@ -115,7 +115,7 @@ test('Snapshot, state derived from props, RFQ received', () => {
         mid: 1.48357,
         priceMovementType: 'Down' as PriceMovementTypes,
         symbol: 'EURCAD',
-        valueDate: '2019-04-07T00:00:00Z',
+        valueDate: '2019-04-06T00:00:00Z',
       },
     },
   }
@@ -150,7 +150,7 @@ test('Snapshot, state derived from props, RFQ expired', () => {
         mid: 1.48357,
         priceMovementType: 'Down' as PriceMovementTypes,
         symbol: 'EURCAD',
-        valueDate: '2019-04-07T00:00:00Z',
+        valueDate: '2019-04-06T00:00:00Z',
       },
     },
   }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -219,7 +219,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -247,7 +247,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -271,10 +271,10 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -294,7 +294,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -316,25 +316,25 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -379,25 +379,25 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -700,7 +700,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -708,7 +708,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -736,7 +736,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -772,10 +772,10 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -795,7 +795,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -817,25 +817,25 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -903,25 +903,25 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -1230,7 +1230,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -1238,7 +1238,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -1266,7 +1266,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -1302,10 +1302,10 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -1325,7 +1325,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -1347,25 +1347,25 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -1439,25 +1439,25 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -1759,7 +1759,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -1767,7 +1767,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -1795,7 +1795,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -1819,10 +1819,10 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -1842,7 +1842,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -1864,25 +1864,25 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -1927,25 +1927,25 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -1987,42 +1987,6 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
 `;
 
 exports[`Snapshot, state derived from props, RFQ requested 1`] = `
-.c9 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.48s;
-  animation-delay: -0.48s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c10 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.3261538461538461s;
-  animation-delay: -0.3261538461538461s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c11 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.17230769230769227s;
-  animation-delay: -0.17230769230769227s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c12 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.018461538461538418s;
-  animation-delay: -0.018461538461538418s;
-  fill: #fff;
-  will-change: transform;
-}
-
 .c22 {
   grid-area: Currency;
   opacity: 0.59;
@@ -2097,6 +2061,42 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   flex-direction: column;
   width: 100%;
   z-index: 1;
+}
+
+.c9 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.48s;
+  animation-delay: -0.48s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c10 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.3261538461538461s;
+  animation-delay: -0.3261538461538461s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c11 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.17230769230769227s;
+  animation-delay: -0.17230769230769227s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c12 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.018461538461538418s;
+  animation-delay: -0.018461538461538418s;
+  fill: #fff;
+  will-change: transform;
 }
 
 .c6 {
@@ -2241,7 +2241,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -2249,7 +2249,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -2277,7 +2277,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -2313,10 +2313,10 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -2336,7 +2336,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -2775,7 +2775,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -2783,7 +2783,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -2811,7 +2811,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -2835,10 +2835,10 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -2858,7 +2858,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -2880,25 +2880,25 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -2943,25 +2943,25 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -3003,42 +3003,6 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
 `;
 
 exports[`Snapshot, state derived from props, in trade 1`] = `
-.c21 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.48s;
-  animation-delay: -0.48s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c22 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.3261538461538461s;
-  animation-delay: -0.3261538461538461s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c23 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.17230769230769227s;
-  animation-delay: -0.17230769230769227s;
-  fill: #fff;
-  will-change: transform;
-}
-
-.c24 {
-  -webkit-animation: kpOBsK 0.8s infinite;
-  animation: kpOBsK 0.8s infinite;
-  -webkit-animation-delay: -0.018461538461538418s;
-  animation-delay: -0.018461538461538418s;
-  fill: #fff;
-  will-change: transform;
-}
-
 .c28 {
   grid-area: Currency;
   opacity: 0.59;
@@ -3197,6 +3161,42 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
   z-index: 1;
 }
 
+.c21 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.48s;
+  animation-delay: -0.48s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c22 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.3261538461538461s;
+  animation-delay: -0.3261538461538461s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c23 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.17230769230769227s;
+  animation-delay: -0.17230769230769227s;
+  fill: #fff;
+  will-change: transform;
+}
+
+.c24 {
+  -webkit-animation: kpOBsK 0.8s infinite;
+  animation: kpOBsK 0.8s infinite;
+  -webkit-animation-delay: -0.018461538461538418s;
+  animation-delay: -0.018461538461538418s;
+  fill: #fff;
+  will-change: transform;
+}
+
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3306,7 +3306,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
   height: 100%;
 }
 
-.c0:hover .sc-fzqMdD {
+.c0:hover .sc-fzoJMP {
   opacity: 0.75;
 }
 
@@ -3314,7 +3314,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
   margin-right: 1.3rem;
 }
 
-.c0:hover .sc-fzowVh {
+.c0:hover .sc-fzoYHE {
   opacity: 0.75;
 }
 
@@ -3342,7 +3342,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
   overflow: hidden;
 }
 
-.sc-fzqBZW .c1 {
+.sc-fznxKY .c1 {
   border-radius: 0px;
 }
 
@@ -3378,10 +3378,10 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
 }
 
 <div
-  className="sc-fzokvW c0"
+  className="sc-fzqMdD c0"
 >
   <div
-    className="sc-fzpisO c1 spot-tile"
+    className="sc-fznLPX c1 spot-tile"
     data-qa="spot-tile__tile"
     data-qa-id="currency-pair-eurusd"
   >
@@ -3401,7 +3401,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -3423,25 +3423,25 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 SELL
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4
@@ -3555,25 +3555,25 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
               className="c9"
             >
               <div
-                className="sc-fzolEj c10"
+                className="sc-AxheI c10"
               >
                 BUY
               </div>
               <div
-                className="sc-fzolEj c11"
+                className="sc-AxheI c11"
                 data-qa="price-button__big"
               >
                 1.
               </div>
             </div>
             <div
-              className="sc-fzolEj c12"
+              className="sc-AxheI c12"
               data-qa="price-button__pip"
             >
               48
             </div>
             <div
-              className="sc-fzolEj c13"
+              className="sc-AxheI c13"
               data-qa="price-button__tenth"
             >
               4

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -294,7 +294,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -795,7 +795,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -1325,7 +1325,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -1842,7 +1842,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -2336,7 +2336,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -2858,7 +2858,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -3401,7 +3401,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           className="c4 c5"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useEffect, useState } from 'react'
 import { styled } from 'rt-theme'
-import { Platform, usePlatform, isParentAppLauncher } from 'rt-platforms'
+import { Platform, usePlatform, isParentAppOpenfinLauncher } from 'rt-platforms'
 
-const RouteStyle = styled('div')<{ platform: Platform }>`
+const RouteStyle = styled('div') <{ platform: Platform }>`
   width: 100%;
   background-color: ${({ theme }) => theme.core.darkBackground};
   overflow: hidden;
@@ -36,7 +36,7 @@ const RouteWrapper: React.FC<RouteWrapperProps> = props => {
   const { PlatformHeader, PlatformControls, PlatformRoute, window } = platform
 
   useEffect(() => {
-    isParentAppLauncher()
+    isParentAppOpenfinLauncher()
       .then(isLauncher => {
         setFromLauncher(isLauncher)
       })

--- a/src/client/src/rt-platforms/index.ts
+++ b/src/client/src/rt-platforms/index.ts
@@ -14,5 +14,11 @@ export { PlatformProvider, usePlatform } from './context'
 export { externalWindowDefault } from './externalWindowDefault'
 export * from './excelApp'
 export * from './limitChecker'
+<<<<<<< HEAD
 export type ExternalWindow = externalWindowDefault.ExternalWindow
 export { isParentAppLauncher } from './openFin'
+||||||| parent of e7e24afb... bug(finsemble): fixes bug preventing finsemble from loading (ARTP-1136)
+export { isParentAppLauncher } from './openFin'
+=======
+export { isParentAppOpenfinLauncher } from './openFin/adapter/launcherUtils'
+>>>>>>> e7e24afb... bug(finsemble): fixes bug preventing finsemble from loading (ARTP-1136)

--- a/src/client/src/rt-platforms/index.ts
+++ b/src/client/src/rt-platforms/index.ts
@@ -14,11 +14,5 @@ export { PlatformProvider, usePlatform } from './context'
 export { externalWindowDefault } from './externalWindowDefault'
 export * from './excelApp'
 export * from './limitChecker'
-<<<<<<< HEAD
 export type ExternalWindow = externalWindowDefault.ExternalWindow
-export { isParentAppLauncher } from './openFin'
-||||||| parent of e7e24afb... bug(finsemble): fixes bug preventing finsemble from loading (ARTP-1136)
-export { isParentAppLauncher } from './openFin'
-=======
 export { isParentAppOpenfinLauncher } from './openFin/adapter/launcherUtils'
->>>>>>> e7e24afb... bug(finsemble): fixes bug preventing finsemble from loading (ARTP-1136)

--- a/src/client/src/rt-platforms/openFin/adapter/index.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/index.ts
@@ -1,4 +1,5 @@
 export { default as OpenFin } from './openFin'
-export { openDesktopWindow, isCurrentWindowDocked, isParentAppLauncher } from './window'
+export { openDesktopWindow, isCurrentWindowDocked } from './window'
+export { isParentAppOpenfinLauncher } from './launcherUtils';
 export { createExcelApp } from '../../excelApp'
 export { platformEpics } from './epics'

--- a/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
@@ -1,0 +1,8 @@
+export async function isParentAppOpenfinLauncher() {
+  const app = await fin.Window.getCurrent()
+  const {
+    identity: { uuid },
+  } = await app.getParentApplication()
+
+  return uuid.split('-').includes('launcher')
+}

--- a/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
@@ -1,8 +1,11 @@
 export async function isParentAppOpenfinLauncher() {
-  const app = await fin.Window.getCurrent()
-  const {
-    identity: { uuid },
-  } = await app.getParentApplication()
+  if (fin?.Window) {
+    const app = await fin.Window.getCurrent()
+    const {
+      identity: { uuid },
+    } = await app.getParentApplication()
 
-  return uuid.split('-').includes('launcher')
+    return uuid.split('-').includes('launcher')
+  }
+  return false
 }

--- a/src/client/src/rt-platforms/openFin/adapter/window.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/window.ts
@@ -215,13 +215,3 @@ export async function isCurrentWindowDocked() {
     return hasIdentity
   }, false)
 }
-
-export async function isParentAppLauncher() {
-  const app = await fin.Window.getCurrent()
-
-  const {
-    identity: { uuid },
-  } = await app.getParentApplication()
-
-  return uuid.split('-').includes('launcher')
-}

--- a/src/client/src/rt-platforms/openFin/index.ts
+++ b/src/client/src/rt-platforms/openFin/index.ts
@@ -1,4 +1,5 @@
-export { OpenFin, openDesktopWindow, isParentAppLauncher } from './adapter'
+export { OpenFin, openDesktopWindow } from './adapter'
+export { isParentAppOpenfinLauncher } from './adapter/launcherUtils'
 export { OpenFinLimitChecker } from './limitChecker/openFin'
 export { OpenFinHeader } from './components'
 export * from './excel'


### PR DESCRIPTION
<img width="706" alt="Screen Shot 2020-05-05 at 3 31 39 PM" src="https://user-images.githubusercontent.com/3123490/81107770-ac719000-8ee5-11ea-860a-8b08e4423eba.png">

- Renames `isParentAppLauncher` to `isParentAppOpenfinLauncher` for clarity
- Creates `/launcherUtils` to contain `isParentAppOpenfinLauncher` since the exports of `/openfin` were causing the error