### PR TITLE
chore(server): add connection timeout to node bot

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -103,6 +103,8 @@ services:
     image: ${DOCKER_USER}/bot:${BUILD_VERSION}
     build:
       context: ./server/node/bot
+    depends_on:
+      - broker
   # web client
   nginx:
     image: ${DOCKER_USER}/nginx:${BUILD_VERSION}

--- a/src/server/node/bot/src/connection/StompConfig.ts
+++ b/src/server/node/bot/src/connection/StompConfig.ts
@@ -3,6 +3,7 @@
  */
 export default class StompConfig {
   public brokerURL: string
+  public connectionTimeout = 500
   public reconnectDelay = 500
 
   constructor(url: string, port?: number) {

--- a/src/server/node/bot/src/connection/WsConnection.ts
+++ b/src/server/node/bot/src/connection/WsConnection.ts
@@ -24,10 +24,7 @@ export class WsConnection {
   private createStreamEndpoint = () => {
     const stompInstance = new RxStomp()
 
-    stompInstance.configure({
-      brokerURL: this.config.brokerURL,
-      reconnectDelay: this.config.reconnectDelay
-    })
+    stompInstance.configure({ ...this.config })
 
     stompInstance.webSocketErrors$.subscribe(e => logger.error('WebSocket Error ', e))
     stompInstance.stompErrors$.subscribe(e => logger.error('Stomp Error ', e))


### PR DESCRIPTION
Adds `connectionTimeout` to the existing bot config

Also adds `depends_on` to bot (depending on the broker)