### PR TITLE
Fix launcher icon hover (ARTP-1362)

### DIFF
--- a/src/client/src/apps/SimpleLauncher/LaunchButton.tsx
+++ b/src/client/src/apps/SimpleLauncher/LaunchButton.tsx
@@ -36,6 +36,9 @@ const StyledButton = styled.button<{
     svg {
       fill: ${({ iconHoverFill }) => iconHoverFill};
     }
+    span {
+      color: ${({ theme }) => theme.core.textColor};
+    }
   }
 `
 

--- a/src/client/src/apps/SimpleLauncher/styles.ts
+++ b/src/client/src/apps/SimpleLauncher/styles.ts
@@ -45,12 +45,6 @@ export const IconContainer = styled.div`
   align-items: center;
   justify-content: center;
   flex-direction: column;
-
-  &:hover {
-    span {
-      color: ${({ theme }) => theme.core.textColor};
-    }
-  }
 `
 
 export const LogoLauncherContainer = styled(IconContainer)`


### PR DESCRIPTION
-launcher icons will be highlighted as soon as the icon text comes up, no overlap. 