### PR TITLE
ARTP-1109 Replace nsgate with ingress

### DIFF
--- a/docs/deployment/tls-key-for-ingress.md
+++ b/docs/deployment/tls-key-for-ingress.md
@@ -1,0 +1,10 @@
+### How to create a pre-shared certificate in order to enable ssl
+
+All the ingresses use a pre-shared certificate called `web-ssl-shared` that contains the certificate and key file.
+
+In order to create it, run this command:
+```shell script
+gcloud compute ssl-certificates create web-ssl-shared  --certificate tls.crt --private-key tls.key
+```
+
+Useful link: [Specifying certificates for your Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-multi-ssl#specifying_certificates_for_your_ingress)

--- a/src/services/kubernetes/deploy_locally.sh
+++ b/src/services/kubernetes/deploy_locally.sh
@@ -2,18 +2,20 @@
 
 export DOCKER_USER='localhost:32000'
 export BUILD_VERSION='0.0.0'
+export DEPLOY_ENV='reactive-trader-local'
 cd ../..
 docker-compose build
 docker-compose push
 
 # This is how we deploy from GitHub
-#microk8s kubectl scale deploy --replicas=0 --all -n reactive-trader-local
+#microk8s kubectl scale deploy --replicas=0 --all -n ${DEPLOY_ENV}
 
 # In this way I can start from scratch and seed the data each time
-microk8s kubectl delete --all deployments -n reactive-trader-local
-microk8s kubectl delete --all jobs -n reactive-trader-local
+microk8s kubectl delete --all ingress -n ${DEPLOY_ENV}
+microk8s kubectl delete --all deployments -n ${DEPLOY_ENV}
+microk8s kubectl delete --all jobs -n ${DEPLOY_ENV}
 
-# Removing the services will change the IP adresses 
-#microk8s kubectl delete --all services -n reactive-trader-local
+# Removing the services will change the IP adresses
+#microk8s kubectl delete --all services -n ${DEPLOY_ENV}
 
-for f in $(find ./services/kubernetes -type f -name "*.yaml"); do cat $f | /usr/bin/envsubst | microk8s kubectl apply -n reactive-trader-local -f -; done
+for f in $(find ./services/kubernetes -type f -name "*.yaml"); do cat $f | /usr/bin/envsubst | microk8s kubectl apply -n ${DEPLOY_ENV} -f -; done

--- a/src/services/kubernetes/ingress.yaml
+++ b/src/services/kubernetes/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: reactive-trader-ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+    - host: web-${DEPLOY_ENV}.adaptivecluster.com
+      http:
+        paths:
+          - path:
+            backend:
+              serviceName: web
+              servicePort: 80

--- a/src/services/kubernetes/ingress.yaml
+++ b/src/services/kubernetes/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: reactive-trader-ingress
   annotations:
     kubernetes.io/ingress.class: "gce"
+    ingress.gcp.kubernetes.io/pre-shared-cert: "web-ssl-shared"
 spec:
   rules:
     - host: web-${DEPLOY_ENV}.adaptivecluster.com

--- a/src/services/kubernetes/web-backend-config.yaml
+++ b/src/services/kubernetes/web-backend-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: web-backend-config
+spec:
+  timeoutSec: 86400

--- a/src/services/kubernetes/web-service.yaml
+++ b/src/services/kubernetes/web-service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     name: web
     public: 'true'
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default": "web-backend-config"}'
 spec:
   selector:
     component: web

--- a/src/services/kubernetes/web-service.yaml
+++ b/src/services/kubernetes/web-service.yaml
@@ -12,3 +12,4 @@ spec:
     - name: web
       port: 80
       targetPort: 80
+  type: NodePort


### PR DESCRIPTION
Added configuration that will replace `nsgate` with multiple Kubernetes ingresses (one for each namespace).
Since we will have multiple ingresses, I created a pre-shared certificate for the TLS certificate.