### PR TITLE
fix: removed open fin specific code from RouteWrapper and AppLayout

### DIFF
--- a/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
+++ b/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
@@ -12,15 +12,11 @@ export interface Props {
 }
 
 const AppLayout: React.FC<Props> = ({ before, header, body, footer, after }) => {
-  // TODO - move to openfin-platform
-  //@ts-ignore
-  const isChildView = window.fin && window.fin.me && window.fin.me.isView
-
   return (
     <AppLayoutRoot data-qa="app-layout__root">
       {before}
 
-      {!isChildView && header !== null && <Header controls={header} />}
+      {header !== null && <Header controls={header} />}
 
       <Body>{body}</Body>
 

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -1,9 +1,7 @@
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useEffect } from 'react'
 import styled from 'styled-components/macro'
-import { Platform, usePlatform, isParentAppOpenfinLauncher } from 'rt-platforms'
-import { getAppName } from 'rt-util'
+import { Platform, usePlatform } from 'rt-platforms'
 import { useTheme, ThemeName } from 'rt-theme'
-import Helmet from 'react-helmet'
 
 const RouteStyle = styled('div')<{ platform: Platform }>`
   width: 100%;
@@ -31,27 +29,12 @@ interface RouteWrapperProps {
   title?: string | SymbolParamObject
 }
 
-// TODO Move to openfin-platform
-//@ts-ignore
-const isChildView = window.fin && window.fin.me && window.fin.me.isView
-
 const RouteWrapper: React.FC<RouteWrapperProps> = props => {
-  const { children, windowType = 'main', title } = props
-  const [fromLauncher, setFromLauncher] = useState<boolean>(false)
+  const { children, windowType = 'main' } = props
   const platform = usePlatform()
   const theme = useTheme()
 
-  const { PlatformHeader, PlatformFooter, PlatformControls, PlatformRoute, window } = platform
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
+  const { PlatformFooter, PlatformControls, PlatformRoute, window } = platform
 
   useEffect(() => {
     const head = document.getElementById('themeColor')
@@ -62,36 +45,12 @@ const RouteWrapper: React.FC<RouteWrapperProps> = props => {
       )
   }, [theme])
 
-  const isBlotterOrTrade = title === 'Trades' || title === 'Live Rates'
-
   const Header = windowType === 'main' ? PlatformControls : null
   const Footer = windowType === 'main' ? PlatformFooter : null
 
-  const subheader =
-    windowType === 'sub' && !isChildView ? (
-      <PlatformHeader
-        close={fromLauncher && window.close}
-        popIn={!fromLauncher && window.close}
-        minimize={window.minimize}
-        title={`${getAppName()} - ${title}`}
-        isBlotterOrTrade={isBlotterOrTrade}
-      />
-    ) : null
-
-  const helmet =
-    windowType === 'sub' ? (
-      isChildView ? (
-        <Helmet title={`${title}`} />
-      ) : (
-        <Helmet title={`${getAppName()} - ${title}`} />
-      )
-    ) : null
-
   return (
     <RouteStyle platform={platform}>
-      {helmet}
       <PlatformRoute>
-        {subheader}
         {React.cloneElement(children as React.ReactElement, {
           header: Header ? <Header {...window} /> : null,
           footer: Footer ? <Footer /> : null,

--- a/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
@@ -1,10 +1,6 @@
-export async function isParentAppOpenfinLauncher() {
-  if (fin?.Window) {
-    const app = await fin.Window.getCurrent()
-    const {
-      identity: { uuid },
-    } = await app.getParentApplication()
-
+export function isParentAppOpenfinLauncher() {
+  if (window?.fin?.me) {
+    const uuid = window.fin.me.uuid
     return uuid.split('-').includes('launcher')
   }
   return false

--- a/src/client/src/rt-platforms/openfin-platform/components/OpenFinSubWindowFrame.tsx
+++ b/src/client/src/rt-platforms/openfin-platform/components/OpenFinSubWindowFrame.tsx
@@ -56,23 +56,14 @@ const LayoutRoot = styled.div`
 
 export const OpenFinSubWindowFrame: React.FC = () => {
   const win = fin.Window.getCurrentSync()
-  const [, setFromLauncher] = useState<boolean>(false)
+  const [fromLauncher] = useState<boolean>(isParentAppOpenfinLauncher())
   const [windowName, setWindowName] = useState('')
 
   const headerControlHandlers = {
     minimize: () => win.minimize(),
-    popIn: () => win.close(),
+    popIn: !fromLauncher ? () => win.close() : undefined,
+    close: fromLauncher ? () => win.close() : undefined,
   }
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
 
   useEffect(() => {
     window.document.dispatchEvent(

--- a/src/client/src/rt-platforms/openfin-platform/components/OpenFinWindowFrame.tsx
+++ b/src/client/src/rt-platforms/openfin-platform/components/OpenFinWindowFrame.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
-import { isParentAppOpenfinLauncher } from 'rt-platforms'
 import styled from 'styled-components/macro'
 import { OpenFinChrome, OpenFinHeader, OpenFinFooter } from './OpenFinChrome'
 import { getAppName } from 'rt-util'
@@ -63,8 +62,6 @@ const LayoutRoot = styled.div`
 `
 
 export const OpenFinWindowFrame: React.FC = () => {
-  const [, setFromLauncher] = useState<boolean>(false)
-
   const win = fin.Window.getCurrentSync()
   const headerControlHandlers = {
     close: () => win.close(),
@@ -72,16 +69,6 @@ export const OpenFinWindowFrame: React.FC = () => {
     maximize: () =>
       win.getState().then(state => (state === 'maximized' ? win.restore() : win.maximize())),
   }
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
 
   useEffect(() => {
     window.document.dispatchEvent(


### PR DESCRIPTION
Removed PlatformHeader from the RouteWrapper, its never rendered as the check for windowType === 'sub' && !isChildView never === true

Moved check of isParentAppOpenfinLauncher into OpenFinSubWindowFrame and deleted from OpenFinWindowFrame
The check is used to determine if headerControlHandlers should show a close or popin button on the subframe windows

subwindow from launcher = close button
subwindow from !launcher = popin button

isParentAppOpenfinLauncher was throwing an exception, replaced check of fin.Window.getCurrent().getParentApplication with window.fin.me.uuid
