### PR TITLE
fix: paths for new subwindows opened from launcher (ARTP-1323)

### DIFF
--- a/src/client/public/openfin/launcher.json
+++ b/src/client/public/openfin/launcher.json
@@ -48,7 +48,8 @@
     "applicationIcon": "{*host_url*}/static/media/adaptive-icon-256x256.png",
     "defaultWindowOptions": {
       "contextMenu": true,
-      "frame": false
+      "frame": false,
+      "url": "{*host_url*}/openfin-sub-window-frame"
     },
     "fdc3Api": true
   },

--- a/src/client/src/rt-interop/intents/showBlotter.ts
+++ b/src/client/src/rt-interop/intents/showBlotter.ts
@@ -1,6 +1,6 @@
 import { InteropTopics, Platform, platformHasFeature, PlatformWindow } from 'rt-platforms'
 import { stringify } from 'query-string'
-import { defaultConfig, windowOrigin } from './defaultWindowConfig'
+import { defaultConfig } from './defaultWindowConfig'
 import { BlotterFilters, validateFilters } from 'apps/MainRoute/widgets/blotter/blotterTradesFilter'
 
 let openedWindow: PlatformWindow | undefined
@@ -32,7 +32,7 @@ async function openNewWindow(
   filters: BlotterFilters,
   platform: Platform
 ): Promise<PlatformWindow | undefined> {
-  const baseUrl = `${windowOrigin}/blotter`
+  const baseUrl = `/blotter`
   const queryString = stringify(validateFilters(filters))
   const url = queryString ? `${baseUrl}/?${queryString}` : baseUrl
 

--- a/src/client/src/rt-interop/intents/showCurrencyPair.ts
+++ b/src/client/src/rt-interop/intents/showCurrencyPair.ts
@@ -1,6 +1,6 @@
 import { PlatformWindow, Platform } from 'rt-platforms'
 import { currencyFormatter } from 'rt-util'
-import { defaultConfig, windowOrigin } from './defaultWindowConfig'
+import { defaultConfig } from './defaultWindowConfig'
 
 let openedWindow: PlatformWindow | undefined
 let updatedPosition: { x: number | undefined; y: number | undefined } = {
@@ -25,7 +25,7 @@ async function openNewWindow(
       height: 200,
       name: currencyPair,
       displayName,
-      url: `${windowOrigin}/spot/${currencyPair}?tileView=Analytics`,
+      url: `/spot/${currencyPair}?tileView=Analytics`,
       ...updatedPosition,
     },
     () => (openedWindow = undefined),

--- a/src/client/src/rt-interop/intents/showMarket.ts
+++ b/src/client/src/rt-interop/intents/showMarket.ts
@@ -1,5 +1,5 @@
 import { Platform, PlatformWindow } from 'rt-platforms'
-import { defaultConfig, windowOrigin } from './defaultWindowConfig'
+import { defaultConfig } from './defaultWindowConfig'
 
 let openedWindow: PlatformWindow | undefined
 let updatedPosition: { x: number | undefined; y: number | undefined } = {
@@ -25,7 +25,7 @@ export async function showMarket({ window }: Platform) {
       ...defaultConfig,
       name: 'market',
       height: 600,
-      url: `${windowOrigin}/tiles`,
+      url: `/tiles`,
       saveWindowState: true,
       ...updatedPosition
     },


### PR DESCRIPTION
host url prefix is added by the openfin-platform window.ts we were adding it twice

headers were not correct due to missing openfin-sub-window-frame in launchers defaultWindowOptions