### PR TITLE
fix: use k8s job to populate the event store (ARTP-1183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: docker-compose -f ./src/docker-compose.yml build --parallel
 
-      - name: Initialise currency data
-        run: |
-          # The eventstore should be initialised with a clean set of data
-          docker-compose -f src/docker-compose.yml run initialise
-          docker commit eventstore_base ${DOCKER_USER}/eventstore:${BUILD_VERSION}
-
       - name: Run integration tests
         run: docker-compose -f ./src/docker-compose.e2e.yml -f ./src/docker-compose.yml run integration
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           # TODO: create new environment automatically
           # Update/create each deployment file in src/services/kubernetes
-          for f in ./src/services/kubernetes/*.yaml; do
+          for f in $(find ./src/services/kubernetes -type f -name "*.yaml"); do
               cat $f | /usr/bin/envsubst | kubectl --namespace=$DEPLOY_ENV apply -f -
           done
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 services:
   # infrastructure
   eventstore:
-    container_name: eventstore_base
     image: ${DOCKER_USER}/eventstore:${BUILD_VERSION}
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
This removes the eventstore initialisation from the CI build and instead uses the existing (but currently unused) Kubernetes job. This change will mean that the eventstore is seeded at deploy time, against the running instance in k8s, instead of committing a modified image to docker.