### PR TITLE
Artp 1302 popped out tiles dont have tabs

### DIFF
--- a/src/client/src/apps/MainRoute/components/windowFrame/WindowFrame.tsx
+++ b/src/client/src/apps/MainRoute/components/windowFrame/WindowFrame.tsx
@@ -47,6 +47,14 @@ const TitleBarRoot = styled.div`
   height: var(--title-bar-height);
   display: flex;
 `
+
+const TitleBarWindowName = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
 const LayoutRoot = styled.div`
   height: calc(100% - var(--title-bar-height));
 `
@@ -56,6 +64,7 @@ const WindowFrame: FC<{ maximize?: boolean }> = ({ maximize = false }) => {
   const onMinimize = () => win.minimize()
   const onMaximize = async () =>
     win.getState().then(state => (state === 'maximized' ? win.restore() : win.maximize()))
+  const windowName = win.identity.name
 
   useEffect(() => {
     window.document.dispatchEvent(
@@ -70,7 +79,9 @@ const WindowFrame: FC<{ maximize?: boolean }> = ({ maximize = false }) => {
   return (
     <FrameRoot>
       <TitleBarRoot>
-        <div className="title-bar-draggable"></div>
+        <div className="title-bar-draggable">
+          <TitleBarWindowName>{windowName}</TitleBarWindowName>
+        </div>
         <OpenFinControls
           minimize={onMinimize}
           maximize={maximize ? onMaximize : undefined}

--- a/src/client/src/rt-platforms/openfin-platform/adapter/window.ts
+++ b/src/client/src/rt-platforms/openfin-platform/adapter/window.ts
@@ -150,6 +150,10 @@ export const openDesktopWindow = async (
     ...position,
     ...updatedPosition,
     layout: {
+      settings: {
+        hasHeaders: false,
+        reorderEnabled: false,
+      },
       content: [
         {
           type: 'stack',


### PR DESCRIPTION
Torn off windows now look like this:

![image](https://user-images.githubusercontent.com/4398367/94599158-f2116980-0287-11eb-9119-4572eae34d4f.png)

Chrome styles (buttons and and title font) will be addressed in a future ticket