### PR TITLE
ARTP-1288-Make-version-URL-clickable-v2

### DIFF
--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import styled from 'styled-components/macro'
 
 export const Wrapper = styled.div`
@@ -6,7 +6,41 @@ export const Wrapper = styled.div`
   opacity: 0.59;
   font-size: 0.75rem;
 `
+export const Link = styled.a`
+  color: inherit;
+  text-decoration: inherit;
+`
 
-const FooterVersion: FC = () => <Wrapper>{process.env.REACT_APP_BUILD_VERSION}</Wrapper>
+const gitTagExists = async (gitTag: string | undefined) => {
+  const response = await fetch(
+    'https://api.github.com/repos/AdaptiveConsulting/ReactiveTraderCloud/releases'
+  )
+  const data = await response.json()
+  const exists = data.find((element: any) => element.tag_name === gitTag)
+  return exists
+}
 
+const FooterVersion: FC = () => {
+  const [versionExists, setVersionExists] = useState<boolean | void>(false)
+  const currentVersion: string | undefined = process.env.REACT_APP_VERSION
+  const URL =
+    'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
+    process.env.REACT_APP_VERSION
+
+  useEffect(() => {
+    gitTagExists(currentVersion).then(resolution => setVersionExists(resolution))
+  }, [])
+
+  return (
+    <Wrapper>
+      {versionExists ? (
+        <Link target="_blank" href={URL}>
+          {currentVersion}
+        </Link>
+      ) : (
+        <p>{currentVersion}</p>
+      )}
+    </Wrapper>
+  )
+}
 export default FooterVersion

--- a/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
+++ b/src/client/src/apps/MainRoute/widgets/footer-version/FooterVersion.tsx
@@ -22,23 +22,23 @@ const gitTagExists = async (gitTag: string | undefined) => {
 
 const FooterVersion: FC = () => {
   const [versionExists, setVersionExists] = useState<boolean | void>(false)
-  const currentVersion: string | undefined = process.env.REACT_APP_VERSION
+
   const URL =
     'https://github.com/AdaptiveConsulting/ReactiveTraderCloud/releases/tag/' +
     process.env.REACT_APP_VERSION
 
   useEffect(() => {
-    gitTagExists(currentVersion).then(resolution => setVersionExists(resolution))
+    gitTagExists(process.env.REACT_APP_VERSION).then(resolution => setVersionExists(resolution))
   }, [])
 
   return (
     <Wrapper>
       {versionExists ? (
         <Link target="_blank" href={URL}>
-          {currentVersion}
+          {process.env.REACT_APP_VERSION}
         </Link>
       ) : (
-        <p>{currentVersion}</p>
+        <p>{process.env.REACT_APP_VERSION}</p>
       )}
     </Wrapper>
   )


### PR DESCRIPTION
Updated version of the clickable URL PR. 
Clickable when version number exists:
![image](https://user-images.githubusercontent.com/66634974/98404059-eb6cd380-2037-11eb-8dee-5501d0207572.png)
Not clickable when version number does not exist in responses: 
![image](https://user-images.githubusercontent.com/66634974/98404068-ef005a80-2037-11eb-95f8-624f02627d01.png)
Tests passing locally: 
![image](https://user-images.githubusercontent.com/66634974/98404283-4999b680-2038-11eb-96d9-2e7868a46f19.png)

