### PR TITLE
feat: added cpu and memory requests for each pod ARTP-1112

### DIFF
--- a/src/services/kubernetes/analytics-deployment.yaml
+++ b/src/services/kubernetes/analytics-deployment.yaml
@@ -26,3 +26,8 @@ spec:
               value: '1113'
           command:
             ['sh', '-c', 'dotnet ./Adaptive.ReactiveTrader.Server.Analytics.dll config.prod.json']
+          resources:
+            requests:
+              memory: "50M"
+              cpu: "10m"
+

--- a/src/services/kubernetes/blotter-deployment.yaml
+++ b/src/services/kubernetes/blotter-deployment.yaml
@@ -26,3 +26,8 @@ spec:
               value: '1113'
           command:
             ['sh', '-c', 'dotnet ./Adaptive.ReactiveTrader.Server.Blotter.dll config.prod.json']
+          resources:
+            requests:
+              memory: "80M"
+              cpu: "10m"
+

--- a/src/services/kubernetes/bot-deployment.yaml
+++ b/src/services/kubernetes/bot-deployment.yaml
@@ -48,3 +48,7 @@ spec:
               value: rsa.pem
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/key.json
+          resources:
+            requests:
+              memory: "120M"
+              cpu: "15m"

--- a/src/services/kubernetes/broker-deployment.yaml
+++ b/src/services/kubernetes/broker-deployment.yaml
@@ -21,6 +21,6 @@ spec:
             - containerPort: 15674
           resources:
             requests:
-              memory: "80M"
+              memory: "120M"
               cpu: "100m"
 

--- a/src/services/kubernetes/broker-deployment.yaml
+++ b/src/services/kubernetes/broker-deployment.yaml
@@ -19,3 +19,8 @@ spec:
             - containerPort: 5672
             - containerPort: 15672
             - containerPort: 15674
+          resources:
+            requests:
+              memory: "80M"
+              cpu: "100m"
+

--- a/src/services/kubernetes/client-deployment.yaml
+++ b/src/services/kubernetes/client-deployment.yaml
@@ -23,3 +23,7 @@ spec:
                 configMapKeyRef:
                   name: client-config
                   key: environment-name
+          resources:
+            requests:
+              memory: "20M"
+              cpu: "10m"

--- a/src/services/kubernetes/eventstore-deployment.yaml
+++ b/src/services/kubernetes/eventstore-deployment.yaml
@@ -18,3 +18,8 @@ spec:
           ports:
             - containerPort: 1113
             - containerPort: 2113
+          resources:
+            requests:
+              memory: "1G"
+              cpu: "80m"
+

--- a/src/services/kubernetes/nlp-deployment.yaml
+++ b/src/services/kubernetes/nlp-deployment.yaml
@@ -29,3 +29,7 @@ spec:
               value: '15674'
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/key.json
+          resources:
+            requests:
+              memory: "100M"
+              cpu: "10m"

--- a/src/services/kubernetes/pricehistory-deployment.yaml
+++ b/src/services/kubernetes/pricehistory-deployment.yaml
@@ -20,3 +20,7 @@ spec:
               value: broker
             - name: BROKER_PORT
               value: '15674'
+          resources:
+            requests:
+              memory: "150M"
+              cpu: "15m"

--- a/src/services/kubernetes/pricing-deployment.yaml
+++ b/src/services/kubernetes/pricing-deployment.yaml
@@ -26,3 +26,7 @@ spec:
               value: '1113'
           command:
             ['sh', '-c', 'dotnet ./Adaptive.ReactiveTrader.Server.Pricing.dll config.prod.json']
+          resources:
+            requests:
+              memory: "100M"
+              cpu: "15m"

--- a/src/services/kubernetes/referencedataread-deployment.yaml
+++ b/src/services/kubernetes/referencedataread-deployment.yaml
@@ -30,3 +30,7 @@ spec:
               '-c',
               'dotnet ./Adaptive.ReactiveTrader.Server.ReferenceDataRead.dll config.prod.json',
             ]
+          resources:
+            requests:
+              memory: "50M"
+              cpu: "5m"

--- a/src/services/kubernetes/tradeexecution-deployment.yaml
+++ b/src/services/kubernetes/tradeexecution-deployment.yaml
@@ -30,3 +30,8 @@ spec:
               '-c',
               'dotnet ./Adaptive.ReactiveTrader.Server.TradeExecution.dll config.prod.json',
             ]
+          resources:
+            requests:
+              memory: "80M"
+              cpu: "5m"
+

--- a/src/services/kubernetes/web-deployment.yaml
+++ b/src/services/kubernetes/web-deployment.yaml
@@ -17,3 +17,7 @@ spec:
           image: ${DOCKER_USER}/nginx:${BUILD_VERSION}
           ports:
             - containerPort: 3000
+          resources:
+            requests:
+              memory: "10M"
+              cpu: "15m"


### PR DESCRIPTION
Added requests specifications for each pod. 
I had some issues setting the limits while using Kubernetes locally. The CPU usages I faced are higher from the one in our deployments and the pods were slow and tend to restart without hitting the memory limit. 