### PR TITLE
fix(Tile): fix issue with flaky snapshop-tests with dates

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
+++ b/src/client/src/apps/MainRoute/widgets/spotTile/components/Tile/Tile.test.tsx
@@ -30,7 +30,7 @@ const defaultParams: Parameters<typeof getDerivedStateFromUserInput>[0] = {
       mid: 1.48357,
       priceMovementType: 'Down' as PriceMovementTypes,
       symbol: 'EURCAD',
-      valueDate: '2019-04-07T00:00:00Z',
+      valueDate: new Date(2019, 3, 7).toISOString(),
     },
     rfqPrice: null,
     rfqState: 'none',


### PR DESCRIPTION
We keep seeing this issue where someone in north-america updates the snapshots of the Tile and then the tests fail on the CI because the dates don't match.

This was happening because the date that was being set on `Tile.test.tsx` had a UTC offset of zero (`2019-04-07T00:00:00Z`). However, when the date is being formatted, it's being formatted using the local time-zone of the client. What that means is that the further you are from UTC-0, the higher the likelihood that when the test runs it will produce a different date of the one that's in the snapshot.

The "fix" (for now) is to use the timezone of the user also when setting up the date of the test.