### PR TITLE
Fix/stomp client

### DIFF
--- a/src/new-client/src/services/client/client.ts
+++ b/src/new-client/src/services/client/client.ts
@@ -1,5 +1,5 @@
 import { combineLatest, Observable } from "rxjs"
-import { map, switchMap } from "rxjs/operators"
+import { map, switchMap, take } from "rxjs/operators"
 import { currentUser$ } from "../currentUser"
 import { endpoints$ } from "./endpoints"
 
@@ -24,6 +24,7 @@ export const getRemoteProcedureCall$ = <TResponse, TPayload>(
       }),
     ),
     map((message) => JSON.parse(message.body)),
+    take(1),
   )
 
 export const getStream$ = <TResponse, TPayload = {}>(

--- a/src/new-client/src/services/client/endpoints.ts
+++ b/src/new-client/src/services/client/endpoints.ts
@@ -15,11 +15,13 @@ export const endpoints$ = new Observable<{
     ? `wss://${url}:${securePort}/ws`
     : `ws://${url}:${defaultPort}/ws`
   const reconnectDelay = 500
+  const connectionTimeout = 0
 
   const streamEndpoint = new RxStomp()
   streamEndpoint.configure({
     brokerURL,
     reconnectDelay,
+    connectionTimeout,
   })
   const rpcEndpoint = new RxStompRPC(streamEndpoint)
   streamEndpoint.activate()

--- a/src/new-client/src/services/prices.ts
+++ b/src/new-client/src/services/prices.ts
@@ -1,6 +1,6 @@
 import { bind } from "@react-rxjs/core"
 import { concat } from "rxjs"
-import { scan, take, mergeAll, debounceTime } from "rxjs/operators"
+import { scan, mergeAll, debounceTime } from "rxjs/operators"
 import { getRemoteProcedureCall$, getStream$ } from "./client"
 import { CamelCase } from "./utils"
 
@@ -62,7 +62,7 @@ export const [useHistoricalPrices, getHistoricalPrices$] = bind<
       "priceHistory",
       "getPriceHistory",
       symbol,
-    ).pipe(take(1), mergeAll()),
+    ).pipe(mergeAll()),
     getPrice$(symbol),
   ).pipe(
     scan((acc, price) => {


### PR DESCRIPTION
Two changes to our stomp client: 

1.  Rolled back rx-stomp so that the automatic reconnects succeed.  Issue opened on the library here: https://github.com/stomp-js/rx-stomp/issues/277
2. Move `take(1)` inside our `getRemoteProcedureCall$` so that it always completes (the underlying rpc stream does complete, but we because we wrap in a `combineLatest` with two source streams that don't, our stream needs to be manually completed).