### PR TITLE
chore(build): update gcloud action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $DOCKER_USER/client:$BUILD_VERSION > /dev/null
 
       - name: Set up Google Cloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '285.0.0'
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}


### PR DESCRIPTION
No data still on `dev` after second deploy. I saw no build errors, just this deprecation warning.

![deprecation-warning](https://user-images.githubusercontent.com/73487693/100696701-2970c500-3362-11eb-82a1-8e35f3d8a356.png)
