### PR TITLE
fix: launcher autoShow = false, explicitly show on render

### DIFF
--- a/src/client/public/openfin/launcher.json
+++ b/src/client/public/openfin/launcher.json
@@ -2,7 +2,7 @@
   "snapshot": {
     "windows": [
       {
-        "autoShow": true,
+        "autoShow": false,
         "frame": false,
         "_comment": "Openfin Excel API preloaded below + added in appAssets (not included in standard OpenFin package)",
         "preload": [

--- a/src/client/src/apps/SimpleLauncher/SimpleLauncher.tsx
+++ b/src/client/src/apps/SimpleLauncher/SimpleLauncher.tsx
@@ -41,6 +41,8 @@ export const SimpleLauncher: React.FC = () => {
       const serviceClient = createServiceStub(broker)
       const platformResult = await getPlatformAsync()
 
+      platformResult.window.show()
+
       // blotter service
       const blotterService = new BlotterService(serviceClient)
       const blotterUpdates$ = blotterService.getTradesStream()

--- a/src/client/src/rt-platforms/browser/browser.ts
+++ b/src/client/src/rt-platforms/browser/browser.ts
@@ -35,6 +35,7 @@ export default class Browser implements Platform {
       })
       return openBrowserWindow(config, onClose)
     },
+    show: () => {},
   }
 
   notification = {

--- a/src/client/src/rt-platforms/finsemble/finsemble.ts
+++ b/src/client/src/rt-platforms/finsemble/finsemble.ts
@@ -32,6 +32,7 @@ export class Finsemble implements Platform {
       const createdWindow = window.open()
       return Promise.resolve(createdWindow ? createDefaultPlatformWindow(createdWindow) : undefined)
     },
+    show: () => {},
   }
 
   app = {

--- a/src/client/src/rt-platforms/glue/glue.ts
+++ b/src/client/src/rt-platforms/glue/glue.ts
@@ -65,6 +65,7 @@ export class Glue42 implements Platform {
         console.warn(err.message)
       }
     },
+    show: () => {},
   }
 
   notification = {

--- a/src/client/src/rt-platforms/glue/glueCore.ts
+++ b/src/client/src/rt-platforms/glue/glueCore.ts
@@ -56,6 +56,7 @@ export class Glue42Core implements Platform {
         .open(config.name, url, config)
         .then((createdWindow: any) => createdWindow)
     },
+    show: () => {},
   }
 
   notification = {

--- a/src/client/src/rt-platforms/noopAdapter.ts
+++ b/src/client/src/rt-platforms/noopAdapter.ts
@@ -25,6 +25,7 @@ export default class NoopPlatformAdapter implements Platform {
     open: (config: WindowConfig, onClose?: () => void) => {
       throw new Error('NOT IMPLEMENTED')
     },
+    show: () => {},
   }
 
   notification = {

--- a/src/client/src/rt-platforms/openFin/adapter/openFin.ts
+++ b/src/client/src/rt-platforms/openFin/adapter/openFin.ts
@@ -36,6 +36,7 @@ export default class OpenFin implements Platform {
   window = {
     ...createPlatformWindow(() => Promise.resolve(fin.desktop.Window.getCurrent())),
     open: openDesktopWindow,
+    show: () => {},
   }
 
   app = {

--- a/src/client/src/rt-platforms/openfin-platform/adapter/openFinPlatform.ts
+++ b/src/client/src/rt-platforms/openfin-platform/adapter/openFinPlatform.ts
@@ -3,7 +3,7 @@
 
 import { Platform } from '../../platform'
 import { AppConfig, InteropTopics } from '../../types'
-import { createPlatformWindow, openDesktopWindow } from './window'
+import { createPlatformWindow, openDesktopWindow, showWindow } from './window'
 import { fromEventPattern } from 'rxjs'
 import {
   Notification,
@@ -34,6 +34,7 @@ export default class OpenFinPlatform implements Platform {
   window = {
     ...createPlatformWindow(() => Promise.resolve(fin.Window.getCurrent())),
     open: openDesktopWindow,
+    show: showWindow,
   }
 
   app = {

--- a/src/client/src/rt-platforms/openfin-platform/adapter/window.ts
+++ b/src/client/src/rt-platforms/openfin-platform/adapter/window.ts
@@ -185,3 +185,8 @@ export const openDesktopWindow = async (
 
   return createPlatformWindow(() => Promise.resolve(win))
 }
+
+export const showWindow = async () => {
+  const window = await fin.Window.getCurrent()
+  window.show();
+}

--- a/src/client/src/rt-platforms/platformWindow.ts
+++ b/src/client/src/rt-platforms/platformWindow.ts
@@ -6,6 +6,7 @@ export type PlatformWindowApi = {
     onClose?: () => void,
     onUpdatePosition?: (event: any) => void
   ) => Promise<PlatformWindow | undefined>
+  show: () => void
 }
 
 export type PlatformWindow = {

--- a/src/client/src/rt-platforms/pwa/pwa.ts
+++ b/src/client/src/rt-platforms/pwa/pwa.ts
@@ -40,6 +40,7 @@ export default class PWA implements Platform {
       })
       return openBrowserWindow(config, onClose)
     },
+    show: () => {},
   }
 
   notification = {

--- a/src/client/src/rt-platforms/symphony/adapter/index.ts
+++ b/src/client/src/rt-platforms/symphony/adapter/index.ts
@@ -50,6 +50,7 @@ export default class Symphony implements Platform {
       })
       return Promise.resolve(undefined)
     },
+    show: () => {},
   }
 
   notification = {


### PR DESCRIPTION
Added show to PlatformWindowApi implemented in openfin platform only

Dont auto show the launcher, call show on render