### PR TITLE
Use correct platform name for OpenFin adapter

### DIFF
--- a/src/client/src/rt-platforms/openfin/adapter/openfin.ts
+++ b/src/client/src/rt-platforms/openfin/adapter/openfin.ts
@@ -17,7 +17,7 @@ import OpenFinRoute from './OpenFinRoute'
 import { OpenFinControls, OpenFinHeader, OpenFinFooter, OpenFinLogo } from '../components'
 
 export default class OpenFin implements Platform {
-  readonly name = 'openfin-platform'
+  readonly name = 'openfin'
   readonly type = 'desktop'
   readonly allowTearOff = true
 


### PR DESCRIPTION
This was left over from the removal of the legacy OpenFin adapter. A side effect of this is that the Limit Checker subscription is never established, as this expects the platform name to be "openfin".