### PR TITLE
fix(launcher): set permissions to launch Limit Checker (ARTP-1363)

### DIFF
--- a/src/client/public/openfin/launcher.json
+++ b/src/client/public/openfin/launcher.json
@@ -23,11 +23,6 @@
           "width": 4,
           "height": 4
         },
-        "permissions": {
-          "System": {
-            "launchExternalProcess": true
-          }
-        },
         "saveWindowState": false,
         "resizable": false,
         "shadow": true,
@@ -49,9 +44,19 @@
     "defaultWindowOptions": {
       "contextMenu": true,
       "frame": false,
-      "url": "{*host_url*}/openfin-sub-window-frame"
+      "url": "{*host_url*}/openfin-sub-window-frame",
+      "permissions": {
+        "System": {
+          "launchExternalProcess": true
+        }
+      }
     },
-    "fdc3Api": true
+    "fdc3Api": true,
+    "permissions": {
+      "System": {
+        "launchExternalProcess": true
+      }
+    }
   },
   "runtime": {
     "version": "17.85.53.10"


### PR DESCRIPTION
For reasons I don't yet understand, we need to set the permissions on both the parent and child windows (perhaps the IPC call is delegated via the platform window - I will clarify this with OpenFin). By setting the permission on both windows, the Limit Checker can now be opened.