### PR TITLE
feat(browser): use portals for tile popouts (ARTP-1317)

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/SpotTileContainer.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/SpotTileContainer.tsx
@@ -24,6 +24,7 @@ export interface SpotTileContainerOwnProps {
   id: string
   tileView: TileView
   onPopoutClick?: (x: number, y: number) => void
+  onPopInClick?: () => void
   tornOff?: boolean
   tearable?: boolean
 }

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileControls.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileControls.tsx
@@ -21,11 +21,12 @@ export const TopRightButton = styled('button')`
 interface Props {
   canPopout?: boolean
   onPopoutClick?: (x: number, y: number) => void
+  onPopInClick?: () => void
   currencyPair: CurrencyPair
   notional?: number | undefined
 }
 
-const TileControls: React.FC<Props> = ({ onPopoutClick, canPopout, currencyPair, notional }) => {
+const TileControls: React.FC<Props> = ({ onPopoutClick, onPopInClick, canPopout, currencyPair, notional }) => {
   const platform = usePlatform()
 
   const popoutClickHandler = useCallback(
@@ -42,7 +43,7 @@ const TileControls: React.FC<Props> = ({ onPopoutClick, canPopout, currencyPair,
     if (typeof notional !== 'undefined') {
       setNotionalOnStorage(currencyPair.symbol, notional)
     }
-    platform.window.close()
+    onPopInClick && onPopInClick()
   }
 
   return (

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/TileSwitch.tsx
@@ -15,6 +15,7 @@ interface Props {
   executionStatus: ServiceConnectionStatus
   executeTrade: (tradeRequestObj: ExecuteTradeRequest) => void
   onPopoutClick?: (x: number, y: number) => void
+  onPopInClick?: () => void
   onNotificationDismissed: () => void
   displayCurrencyChart?: () => void
   setTradingMode: (tradingMode: TradingMode) => void
@@ -29,6 +30,7 @@ const TileSwitch: React.FC<Props> = ({
   executeTrade,
   canPopout,
   onPopoutClick,
+  onPopInClick,
   onNotificationDismissed,
   displayCurrencyChart,
   executionStatus,
@@ -59,6 +61,7 @@ const TileSwitch: React.FC<Props> = ({
           <TileControls
             canPopout={canPopout}
             onPopoutClick={onPopoutClick}
+            onPopInClick={onPopInClick}
             currencyPair={currencyPair}
             notional={spotTileData.notional}
           />

--- a/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
+++ b/src/client/src/apps/MainRoute/widgets/workspace/Workspace.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components/macro'
 import SpotTileContainer from '../spotTile/SpotTileContainer'
 import { WorkspaceHeader, TileView } from './workspaceHeader'
 import { ExternalWindowProps } from './selectors'
-import { useLocalStorage } from 'rt-util'
 
 const WorkspaceItems = styled.div`
   display: grid;
@@ -39,7 +38,7 @@ const Workspace: React.FC<Props> = ({
   onPopoutClick,
 }) => {
   const [currency, setCurrencyOption] = useState(ALL)
-  const [tileView, setTileView] = useLocalStorage('tileView', TileView.Analytics)
+  const [tileView, setTileView] = useState(TileView.Analytics)
 
   return (
     <div data-qa="workspace__tiles-workspace">
@@ -62,12 +61,13 @@ const Workspace: React.FC<Props> = ({
               key={key}
               dragTearOff
               externalWindowProps={externalWindowProps}
-              render={(popOut, isTornOff) => (
+              render={(popOut, isTornOff, popIn) => (
                 <WorkspaceItem>
                   <SpotTileContainer
                     id={key}
                     tileView={tileView as TileView}
                     onPopoutClick={popOut}
+                    onPopInClick={popIn}
                     tornOff={isTornOff}
                     tearable
                   />

--- a/src/client/src/rt-components/tear-off/ExternalWindow.tsx
+++ b/src/client/src/rt-components/tear-off/ExternalWindow.tsx
@@ -13,6 +13,7 @@ const defaultConfig: WindowConfig = {
 }
 
 export interface ExternalWindowProps {
+  title?: string
   onUnload: () => void
   config?: WindowConfig
 }

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -190,8 +190,9 @@ const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff,
   }
 
   if (tornOff) {
+    console.info('extWP', externalWindowProps!.config!.name!)
     // use portal only for browser tiles
-    if (['LiveRates', 'analytics'].includes(externalWindowProps!.config!.name!)
+    if (['LiveRates', 'analytics', 'blotter'].includes(externalWindowProps!.config!.name!)
       || platform.name !== 'browser') {
       return (
         <ExternalWindow onUnload={popIn} {...externalWindowProps} />

--- a/src/client/src/rt-components/tear-off/TearOff.tsx
+++ b/src/client/src/rt-components/tear-off/TearOff.tsx
@@ -1,11 +1,22 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useRef, useState, useEffect } from 'react'
+import ReactDOM from 'react-dom'
 import ExternalWindow, { ExternalWindowProps } from './ExternalWindow'
 import styled from 'styled-components/macro'
 import { useDispatch } from 'react-redux'
 import { usePlatform } from 'rt-platforms'
 import { LayoutActions } from 'rt-actions'
+import { RouteWrapper } from 'rt-components'
 
-type RenderCB = (popOut: (x?: number, y?: number) => void, tornOff: boolean) => JSX.Element
+const SpotTileStyle = styled.div`
+  min-width: 26rem;
+  width: 26rem;
+  min-height: 12.2rem;
+  height: 12.2rem;
+  padding: 0 0.575rem 0.5rem 0.575rem;
+  margin
+`
+
+type RenderCB = (popOut: (x?: number, y?: number) => void, tornOff: boolean, popIn?: () => void) => JSX.Element
 
 const DragWrapper = styled.div`
   height: 100%;
@@ -57,10 +68,86 @@ export interface TearOffProps {
   dragTearOff: boolean
 }
 
+export interface PortalProps {
+  children: React.ReactNode,
+  className?: string,
+  element?: string
+  onUnload?: Function
+  externalWindowProps?: Partial<ExternalWindowProps>
+  externalWindowRef?: React.MutableRefObject<Window | undefined>
+}
+
+
+function copyStyles(sourceDoc: Document, targetDoc: Document) {
+  Array.from(sourceDoc.querySelectorAll('link[rel="stylesheet"], style, meta'))
+    .forEach(stylesheet => {
+      targetDoc.head.appendChild(stylesheet.cloneNode(true));
+    })
+}
+
+function removeStyles(document: Document) {
+  document.querySelectorAll('link[rel="stylesheet"], style, meta')
+    .forEach(stylesheet => {
+      stylesheet.parentNode!.removeChild(stylesheet)
+    })
+}
+
+export const Portal = ({
+  children,
+  className = 'tile-portal',
+  element = 'div',
+  externalWindowProps,
+  onUnload,
+  externalWindowRef
+}: PortalProps) => {
+  const [container] = useState(() => {
+    const el = document.createElement(element)
+    el.classList.add(className)
+    return el
+  })
+
+  useEffect(() => {
+    if (externalWindowRef) {
+      externalWindowRef.current = window.open('', externalWindowProps!.config!.name, 'height=202, width=366, left=1000, top=500') as Window;
+      if (onUnload instanceof Function) {
+        externalWindowRef.current.addEventListener('unload', () => onUnload())
+      }
+      externalWindowRef.current.document.body.appendChild(container)
+      externalWindowProps && (externalWindowRef.current.document.title = externalWindowProps.title as string)
+      copyStyles(document, externalWindowRef.current.document)
+    }
+
+    const onCssChange = () => {
+      if (externalWindowRef && externalWindowRef.current) {
+        removeStyles(externalWindowRef.current.document);
+        copyStyles(document, externalWindowRef.current.document);
+      }
+    }
+
+    const options = {
+      childList: true,
+      subtree: true
+    }
+
+    const observer = new MutationObserver(onCssChange)
+    observer.observe(document.head, options)
+
+    return () => {
+      observer.disconnect()
+    }
+    // eslint-disable-next-line
+  }, [])
+
+  return ReactDOM.createPortal(children, container)
+}
+
+
 const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff, dragTearOff }) => {
-  const { allowTearOff } = usePlatform()
+  const platform = usePlatform()
+  const { allowTearOff } = platform
   const targetMouseXRef = useRef<number>()
   const targetMouseYRef = useRef<number>()
+  let externalWindowRef = useRef<Window | undefined>();
 
   const dispatch = useDispatch()
   const windowName = externalWindowProps.config && externalWindowProps.config.name
@@ -86,9 +173,10 @@ const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff,
     },
     [windowName, dispatch]
   )
-  const popIn = useCallback(
-    () =>
-      dispatch(LayoutActions.updateContainerVisibilityAction({ name: windowName, display: true })),
+  const popIn = useCallback(() => {
+    dispatch(LayoutActions.updateContainerVisibilityAction({ name: windowName, display: true }))
+    externalWindowRef.current && externalWindowRef.current.close()
+  },
     [windowName, dispatch]
   )
 
@@ -102,7 +190,23 @@ const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff,
   }
 
   if (tornOff) {
-    return <ExternalWindow onUnload={popIn} {...externalWindowProps} />
+    // use portal only for browser tiles
+    if (['LiveRates', 'analytics'].includes(externalWindowProps!.config!.name!)
+      || platform.name !== 'browser') {
+      return (
+        <ExternalWindow onUnload={popIn} {...externalWindowProps} />
+      )
+    }
+
+    return (
+      <Portal onUnload={popIn} externalWindowRef={externalWindowRef} externalWindowProps={externalWindowProps}>
+        <RouteWrapper>
+          <SpotTileStyle>
+            {render(popOut, tornOff, popIn)}
+          </SpotTileStyle>
+        </ RouteWrapper>
+      </Portal>
+    )
   }
 
   if (dragTearOff) {
@@ -122,3 +226,4 @@ const TearOff: React.FC<TearOffProps> = ({ render, externalWindowProps, tornOff,
 }
 
 export default TearOff
+


### PR DESCRIPTION
This is an attempt at using React Portals to handle tile pop outs, avoiding the loading time needed with the current solution. I don't consider this merge-ready but I am making a draft PR so that the general approach can be discussed.
![676a7993340ad61b623376688e58a67e](https://user-images.githubusercontent.com/26552273/97139271-84dee000-1730-11eb-86f2-e7092c79c9b4.gif)

This approach maintains tile view / theme sync across windows. Some current outstanding issues:
1) I'm not sure how we want to handle the address bar:
![4f56ba39df963c4795ebaa315923002e](https://user-images.githubusercontent.com/26552273/97139447-e737e080-1730-11eb-9b16-3b4dc7397867.png)
Since we wouldn't be using routes anymore, we don't actually need anything here, but it doesn't seem right to leave it as 'about:blank' either.

2) There is currently a bug that you can reproduce as follows: pop out the entire tile workspace, and from that popped out window, pop out an individual tile. Now, if you pop the workspace back in, the popped-out tile stops updating, but its window doesn't automatically close. This also applies to closing the main / full application view while a tile is popped out.