### PR TITLE
fix(workspace): fix openfin theme toggle (ARTP-1172)

### DIFF
--- a/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
+++ b/src/client/src/rt-platforms/openFin/components/OpenFinChrome.tsx
@@ -123,10 +123,10 @@ const TitleContainer = styled.div`
   left: 0;
   right: 0;
   text-align: center;
-  width: 80%;
+  width: 100%;
   font-size: 0.625rem;
   font-weight: normal;
-  z-index: 100;
+  z-index: -1;
   text-transform: uppercase;
 `
 


### PR DESCRIPTION
**Changes:**
- Fix theme switcher and logo being blocked by an absolutely positioned `div`

Screengrab at smallest possible size:
![QuickFix](https://user-images.githubusercontent.com/54838842/84366556-e3b11c00-abca-11ea-9455-03c58790cd51.gif)
