### PR TITLE
POC for FDC3 sandbox integration

### DIFF
--- a/src/client/.npmrc
+++ b/src/client/.npmrc
@@ -1,0 +1,1 @@
+@adaptive:registry=http://localhost:3004

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -3,6 +3,46 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@adaptive/fdc3-types": {
+      "version": "1.1.0",
+      "resolved": "http://localhost:3004/@adaptive%2ffdc3-types/-/fdc3-types-1.1.0.tgz",
+      "integrity": "sha512-UCejHsBMuCUzyiq51CgRhrc1fcp+z/iwQbLMXk2JFpgflT9VDc8L/acTs8jO9q7xhkjJFzFsiEeAjj5CNFLulg=="
+    },
+    "@adaptive/openfin-fdc3-desktop-agent": {
+      "version": "1.1.0",
+      "resolved": "http://localhost:3004/@adaptive%2fopenfin-fdc3-desktop-agent/-/openfin-fdc3-desktop-agent-1.1.0.tgz",
+      "integrity": "sha512-nHM4wIezkUBcJEZk/Vkty5bntGowRb1znHbD7p6jiCNyye9lvb7ORn0M7QmoKx5xaq+VtWHUzr7FW2GArGY5zA==",
+      "requires": {
+        "@adaptive/fdc3-types": "*",
+        "openfin-fdc3": "^0.2.0"
+      }
+    },
+    "@adaptive/sandbox-fdc3-desktop-agent": {
+      "version": "1.1.0-1",
+      "resolved": "http://localhost:3004/@adaptive%2fsandbox-fdc3-desktop-agent/-/sandbox-fdc3-desktop-agent-1.1.0-1.tgz",
+      "integrity": "sha512-bnHfkWdfnElZYFzqQqu+0dkJFIojOb5y+cN/v1mb2aMbicrFU63KvGrqxKpSMlD1SnFwEP8C7PzbhIARI4gq8w==",
+      "requires": {
+        "@adaptive/fdc3-types": "*",
+        "monet": "^0.9.1",
+        "rxjs": "^6.5.5",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -14836,6 +14876,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "monet": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/monet/-/monet-0.9.1.tgz",
+      "integrity": "sha512-GaZw308g6t0WD+U2mGujwJckGp2b8AGGVuB6PiIwkXbq6rJeiqddre2mdbO4PxjyILPi+7GgtRkkfr6dBYXWtA=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -52,9 +52,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@adaptive/fdc3-types": "*",
-    "@adaptive/openfin-fdc3-desktop-agent": "*",
-    "@adaptive/sandbox-fdc3-desktop-agent": "*",
+    "@adaptive/fdc3-types": "1.1.0",
+    "@adaptive/openfin-fdc3-desktop-agent": "1.1.0",
+    "@adaptive/sandbox-fdc3-desktop-agent": "1.1.0-1",
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.2",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -52,6 +52,9 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@adaptive/fdc3-types": "*",
+    "@adaptive/openfin-fdc3-desktop-agent": "*",
+    "@adaptive/sandbox-fdc3-desktop-agent": "*",
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.2",

--- a/src/client/public/config/openfin/local.json
+++ b/src/client/public/config/openfin/local.json
@@ -1,11 +1,11 @@
 {
     "devtools_port": 9090,
-    "splashScreenImage": "http://localhost:3000/static/media/splash-screen.png",
+    "splashScreenImage": "http://localhost:3005/static/media/splash-screen.png",
     "startup_app": {
         "name": "Reactive Trader (Local)",
-        "url": "http://localhost:3000/",
+        "url": "http://localhost:3005/",
         "uuid": "reactive-trader-local",
-        "applicationIcon": "http://localhost:3000/static/media/reactive-trader-icon-256x256.png",
+        "applicationIcon": "http://localhost:3005/static/media/reactive-trader-icon-256x256.png",
         "autoShow": true,
         "defaultWidth": 1280,
         "defaultHeight": 900,
@@ -18,10 +18,10 @@
         "_comment": "Openfin Excel API preloaded below + added in appAssets (not included in standard OpenFin package)",
         "preload": [
             {
-                "url": "http://localhost:3000/plugin/service-loader.js"
+                "url": "http://localhost:3005/plugin/service-loader.js"
             },
             {
-                "url": "http://localhost:3000/plugin/fin.desktop.Excel.js"
+                "url": "http://localhost:3005/plugin/fin.desktop.Excel.js"
             }
         ],
         "contextMenu": true,
@@ -38,12 +38,12 @@
     "shortcut": {
         "company": "Adaptive Consulting",
         "description": "Desktop Reactive Trader",
-        "icon": "http://localhost:3000/static/media/reactive-trader.ico",
+        "icon": "http://localhost:3005/static/media/reactive-trader.ico",
         "name": "Reactive Trader (Local)"
     },
     "appAssets": [
         {
-            "src": "http://localhost:3000/plugin/add-in.zip",
+            "src": "http://localhost:3005/plugin/add-in.zip",
             "alias": "excel-api-addin",
             "version": "2.0.0",
             "forceDownload": true
@@ -63,7 +63,7 @@
         },
         {
             "name": "fdc3",
-            "manifestUrl": "https://cdn.openfin.co/services/openfin/fdc3/0.2.0/app.json"
+            "manifestUrl": "http://localhost:3001/config/fdc3-manifest.json"
         },
         {
             "name": "notifications",

--- a/src/client/src/apps/MainRoute/MainRoute.tsx
+++ b/src/client/src/apps/MainRoute/MainRoute.tsx
@@ -34,6 +34,15 @@ const MainRoute = () => {
   }, [])
 
   useEffect(() => {
+    // TODO: this should be set as config in the app manifest
+    intentsProvider.context.getSystemChannels()
+      .then(channels => console.log('system channel', channels))
+
+    intentsProvider.joinChannel('red')
+      .then(() => console.log('channel joined'))
+  }, [intentsProvider])
+
+  useEffect(() => {
     if (platform) {
       ReactGA.set({
         dimension1: platform.type,

--- a/src/client/src/rt-interop/fdc3/provider.ts
+++ b/src/client/src/rt-interop/fdc3/provider.ts
@@ -1,9 +1,8 @@
-import { Context } from 'openfin-fdc3'
-import { InteropProvider, Application } from 'rt-interop/types'
+import { Application, Context, DesktopAgent } from '@adaptive/fdc3-types'
+import { InteropProvider } from 'rt-interop/types'
 import { getCurrencyPair } from './contexts'
 import { DetectIntentResponse } from 'dialogflow'
 import { TRADES_INFO_INTENT } from '../intents'
-import { FDC3Platform } from './adapter/types'
 
 const mapIntentToFdc3 = (response: DetectIntentResponse): string | undefined => {
   if (!response) {
@@ -21,9 +20,9 @@ const mapIntentToFdc3 = (response: DetectIntentResponse): string | undefined => 
 export default class FDC3 implements InteropProvider {
   readonly name = 'fdc3'
 
-  readonly context: FDC3Platform
+  readonly context: DesktopAgent
 
-  constructor(context: FDC3Platform) {
+  constructor(context: DesktopAgent) {
     this.context = context
   }
 

--- a/src/client/src/rt-interop/fdc3/provider.ts
+++ b/src/client/src/rt-interop/fdc3/provider.ts
@@ -41,10 +41,10 @@ export default class FDC3 implements InteropProvider {
 
     return this.context.findIntent(fdc3Intent).then(({ apps }) =>
       apps.map(
-        ({ appId, title }) =>
+        ({ name }) =>
           ({
-            id: appId,
-            name: title,
+            appId: name,
+            name,
           } as Application),
       ),
     )
@@ -53,4 +53,10 @@ export default class FDC3 implements InteropProvider {
   open = (appId: string): Promise<void> => {
     return this.context.open(appId)
   }
+
+  joinChannel = (channelId: string): Promise<void> => {
+    return this.context.joinChannel(channelId)
+  }
+
+  getContext = () => this.context
 }

--- a/src/client/src/rt-interop/types.ts
+++ b/src/client/src/rt-interop/types.ts
@@ -1,11 +1,7 @@
+import { Application, DesktopAgent } from '@adaptive/fdc3-types'
 import { DetectIntentResponse } from 'dialogflow'
 
 export type ProviderName = 'fdc3' | 'noop'
-
-export interface Application {
-  id: string
-  name: string
-}
 
 export type InteropProvider = {
   readonly name: ProviderName
@@ -15,4 +11,6 @@ export type InteropProvider = {
   readonly open: (appId: string) => Promise<void>
 
   readonly currencyPairSelected: (currencyPair: string) => void
+
+  readonly getContext: () => DesktopAgent
 }

--- a/src/client/src/rt-interop/util/getProvider.ts
+++ b/src/client/src/rt-interop/util/getProvider.ts
@@ -1,3 +1,7 @@
+import { OpenFinDesktopAgent } from '@adaptive/openfin-fdc3-desktop-agent'
+import { SandboxDesktopAgent } from '@adaptive/sandbox-fdc3-desktop-agent'
+import { default as FDC3 } from '../fdc3/provider'
+
 const isFinsemble = 'FSBL' in window
 // TODO: We should not need to negate `isFinsemble` to check for OpenFin.
 // Somewhere, `fin` is being added to the `window` object even in electron/finsemble versions.
@@ -5,12 +9,8 @@ const isOpenFin = 'fin' in window && !isFinsemble
 
 export const getProvider = () => {
   if (isOpenFin) {
-    // @ts-ignore
-    const { OpenFinFDC3, FDC3 } = require('../fdc3')
-    const openFinFDC3 = new OpenFinFDC3()
-
-    return new FDC3(openFinFDC3)
+    return new FDC3(new OpenFinDesktopAgent())
   }
 
-  return null
+  return new FDC3(new SandboxDesktopAgent())
 }


### PR DESCRIPTION
/cc @rikoe 

This covers the changes required to run RT inside the FDC3 browser sandbox.

Notes:

* We still use the interop provider, but use the Sandbox/OpenFin desktop agent layers from FDC3 as internal context. I added a `getContext()` hook to the provider to access the underlying API directly - this abstraction will need some work.
* The FDC3 packages are not currently published to any well-known repo. To install them in this project, a local NPM registry is bundled with the sandbox and is preferred for @adaptive/* packages.
* The default RT port collides with the sandbox when running locally. I had to shuffle RT on to :3005 when running.
* There is a bug in the sandbox desktop agent that causes intents to fire repeatedly when listening inside a React effect hook (due to use of a ReplaySubject upstream). This needs to be fixed in the sandbox desktop agent, but I patched it here by only letting the intent be handled once.