### PR TITLE
Artp 1288 make version url clickable

### DIFF
--- a/src/client/.env
+++ b/src/client/.env
@@ -1,6 +1,6 @@
 NODE_ENV=development
 REACT_APP_ENV=default
-REACT_APP_VERSION=$npm_package_version
+REACT_APP_VERSION=v1.5.2
 REACT_APP_NAME=$npm_package_name
 REACT_EDITOR=code
 REACT_APP_GREENKEY_URL=ws://localhost:8888/client/ws/speech

--- a/src/client/.env
+++ b/src/client/.env
@@ -1,6 +1,6 @@
 NODE_ENV=development
 REACT_APP_ENV=default
-REACT_APP_VERSION="$npm_package_version"
+REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 REACT_EDITOR=code
 REACT_APP_GREENKEY_URL=ws://localhost:8888/client/ws/speech

--- a/src/client/.env
+++ b/src/client/.env
@@ -1,6 +1,6 @@
 NODE_ENV=development
 REACT_APP_ENV=default
-REACT_APP_VERSION=v1.5.2
+REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 REACT_EDITOR=code
 REACT_APP_GREENKEY_URL=ws://localhost:8888/client/ws/speech

--- a/src/client/.env
+++ b/src/client/.env
@@ -1,6 +1,6 @@
 NODE_ENV=development
 REACT_APP_ENV=default
-REACT_APP_VERSION=$npm_package_version
+REACT_APP_VERSION="$npm_package_version"
 REACT_APP_NAME=$npm_package_name
 REACT_EDITOR=code
 REACT_APP_GREENKEY_URL=ws://localhost:8888/client/ws/speech

--- a/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
+++ b/src/client/src/apps/MainRoute/layouts/AppLayout.tsx
@@ -12,15 +12,11 @@ export interface Props {
 }
 
 const AppLayout: React.FC<Props> = ({ before, header, body, footer, after }) => {
-  // TODO - move to openfin-platform
-  //@ts-ignore
-  const isChildView = window.fin && window.fin.me && window.fin.me.isView
-
   return (
     <AppLayoutRoot data-qa="app-layout__root">
       {before}
 
-      {!isChildView && header !== null && <Header controls={header} />}
+      {header !== null && <Header controls={header} />}
 
       <Body>{body}</Body>
 

--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -15,10 +15,10 @@ const FooterVersion: FC = () => (
     <Link
       href={
         'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
-        process.env.REACT_APP_ENV
+        process.env.REACT_APP_VERSION
       }
     >
-      {process.env.REACT_APP_ENV}
+      {process.env.REACT_APP_VERSION}
     </Link>
   </Wrapper>
 )

--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import styled from 'styled-components/macro'
 
 export const Wrapper = styled.div`
@@ -10,17 +10,42 @@ export const Link = styled.a`
   color: inherit;
   text-decoration: inherit;
 `
-const FooterVersion: FC = () => (
-  <Wrapper>
-    <Link
-      href={
-        'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
-        process.env.REACT_APP_VERSION
-      }
-    >
-      {process.env.REACT_APP_VERSION}
-    </Link>
-  </Wrapper>
-)
+const FooterVersion: FC = () => {
+  const [versionExists, setVersionExists] = useState<boolean | void>(false)
+  const gitTagExists = async (gitTag: string | undefined) => {
+    const exists = await fetch(
+      'https://api.github.com/repos/AdaptiveConsulting/ReactiveTraderCloud/releases'
+    )
+      .then(response => response.json())
+      .then(data => {
+        for (let i = 0; i < data.length; i++) {
+          if (data[i].tag_name === gitTag) {
+            return true
+          }
+        }
+        return false
+      })
+      .catch(error => console.error(error))
+    setVersionExists(exists)
+  }
 
+  let currentVersion: string | undefined = process.env.REACT_APP_VERSION
+  gitTagExists(currentVersion)
+
+  const URL =
+    'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
+    process.env.REACT_APP_VERSION
+
+  return (
+    <Wrapper>
+      {versionExists ? (
+        <Link target="_blank" href={URL}>
+          {process.env.REACT_APP_VERSION}
+        </Link>
+      ) : (
+        <p>{process.env.REACT_APP_VERSION}</p>
+      )}
+    </Wrapper>
+  )
+}
 export default FooterVersion

--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -6,7 +6,21 @@ export const Wrapper = styled.div`
   opacity: 0.59;
   font-size: 0.75rem;
 `
-
-const FooterVersion: FC = () => <Wrapper>{process.env.REACT_APP_BUILD_VERSION}</Wrapper>
+export const Link = styled.a`
+  color: inherit;
+  text-decoration: inherit;
+`
+const FooterVersion: FC = () => (
+  <Wrapper>
+    <Link
+      href={
+        'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
+        process.env.REACT_APP_ENV
+      }
+    >
+      {process.env.REACT_APP_ENV}
+    </Link>
+  </Wrapper>
+)
 
 export default FooterVersion

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
@@ -30,7 +30,7 @@ const defaultParams: Parameters<typeof getDerivedStateFromUserInput>[0] = {
       mid: 1.48357,
       priceMovementType: 'Down' as PriceMovementTypes,
       symbol: 'EURCAD',
-      valueDate: '2019-04-07T00:00:00Z',
+      valueDate: new Date(2019, 3, 7).toISOString(),
     },
     rfqPrice: null,
     rfqState: 'none',

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -811,7 +811,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -1349,7 +1349,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -1856,7 +1856,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -2361,7 +2361,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -2873,7 +2873,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div
@@ -3424,7 +3424,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (06 APR)
+          SPT (07 APR)
         </div>
       </div>
       <div

--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/__snapshots__/Tile.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Snapshot, state derived from props, DISCONNECTED 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -811,7 +811,7 @@ exports[`Snapshot, state derived from props, RFQ canRequest 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -1349,7 +1349,7 @@ exports[`Snapshot, state derived from props, RFQ expired 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -1856,7 +1856,7 @@ exports[`Snapshot, state derived from props, RFQ received 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -2361,7 +2361,7 @@ exports[`Snapshot, state derived from props, RFQ requested 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -2873,7 +2873,7 @@ exports[`Snapshot, state derived from props, defaults, RFQ none, should be able 
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div
@@ -3424,7 +3424,7 @@ exports[`Snapshot, state derived from props, in trade 1`] = `
           className="c7 c8"
           data-qa="tile-header__delivery-date"
         >
-          SPT (07 APR)
+          SPT (06 APR)
         </div>
       </div>
       <div

--- a/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
+++ b/src/client/src/rt-components/route-wrapper/RouteWrapper.tsx
@@ -1,9 +1,7 @@
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useEffect } from 'react'
 import styled from 'styled-components/macro'
-import { Platform, usePlatform, isParentAppOpenfinLauncher } from 'rt-platforms'
-import { getAppName } from 'rt-util'
+import { Platform, usePlatform } from 'rt-platforms'
 import { useTheme, ThemeName } from 'rt-theme'
-import Helmet from 'react-helmet'
 
 const RouteStyle = styled('div')<{ platform: Platform }>`
   width: 100%;
@@ -31,27 +29,12 @@ interface RouteWrapperProps {
   title?: string | SymbolParamObject
 }
 
-// TODO Move to openfin-platform
-//@ts-ignore
-const isChildView = window.fin && window.fin.me && window.fin.me.isView
-
 const RouteWrapper: React.FC<RouteWrapperProps> = props => {
-  const { children, windowType = 'main', title } = props
-  const [fromLauncher, setFromLauncher] = useState<boolean>(false)
+  const { children, windowType = 'main' } = props
   const platform = usePlatform()
   const theme = useTheme()
 
-  const { PlatformHeader, PlatformFooter, PlatformControls, PlatformRoute, window } = platform
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
+  const { PlatformFooter, PlatformControls, PlatformRoute, window } = platform
 
   useEffect(() => {
     const head = document.getElementById('themeColor')
@@ -62,36 +45,12 @@ const RouteWrapper: React.FC<RouteWrapperProps> = props => {
       )
   }, [theme])
 
-  const isBlotterOrTrade = title === 'Trades' || title === 'Live Rates'
-
   const Header = windowType === 'main' ? PlatformControls : null
   const Footer = windowType === 'main' ? PlatformFooter : null
 
-  const subheader =
-    windowType === 'sub' && !isChildView ? (
-      <PlatformHeader
-        close={fromLauncher && window.close}
-        popIn={!fromLauncher && window.close}
-        minimize={window.minimize}
-        title={`${getAppName()} - ${title}`}
-        isBlotterOrTrade={isBlotterOrTrade}
-      />
-    ) : null
-
-  const helmet =
-    windowType === 'sub' ? (
-      isChildView ? (
-        <Helmet title={`${title}`} />
-      ) : (
-        <Helmet title={`${getAppName()} - ${title}`} />
-      )
-    ) : null
-
   return (
     <RouteStyle platform={platform}>
-      {helmet}
       <PlatformRoute>
-        {subheader}
         {React.cloneElement(children as React.ReactElement, {
           header: Header ? <Header {...window} /> : null,
           footer: Footer ? <Footer /> : null,

--- a/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/launcherUtils.ts
@@ -1,10 +1,6 @@
-export async function isParentAppOpenfinLauncher() {
-  if (fin?.Window) {
-    const app = await fin.Window.getCurrent()
-    const {
-      identity: { uuid },
-    } = await app.getParentApplication()
-
+export function isParentAppOpenfinLauncher() {
+  if (window?.fin?.me) {
+    const uuid = window.fin.me.uuid
     return uuid.split('-').includes('launcher')
   }
   return false

--- a/src/client/src/rt-platforms/openfin-platform/components/OpenFinSubWindowFrame.tsx
+++ b/src/client/src/rt-platforms/openfin-platform/components/OpenFinSubWindowFrame.tsx
@@ -56,23 +56,14 @@ const LayoutRoot = styled.div`
 
 export const OpenFinSubWindowFrame: React.FC = () => {
   const win = fin.Window.getCurrentSync()
-  const [, setFromLauncher] = useState<boolean>(false)
+  const [fromLauncher] = useState<boolean>(isParentAppOpenfinLauncher())
   const [windowName, setWindowName] = useState('')
 
   const headerControlHandlers = {
     minimize: () => win.minimize(),
-    popIn: () => win.close(),
+    popIn: !fromLauncher ? () => win.close() : undefined,
+    close: fromLauncher ? () => win.close() : undefined,
   }
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
 
   useEffect(() => {
     window.document.dispatchEvent(

--- a/src/client/src/rt-platforms/openfin-platform/components/OpenFinWindowFrame.tsx
+++ b/src/client/src/rt-platforms/openfin-platform/components/OpenFinWindowFrame.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
-import { isParentAppOpenfinLauncher } from 'rt-platforms'
 import styled from 'styled-components/macro'
 import { OpenFinChrome, OpenFinHeader, OpenFinFooter } from './OpenFinChrome'
 import { getAppName } from 'rt-util'
@@ -63,8 +62,6 @@ const LayoutRoot = styled.div`
 `
 
 export const OpenFinWindowFrame: React.FC = () => {
-  const [, setFromLauncher] = useState<boolean>(false)
-
   const win = fin.Window.getCurrentSync()
   const headerControlHandlers = {
     close: () => win.close(),
@@ -72,16 +69,6 @@ export const OpenFinWindowFrame: React.FC = () => {
     maximize: () =>
       win.getState().then(state => (state === 'maximized' ? win.restore() : win.maximize())),
   }
-
-  useEffect(() => {
-    isParentAppOpenfinLauncher()
-      .then(isLauncher => {
-        setFromLauncher(isLauncher)
-      })
-      .catch(() => {
-        console.error('Cannot find parent window')
-      })
-  }, [])
 
   useEffect(() => {
     window.document.dispatchEvent(


### PR DESCRIPTION
I made the version number on the connections dialog visible and clickable to redirect to the github page. I was not exactly sure how the REACT_APP_VERSION .env variable works so I just left it as is in this commit but on my local machine I tested I changed the value of REACT_APP_VERSION (the variable that is being displayed as the version number on the connections dialog) to "v1.5.2" and clicked it and it redirected me properly to the github page. I included screenshots of this as well as the tests passing below. If you want the REACT_APP_VERSION variable modified to something else please let me know and I will change it and send out another commit. I created a few redundant commits in the process of rebasing the code so my apologies for that. 

![image](https://user-images.githubusercontent.com/66634974/97742938-54de6680-1abb-11eb-9297-6325491a2b66.png)
![image](https://user-images.githubusercontent.com/66634974/97742949-5871ed80-1abb-11eb-8027-4fe07b83eaec.png)
![image](https://user-images.githubusercontent.com/66634974/97742959-5c057480-1abb-11eb-91fc-10975d7f6a6c.png)
![image](https://user-images.githubusercontent.com/66634974/97742971-5f006500-1abb-11eb-85e3-b66d29e99e14.png)
