### PR TITLE
fix: rework notifications within Finsemble platform (ARTP-1212)

### DIFF
--- a/src/client/src/rt-platforms/browser/utils/sendNotification.ts
+++ b/src/client/src/rt-platforms/browser/utils/sendNotification.ts
@@ -14,10 +14,18 @@ navigator.serviceWorker &&
     registration = reg
   })
 
-export const sendNotification = ({ tradeNotification }: NotificationMessage) => {
+export const getTradeNotificationContents = (tradeNotification : Trade): { title: string, body: string } => {
   const status = tradeNotification.status === 'done' ? 'Accepted' : 'Rejected'
   const title = `Trade ${status}: ID ${tradeNotification.tradeId}`
   const body = `${tradeNotification.direction} ${tradeNotification.dealtCurrency} ${tradeNotification.notional} vs ${tradeNotification.termsCurrency} @ ${tradeNotification.spotRate}`
+  return {
+    title,
+    body
+  }
+}
+
+export const sendNotification = ({ tradeNotification }: NotificationMessage) => {
+  const { title, body } = getTradeNotificationContents(tradeNotification);
   const icon =
     navigator.userAgent.indexOf('Chrome') !== -1 && navigator.userAgent.indexOf('Win') !== -1
       ? './static/media/reactive-trader-icon-no-bkgd-256x256.png'

--- a/src/client/src/rt-platforms/finsemble/finsemble.ts
+++ b/src/client/src/rt-platforms/finsemble/finsemble.ts
@@ -88,9 +88,6 @@ export class Finsemble implements Platform {
 
   notification = {
     notify: (message: object) =>
-      finsembleClient.alert('trade', 'ALWAYS', 'trade-executed', message, {
-        url: '/notification',
-        duration: 1000 * 50,
-      }),
+      finsembleClient.alert(message),
   }
 }

--- a/src/client/src/rt-platforms/finsemble/finsembleClient.js
+++ b/src/client/src/rt-platforms/finsemble/finsembleClient.js
@@ -1,9 +1,8 @@
+import { getTradeNotificationContents } from "rt-platforms/browser/utils/sendNotification"
+
 const LOG_NAME = 'FSBL:'
 
-let FSBL = null
-if (process.env.REACT_APP_FINSEMBLE === 'true') {
-  FSBL = require('@chartiq/finsemble')
-}
+let FSBL = window.FSBL
 
 export function addListener(channel, callback) {
   if (FSBL) {
@@ -40,9 +39,19 @@ export function spawn(command, args, callback) {
   }
 }
 
-export function alert(topic, frequency, identifier, message, params) {
+export function alert(message) {
+  const tradeNotification = message.tradeNotification;
+  const { title, body } = getTradeNotificationContents(tradeNotification);
+
   if (FSBL) {
-    console.log(`${LOG_NAME} alert on ${topic} message ${message}`)
-    FSBL.UserNotification.alert(topic, frequency, identifier, message, params)
+    console.log(`${LOG_NAME} alert with message ${message}`)
+
+    const notification = new FSBL.Clients.NotificationClient.Notification();
+    notification.title = title;
+    notification.details = body;
+    notification.type = 'trade';
+    notification.headerLogo = null;
+
+    FSBL.Clients.NotificationClient.notify([notification]);
   }
 }

--- a/src/client/src/rt-platforms/finsemble/finsembleClient.js
+++ b/src/client/src/rt-platforms/finsemble/finsembleClient.js
@@ -50,7 +50,6 @@ export function alert(message) {
     notification.title = title;
     notification.details = body;
     notification.type = 'trade';
-    notification.headerLogo = null;
 
     FSBL.Clients.NotificationClient.notify([notification]);
   }


### PR DESCRIPTION
We currently aren't getting notifications when the blotter, which controls notifications, is used within the Finsemble demo. Since the current logic was implemented, Finsemble has released a new notification client that gives much more control over notifications than the previous service. This is the RT part of the implementation to get notifications working in this new service.

The notifications are based on those in the web app. I used the same icon, and reused the same logic for generating the title and message.