### PR TITLE
feat(new-client)/connection-status-component(705)

### DIFF
--- a/src/new-client/src/App/Footer/Footer.tsx
+++ b/src/new-client/src/App/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import ContactUsButton from "./ContactUsButton"
 import StatusBar from "./StatusBar"
-import { StatusButton } from "./StatusButton/StatusButton"
+import { StatusButton } from "./StatusButton"
 
 export const Footer: React.FC = () => (
   <StatusBar>

--- a/src/new-client/src/App/Footer/StatusButton/Service.tsx
+++ b/src/new-client/src/App/Footer/StatusButton/Service.tsx
@@ -1,23 +1,27 @@
 import React from "react"
 
-import { ServiceConnectionStatus, ServiceStatus } from "services/connection"
+import { ServiceConnectionStatus } from "services/connection"
+import { ServiceInstanceStatus } from "services/status"
 import { StatusCircle, NodeCount, ServiceName, ServiceRoot } from "./styled"
 
-const Service: React.FC<{ service: ServiceStatus }> = ({
-  service: { serviceType, connectionStatus, connectedInstanceCount },
+const Service: React.FC<{ service: ServiceInstanceStatus }> = ({
+  service: { serviceType, serviceLoad },
 }) => (
   <ServiceRoot>
     <div style={{ display: "flex", alignItems: "center" }}>
-      <StatusCircle status={connectionStatus} />
+      <StatusCircle
+        status={
+          serviceLoad > 0
+            ? ServiceConnectionStatus.CONNECTED
+            : ServiceConnectionStatus.DISCONNECTED
+        }
+      />
       <ServiceName>{serviceType}</ServiceName>
     </div>
 
-    {connectionStatus === ServiceConnectionStatus.CONNECTED && (
-      <NodeCount>
-        ({connectedInstanceCount}{" "}
-        {connectedInstanceCount !== 1 ? "Nodes" : "Node"})
-      </NodeCount>
-    )}
+    <NodeCount>
+      ({serviceLoad} {serviceLoad !== 1 ? "Nodes" : "Node"})
+    </NodeCount>
   </ServiceRoot>
 )
 export default Service

--- a/src/new-client/src/App/Footer/StatusButton/index.ts
+++ b/src/new-client/src/App/Footer/StatusButton/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./StatusButton"
+export { StatusButton } from "./StatusButton"

--- a/src/new-client/src/App/Footer/StatusButton/styled.tsx
+++ b/src/new-client/src/App/Footer/StatusButton/styled.tsx
@@ -103,4 +103,13 @@ export const ServiceList = styled.div`
 
 export const AppUrl = styled.input`
   border-style: none;
+  color: ${(props) => props.theme.textColor};
+`
+export const Header = styled.div`
+  font-size: 1rem;
+  line-height: 2rem;
+  box-shadow: 0 1px 0 ${({ theme }) => theme.core.textColor};
+  margin-bottom: 1rem;
+  margin-left: 5px;
+  margin-right: 5px;
 `

--- a/src/new-client/src/services/status.ts
+++ b/src/new-client/src/services/status.ts
@@ -1,0 +1,61 @@
+import { watch$ } from "services/client"
+import { delay, map, mergeAll, scan, switchMap, take } from "rxjs/operators"
+import { split } from "@react-rxjs/utils"
+import { merge, of } from "rxjs"
+import { bind, shareLatest } from "@react-rxjs/core"
+
+export interface RawServiceStatus {
+  Type: string
+  Instance: string
+  TimeStamp: number
+  Load: number
+}
+
+export interface ServiceInstanceStatus {
+  serviceType: string
+  serviceId: string
+  timestamp: number
+  serviceLoad: number
+}
+
+const STATUS_TIMEOUT = 2000
+
+export const [useStatus, status$] = bind(
+  watch$<RawServiceStatus>("status").pipe(
+    split(
+      (raw) => raw.Instance,
+      (instance$) =>
+        merge(
+          instance$.pipe(
+            map((value) => ({ ...value, isAdded: true })),
+            take(1),
+          ),
+          instance$.pipe(
+            switchMap((info) =>
+              of({ ...info, isAdded: false }).pipe(delay(STATUS_TIMEOUT)),
+            ),
+          ),
+        ).pipe(take(2)),
+    ),
+    mergeAll(),
+    scan((acc, item) => {
+      const timestamp = Date.now()
+      const result = { ...acc }
+      if (item.isAdded) {
+        result[item.Type] = {
+          serviceType: item.Type,
+          serviceId: item.Instance,
+          timestamp,
+          serviceLoad: (result[item.Type]?.serviceLoad ?? 0) + 1,
+        }
+      } else {
+        result[item.Type] = {
+          ...result[item.Type],
+          serviceLoad: result[item.Type].serviceLoad - 1,
+        }
+      }
+      return result
+    }, {} as Record<string, ServiceInstanceStatus>),
+    shareLatest(),
+  ),
+)


### PR DESCRIPTION
-connection status components can display multiple services' connection status now
-service health and application connection status are independent: service health only depends on how many nodes are loaded, while application connection depends on the status of socket
-when connection is lost, status bar will show disconnected and when connection is back, app will reconnect and connection bar will show 'connecting --- connected'