### PR TITLE
fix: clean up existing jobs during deployment (ARTP-1371)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,11 @@ jobs:
           DEPLOY_ENV: ${{ github.event.deployment.environment }}
         run: kubectl scale deploy --replicas=0 --all --namespace $DEPLOY_ENV
 
+      - name: Delete GKE jobs
+        env:
+          DEPLOY_ENV: ${{ github.event.deployment.environment }}
+        run: kubectl delete jobs --all --namespace $DEPLOY_ENV
+
       - name: Update GKE deployment definitions
         env:
           DEPLOY_ENV: ${{ github.event.deployment.environment }}


### PR DESCRIPTION
This cleans up any existing (completed/failed/running) jobs in the deployment namespace. Currently, deployments fail if there is already a job deployed to initialise data.