### PR TITLE
chore(client): use latest OF notification service UI

### DIFF
--- a/src/client/public/openfin/app.json
+++ b/src/client/public/openfin/app.json
@@ -18,7 +18,7 @@
   "services": [
     {
       "name": "notifications",
-      "manifestUrl": "https://cdn.openfin.co/services/openfin/notifications/0.11.1/app.json"
+      "manifestUrl": "https://cdn.openfin.co/services/openfin/notifications/0.12.8/app.json"
     }
   ],
   "devtools_port": 9090,


### PR DESCRIPTION
The npm package is pinned to `0.11.1`. We will want to upgrade that as soon as it is made available. This PR updates the service declaration in the manifest. This gives us access to the latest UI while maintaining all functionality.

# Before

![old-notifications-ui](https://user-images.githubusercontent.com/73487693/100265937-fcb24d00-2f1e-11eb-8fb3-80eb76432b78.png)

# After

![new-notifications-ui](https://user-images.githubusercontent.com/73487693/100265953-02a82e00-2f1f-11eb-8de3-d102fbcf753b.png)
