### PR TITLE
ARTP-1313 Tile scrolling behavior fix

### DIFF
--- a/src/client/src/apps/MainRoute/routes/styled.tsx
+++ b/src/client/src/apps/MainRoute/routes/styled.tsx
@@ -4,7 +4,7 @@ import { rules } from 'rt-styleguide'
 export const OverflowScroll = styled.div`
   overflow-y: scroll;
   ${rules.touchScroll};
-  height: 100%;
+  height: 100%
 `
 
 export const Wrapper = styled.div`
@@ -19,6 +19,7 @@ export const WorkspaceWrapper = styled(Wrapper)`
   @media (max-width: 480px) {
     padding-right: 1rem;
   }
+  overflow-y: auto
 `
 
 export const AnalyticsWrapper = styled(Wrapper)`

--- a/src/client/src/apps/MainRoute/routes/styled.tsx
+++ b/src/client/src/apps/MainRoute/routes/styled.tsx
@@ -4,7 +4,7 @@ import { rules } from 'rt-styleguide'
 export const OverflowScroll = styled.div`
   overflow-y: scroll;
   ${rules.touchScroll};
-  height: 100vh;
+  height: 100%;
 `
 
 export const Wrapper = styled.div`

--- a/src/client/src/apps/MainRoute/routes/styled.tsx
+++ b/src/client/src/apps/MainRoute/routes/styled.tsx
@@ -4,7 +4,7 @@ import { rules } from 'rt-styleguide'
 export const OverflowScroll = styled.div`
   overflow-y: scroll;
   ${rules.touchScroll};
-  height: 100%
+  height: 100%;
 `
 
 export const Wrapper = styled.div`

--- a/src/client/src/apps/MainRoute/routes/styled.tsx
+++ b/src/client/src/apps/MainRoute/routes/styled.tsx
@@ -19,7 +19,7 @@ export const WorkspaceWrapper = styled(Wrapper)`
   @media (max-width: 480px) {
     padding-right: 1rem;
   }
-  overflow-y: auto
+  overflow-y: auto;
 `
 
 export const AnalyticsWrapper = styled(Wrapper)`


### PR DESCRIPTION
The simple fix here seems to be to use parent element height as opposed to viewport in OverflowScroll (vh -> %). Scrolling now works as expected and I don't think this change causes unexpected side-issues.