### PR TITLE
fix: added tear off wrappers to analytics, blotter and tile routes, s…

### DIFF
--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -8,9 +8,9 @@ import { analyticsSelector } from '../layouts'
 import { addLayoutToConfig } from './addLayoutToConfig'
 import { inExternalWindow } from './inExternalWindow'
 
-const AnalyticsRouteStyle = styled.div<{ showOpenFinControls : boolean }>`
+const AnalyticsRouteStyle = styled.div<{ useHeightOffset  : boolean }>`
   /*height offset is needed for openfin controls*/
-  height: ${({ showOpenFinControls }) => (showOpenFinControls ? 'calc(100% - 24px)' : '100%')};
+  height: ${({ useHeightOffset  }) => (useHeightOffset  ? 'calc(100% - 24px)' : '100%')};
   padding: 0.5rem 0.625rem 0.25rem 0.625rem;
   overflow-x: auto;
   margin: auto;
@@ -25,7 +25,7 @@ const AnalyticsRoute = () => {
       dragTearOff={false}
       externalWindowProps={addLayoutToConfig(externalWindowDefault.analyticsRegion, analytics)}
       render={(popOut, tornOff) => (
-        <AnalyticsRouteStyle showOpenFinControls={tornOff}>
+        <AnalyticsRouteStyle useHeightOffset={tornOff}>
           <AnalyticsContainer
             inExternalWindow={isExternalWindow}
             onPopoutClick={popOut}

--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -1,20 +1,41 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { AnalyticsContainer } from '../widgets/analytics'
 import styled from 'styled-components/macro'
+import { externalWindowDefault } from 'rt-platforms'
+import { TearOff } from 'rt-components'
+import { analyticsSelector } from '../layouts'
+import { addLayoutToConfig } from './addLayoutToConfig'
+import { inExternalWindow } from './inExternalWindow'
 
-const AnalyticsRouteStyle = styled.div`
+const AnalyticsRouteStyle = styled.div<{ showOpenFinControls : boolean }>`
   /*height offset is needed for openfin controls*/
-  height: calc(100% - 24px);
-  padding: 0 0.625rem 0rem 0.625rem;
-  overflow-x: scroll;
+  height: ${({ showOpenFinControls }) => (showOpenFinControls ? 'calc(100% - 24px)' : '100%')};
+  padding: 0.5rem 0.625rem 0.25rem 0.625rem;
+  overflow-x: auto;
   margin: auto;
 `
-
 const AnalyticsRoute = () => {
+  const analytics = useSelector(analyticsSelector)
+  const isExternalWindow = inExternalWindow
+
   return (
-    <AnalyticsRouteStyle>
-      <AnalyticsContainer inExternalWindow />
-    </AnalyticsRouteStyle>
+    <TearOff
+      id="Analytics"
+      dragTearOff={false}
+      externalWindowProps={addLayoutToConfig(externalWindowDefault.analyticsRegion, analytics)}
+      render={(popOut, tornOff) => (
+        <AnalyticsRouteStyle showOpenFinControls={tornOff}>
+          <AnalyticsContainer
+            inExternalWindow={isExternalWindow}
+            onPopoutClick={popOut}
+            tornOff={tornOff}
+            tearable={!isExternalWindow}
+          />
+        </AnalyticsRouteStyle>
+      )}
+      tornOff={!analytics.visible}
+    />
   )
 }
 

--- a/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/AnalyticsRoute.tsx
@@ -6,7 +6,7 @@ import { externalWindowDefault } from 'rt-platforms'
 import { TearOff } from 'rt-components'
 import { analyticsSelector } from '../layouts'
 import { addLayoutToConfig } from './addLayoutToConfig'
-import { inExternalWindow } from './inExternalWindow'
+import { inExternalWindow as isExternalWindow } from './inExternalWindow'
 
 const AnalyticsRouteStyle = styled.div<{ useHeightOffset  : boolean }>`
   /*height offset is needed for openfin controls*/
@@ -17,7 +17,6 @@ const AnalyticsRouteStyle = styled.div<{ useHeightOffset  : boolean }>`
 `
 const AnalyticsRoute = () => {
   const analytics = useSelector(analyticsSelector)
-  const isExternalWindow = inExternalWindow
 
   return (
     <TearOff

--- a/src/client/src/apps/MainRoute/routes/BlotterRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/BlotterRoute.tsx
@@ -57,7 +57,6 @@ const BlotterRoute: React.FC<RouteComponentProps<{ symbol: string }>> = ({
 }) => {
   const blotter = useSelector(blotterSelector)
   const platform = usePlatform()
-  const isExternalWindow = inExternalWindow
   const [filtersFromInterop, setFiltersFromInterop] = useState<ReadonlyArray<BlotterFilters>>()
 
   useEffect(() => {
@@ -87,7 +86,7 @@ const BlotterRoute: React.FC<RouteComponentProps<{ symbol: string }>> = ({
             filters={filters} 
             onPopoutClick={popOut}
             tornOff={tornOff}
-            tearable={!isExternalWindow}
+            tearable={!inExternalWindow}
           />
         </BlotterContainerStyle>
       )}

--- a/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/ShellRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { Resizer, TearOff } from 'rt-components'
-import { externalWindowDefault, ExternalWindow, WindowPosition } from 'rt-platforms'
+import { externalWindowDefault } from 'rt-platforms'
 import { AnalyticsContainer } from '../widgets/analytics'
 import { BlotterContainer } from '../widgets/blotter'
 import StatusBar from '../widgets/status-bar'
@@ -12,21 +12,11 @@ import { analyticsSelector, blotterSelector, liveRatesSelector, DefaultLayout } 
 import { BlotterWrapper, AnalyticsWrapper, OverflowScroll, WorkspaceWrapper } from './styled'
 import UsersModal from '../components/users-modal'
 import ContactUsButton from '../widgets/contact-us'
+import { addLayoutToConfig } from './addLayoutToConfig'
 
 interface Props {
   header?: React.ReactChild
   footer?: React.ReactChild
-}
-
-const addLayoutToConfig = (windowConfig: ExternalWindow, layout: WindowPosition) => {
-  return {
-    ...windowConfig,
-    config: {
-      ...windowConfig.config,
-      x: layout.x,
-      y: layout.y,
-    },
-  }
 }
 
 const ShellRoute: React.FC<Props> = ({ header, footer }) => {

--- a/src/client/src/apps/MainRoute/routes/TileRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/TileRoute.tsx
@@ -16,7 +16,6 @@ interface Props {
 
 const ShellRoute: React.FC<Props> = ({ header }) => {
   const liveRates = useSelector(liveRatesSelector)
-  const isExternalWindow = inExternalWindow;
   return (
     <DefaultLayout
       header={header}
@@ -31,7 +30,7 @@ const ShellRoute: React.FC<Props> = ({ header }) => {
                 <WorkspaceContainer 
                   onPopoutClick={popOut}                
                   tornOff={tornOff}
-                  tearable={!isExternalWindow}
+                  tearable={!inExternalWindow}
                 />
               )}
               tornOff={!liveRates.visible}

--- a/src/client/src/apps/MainRoute/routes/TileRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/TileRoute.tsx
@@ -1,21 +1,41 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
+import { TearOff } from 'rt-components'
+import { externalWindowDefault } from 'rt-platforms'
 import { WorkspaceContainer } from '../widgets/workspace'
 import ReconnectModal from '../components/reconnect-modal'
 import DefaultLayout from '../layouts/DefaultLayout'
 import { OverflowScroll, WorkspaceWrapper } from './styled'
+import { addLayoutToConfig } from './addLayoutToConfig'
+import { liveRatesSelector } from '../layouts'
+import { inExternalWindow } from './inExternalWindow'
 
 interface Props {
   header?: React.ReactChild
 }
 
 const ShellRoute: React.FC<Props> = ({ header }) => {
+  const liveRates = useSelector(liveRatesSelector)
+  const isExternalWindow = inExternalWindow;
   return (
     <DefaultLayout
       header={header}
       body={
         <WorkspaceWrapper data-qa="tile-route__workspace-wrapper">
           <OverflowScroll>
-            <WorkspaceContainer />
+            <TearOff
+              id="liveRates"
+              dragTearOff={false}
+              externalWindowProps={addLayoutToConfig(externalWindowDefault.liveRatesRegion, liveRates)}
+              render={(popOut, tornOff) => (
+                <WorkspaceContainer 
+                  onPopoutClick={popOut}                
+                  tornOff={tornOff}
+                  tearable={!isExternalWindow}
+                />
+              )}
+              tornOff={!liveRates.visible}
+            />
           </OverflowScroll>
         </WorkspaceWrapper>
       }

--- a/src/client/src/apps/MainRoute/routes/addLayoutToConfig.ts
+++ b/src/client/src/apps/MainRoute/routes/addLayoutToConfig.ts
@@ -1,0 +1,12 @@
+import { ExternalWindow, WindowPosition } from "rt-platforms"
+
+export const addLayoutToConfig = (windowConfig: ExternalWindow, layout: WindowPosition) => {
+  return {
+    ...windowConfig,
+    config: {
+      ...windowConfig.config,
+      x: layout.x,
+      y: layout.y,
+    },
+  }
+}

--- a/src/client/src/apps/MainRoute/routes/inExternalWindow.ts
+++ b/src/client/src/apps/MainRoute/routes/inExternalWindow.ts
@@ -1,0 +1,1 @@
+export const inExternalWindow = window.name.includes('_ext');

--- a/src/client/src/rt-platforms/externalWindowDefault.ts
+++ b/src/client/src/rt-platforms/externalWindowDefault.ts
@@ -8,7 +8,7 @@ export interface ExternalWindow {
 const blotterRegion: ExternalWindow = {
   title: 'Blotter',
   config: {
-    name: 'blotter',
+    name: 'blotter_ext',
     width: 850,
     height: 450,
     minWidth: 300,
@@ -20,7 +20,7 @@ const blotterRegion: ExternalWindow = {
 const analyticsRegion: ExternalWindow = {
   title: 'Analytics',
   config: {
-    name: 'analytics',
+    name: 'analytics_ext',
     width: 352, // 332 content + 10 padding
     height: 800,
     minWidth: 360,
@@ -32,7 +32,7 @@ const analyticsRegion: ExternalWindow = {
 const liveRatesRegion: ExternalWindow = {
   title: 'LiveRates',
   config: {
-    name: 'LiveRates',
+    name: 'LiveRates_ext',
     width: 664,
     height: 617,
     minWidth: 664,


### PR DESCRIPTION
…tyle fixes (ARTP-1320 ARTP-1319)

Style fixes to AnalyticsRouteStyle to align top and bottom of panel with other panels.

Added '_ext' to names for torn off windows
check window name in routes to see if we are in a torn off window

TearOff wrappers added for Analytics, Blotter and Live rates


![image](https://user-images.githubusercontent.com/30235606/97296245-4dfbed80-1848-11eb-924d-823720a925e4.png)


