### PR TITLE
fix(client): popouts lost after child window close

### DIFF
--- a/src/client/public/openfin/app.json
+++ b/src/client/public/openfin/app.json
@@ -68,6 +68,7 @@
           "zoom": true
         },
         "url": "{*host_url*}/openfin-window-frame",
+        "name": "Reactive-Trader-MAIN",
         "layout": {
           "settings": {
             "blockedPopoutsThrowError": false,

--- a/src/client/src/rt-platforms/openfin/components/OpenFinContactButton.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinContactButton.tsx
@@ -14,8 +14,8 @@ export const OpenFinContactDisplay = () => (
 const OpenFinContactButton: React.FC = () => {
   const [showing, setShowing] = React.useState(false)
 
-  const baseWin = useMemo(() => ({ name: 'openfin-contact-popup', height: 445, width: 245 }), [])
-  const URL = '/contact'
+  const baseWin = useMemo(() => ({ name: 'contact', height: 445, width: 245 }), [])
+  const pathname = '/contact'
 
   const showPopup = useCallback(() => {
     if (!showing) {
@@ -25,7 +25,7 @@ const OpenFinContactButton: React.FC = () => {
   }, [baseWin, showing])
 
   React.useEffect(() => {
-    createOpenFinPopup(baseWin, URL, () => setShowing(false))
+    createOpenFinPopup(baseWin, pathname, () => setShowing(false))
   }, [baseWin])
 
   return (

--- a/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/OpenFinSnapshotButton.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/OpenFinSnapshotButton.tsx
@@ -6,12 +6,12 @@ const OpenFinSnapshotButton: React.FC = () => {
   const [showing, setShowing] = useState(false)
 
   const baseWin = useMemo(() => {
-    return { name: 'openfin-snapshot-popup', height: 249, width: 245 }
+    return { name: 'snapshots', height: 249, width: 245 }
   }, [])
 
   const offset: Offset = useMemo(() => [119, 40], [])
 
-  const URL = '/snapshots'
+  const pathname = '/snapshots'
 
   const showPopup = useCallback(() => {
     if (!showing) {
@@ -21,7 +21,7 @@ const OpenFinSnapshotButton: React.FC = () => {
   }, [baseWin, offset, showing])
 
   useEffect(() => {
-    createOpenFinPopup(baseWin, URL, () => setShowing(false))
+    createOpenFinPopup(baseWin, pathname, () => setShowing(false))
   }, [baseWin])
 
   return (

--- a/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/ToggleOpenFinLayoutLock.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/ToggleOpenFinLayoutLock.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import styled from 'styled-components/macro'
-import { toggleLockedLayout } from './utils'
+import { toggleLayoutLock } from './utils'
 
 const Container = styled('div')`
   padding: 0.75rem 0.75rem 0 0.75rem;
@@ -17,7 +17,7 @@ const ToggleOpenFinLayoutLock = () => {
 
   const toggle = () => {
     setLocked(!locked)
-    toggleLockedLayout()
+    toggleLayoutLock()
   }
 
   return (

--- a/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/utils.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinSnapshot/utils.tsx
@@ -4,6 +4,7 @@ import {
   OPENFIN_SNAPSHOT_NAMES,
   OPENFIN_SNAPSHOTS,
 } from 'rt-platforms/openfin/StorageItems'
+import { mainOpenFinWindowName } from '../utils'
 
 export const resetCurrentSnapshotName = () => {
   setCurrentSnapshotName(OPENFIN_SNAPSHOT_DEFAULT_NAME)
@@ -42,9 +43,7 @@ export const applySnapshotFromStorage = async (snapshotName: string) => {
 
   if (snapshotNames.includes(snapshotName)) {
     setCurrentSnapshotName(snapshotName)
-    await platform.applySnapshot(snapshots.snapshots[snapshotName], {
-      closeExistingWindows: true,
-    })
+    await platform.applySnapshot(snapshots.snapshots[snapshotName])
     return true
   }
   return false
@@ -63,29 +62,11 @@ export const saveSnapshotToStorage = async (newSnapshotName: string) => {
   setSnapshots(snapshots)
 }
 
-/**
- * Toggles the Platform controls
- *
- * Manually created windows are not part of the layout. Layout windows all start
- * with 'internal-generated', so we find one of those windows to retrieve the
- * layout.
- *
- * https://developers.openfin.co/docs/recipes-platform
- *
- */
-export const toggleLockedLayout = async () => {
-  const thisApp = fin.Application.getCurrentSync()
-  const childWindows = await thisApp.getChildWindows()
-  const internallyGeneratedWindows = childWindows.filter(
-    w => w.identity.name && w.identity.name.startsWith('internal-generated')
-  )
-
-  if (internallyGeneratedWindows.length < 1) {
-    console.error('Attempting to toggle layout, but no layout windows found')
-    return
-  }
-
-  const layout = fin.Platform.Layout.wrapSync(internallyGeneratedWindows[0].identity)
+export const toggleLayoutLock = async () => {
+  const layout = fin.Platform.Layout.wrapSync({
+    name: mainOpenFinWindowName,
+    uuid: fin.me.uuid,
+  })
 
   const oldLayout = await layout.getConfig()
   const { settings, dimensions } = oldLayout

--- a/src/client/src/rt-platforms/openfin/components/OpenFinStatusConnection/OpenFinStatusButton.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinStatusConnection/OpenFinStatusButton.tsx
@@ -10,12 +10,12 @@ interface Props {
   services: ServiceStatus[]
 }
 
-export const StatusButton: React.FC<Props> = ({ services }) => {
+const OpenFinStatusButton: React.FC<Props> = ({ services }) => {
   const [appStatus, setAppStatus] = useState<ServiceConnectionStatus>()
   const [showing, setShowing] = React.useState(false)
 
-  const baseWin = useMemo(() => ({ name: 'openfin-status-popup', height: 350, width: 260 }), [])
-  const URL = '/status'
+  const baseWin = useMemo(() => ({ name: 'status', height: 350, width: 260 }), [])
+  const pathname = '/status'
 
   const showPopup = useCallback(() => {
     if (!showing) {
@@ -25,7 +25,7 @@ export const StatusButton: React.FC<Props> = ({ services }) => {
   }, [baseWin, showing])
 
   React.useEffect(() => {
-    createOpenFinPopup(baseWin, URL, () => setShowing(false))
+    createOpenFinPopup(baseWin, pathname, () => setShowing(false))
   }, [baseWin])
 
   useEffect(() => {
@@ -47,3 +47,5 @@ export const StatusButton: React.FC<Props> = ({ services }) => {
     </Root>
   )
 }
+
+export default OpenFinStatusButton

--- a/src/client/src/rt-platforms/openfin/components/OpenFinStatusConnection/StatusContainers.tsx
+++ b/src/client/src/rt-platforms/openfin/components/OpenFinStatusConnection/StatusContainers.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { selectServices } from './selectors'
-import { StatusButton } from './StatusButton'
+import OpenFinStatusButton from './OpenFinStatusButton'
 import StatusDisplay from './StatusDisplay'
 import { GlobalState } from 'StoreTypes'
 
@@ -11,7 +11,7 @@ export const mapStateToProps = (state: GlobalState) => {
   }
 }
 
-const StatusButtonContainer = connect(mapStateToProps)(StatusButton)
+const StatusButtonContainer = connect(mapStateToProps)(OpenFinStatusButton)
 const StatusDisplayContainer = connect(mapStateToProps)(StatusDisplay)
 
 export { StatusButtonContainer, StatusDisplayContainer }


### PR DESCRIPTION
* Assigning a name to the main windows allows us to restore a snapshot without closing and reopening all windows (implemented)
* Closing the main app window now closes the application
* Fixes a bug where closing a popped out view (blotter, tiles, analytics) caused the contact/status/snapshot popup to be lost