### PR TITLE
fix(workspace): fix trades filtering for NLP (ARTP-1168)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/blotter/blotterTradesFilter.ts
+++ b/src/client/src/apps/MainRoute/widgets/blotter/blotterTradesFilter.ts
@@ -21,9 +21,10 @@ const tradeMatchesFilter = (trade: Trade, filterField: string, filterValues: Fie
     return true
   }
 
+  const CONTAINS_SYMBOL = filterValues.some(value => trade.symbol.includes(value))
   const tradeFieldValue = trade[filterField]
 
-  return filterValues.includes(tradeFieldValue)
+  return filterValues.includes(tradeFieldValue) || CONTAINS_SYMBOL
 }
 
 /**
@@ -31,7 +32,7 @@ const tradeMatchesFilter = (trade: Trade, filterField: string, filterValues: Fie
  */
 const tradeFilterFields: ReadonlyArray<keyof Omit<BlotterFilters, 'count'>> = [
   DEALT_CURRENCY,
-  SYMBOL
+  SYMBOL,
 ]
 
 function isMeaningfullValue(value: any): boolean {
@@ -45,7 +46,7 @@ export function validateFilters(filters: BlotterFilters): BlotterFilters {
   return {
     count: filters.count,
     [DEALT_CURRENCY]: (filters[DEALT_CURRENCY] || []).filter(isMeaningfullValue),
-    [SYMBOL]: (filters[SYMBOL] || []).filter(isMeaningfullValue)
+    [SYMBOL]: (filters[SYMBOL] || []).filter(isMeaningfullValue),
   }
 }
 

--- a/src/client/src/apps/SimpleLauncher/spotlight/components/getInlineSuggestionsComponent.tsx
+++ b/src/client/src/apps/SimpleLauncher/spotlight/components/getInlineSuggestionsComponent.tsx
@@ -54,6 +54,7 @@ export function getInlineSuggestionsComponent(response: DetectIntentResponse, pl
     [SYMBOL]: [currencyPair],
     count: getNumber(response.queryResult),
   }
+
   const blotterSuggestion = isTradeIntent(response) ? (
     <Suggestion>
       <InlineBlotter filters={blotterFilter} />

--- a/src/client/src/apps/SimpleLauncher/spotlight/components/useBlotterTrades.ts
+++ b/src/client/src/apps/SimpleLauncher/spotlight/components/useBlotterTrades.ts
@@ -26,7 +26,7 @@ export const useBlotterTrades = (filters?: BlotterFilters) => {
           filterBlotterTrades(tradeUpdate.trades, {
             ...filters,
             // get all trades and then limit in the end (so that we can show user how many filtered out)
-            count: undefined
+            count: undefined,
           })
         ),
         scan<ReadonlyArray<Trade>, Map<number, Trade>>((acc, trades) => {
@@ -47,7 +47,8 @@ export const useBlotterTrades = (filters?: BlotterFilters) => {
             newTrades = newTrades.filter(
               t =>
                 filters?.dealtCurrency?.includes(t.dealtCurrency) ||
-                filters?.symbol?.includes(t.symbol)
+                filters?.symbol?.includes(t.symbol) ||
+                filters?.symbol?.some(value => t.dealtCurrency.includes(value))
             )
           }
 

--- a/src/client/src/rt-types/tradeMapper.ts
+++ b/src/client/src/rt-types/tradeMapper.ts
@@ -83,6 +83,6 @@ function createTrade(
     tradeDate,
     valueDate,
     status,
-    highlight
+    highlight,
   }
 }


### PR DESCRIPTION
**Changes:**
- Allow NLP for a base or quote currency and show relevant trades in blotter

![FilteringExample](https://user-images.githubusercontent.com/54838842/84493453-aff3f600-ac9f-11ea-8010-81e33625f2f5.gif)