### PR TITLE
chore(new-client): remove dependency on external stylesheet for icons

### DIFF
--- a/src/new-client/public/index.html
+++ b/src/new-client/public/index.html
@@ -85,13 +85,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <!-- Used for font-awesome icons rendered outside of React -->
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"
-    />
-
     <title>Reactive Trader®</title>
   </head>
 

--- a/src/new-client/src/App/Footer/StatusBar/Icon.tsx
+++ b/src/new-client/src/App/Footer/StatusBar/Icon.tsx
@@ -2,10 +2,10 @@ import React from "react"
 import styled from "styled-components/macro"
 
 const Icon: React.FC<{
-  name: string
-}> = ({ name, ...props }) => (
+  IconComponent: React.FC<{ expand: boolean }>
+}> = ({ IconComponent, ...props }) => (
   <div {...props}>
-    <i className={`fas fa-${name}`} />
+    <IconComponent expand={false} />
   </div>
 )
 

--- a/src/new-client/src/App/Footer/StatusBar/styled.tsx
+++ b/src/new-client/src/App/Footer/StatusBar/styled.tsx
@@ -29,7 +29,7 @@ export const Root = styled.div`
 export const ChevronIcon: React.FC<{ expand: boolean }> = ({
   expand,
   ...props
-}) => <Icon name="chevron" {...props} />
+}) => <Icon IconComponent={ChevronIcon} {...props} />
 
 export const ExpandToggle = styled(ChevronIcon)`
   transform: rotate(

--- a/src/new-client/src/App/Trades/TradesHeader/QuickFilter.tsx
+++ b/src/new-client/src/App/Trades/TradesHeader/QuickFilter.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react"
+import { FaFilter, FaTimes } from "react-icons/fa"
 import styled from "styled-components/macro"
 
 const QuickFilterStyle = styled("div")`
@@ -61,7 +62,7 @@ export const QuickFilter: React.FC = () => {
         onClick={() => quickFilterInput.current?.focus()}
         data-qa="quick-filter__filter-icon"
       >
-        <i className="fas fa-filter" aria-hidden="true" />
+        <FaFilter aria-hidden="true" />
       </QuickFilterIcon>
       <QuickFilterInput
         ref={quickFilterInput}
@@ -75,7 +76,7 @@ export const QuickFilter: React.FC = () => {
         onClick={() => setQuickFilterText("")}
         data-qa="quick-filter__filter-clear-icon"
       >
-        {quickFilterText.length ? <i className="fas fa-times" /> : null}
+        {quickFilterText.length ? <FaTimes /> : null}
       </QuickFilterClearIcon>
     </QuickFilterStyle>
   )


### PR DESCRIPTION
We were using a stylesheet for Font-Awesome icons (referenced via class names).  I think mainly for ag-grid.  Since we don't have that dependency anymore, we can remove the stylesheet and import FA (or other) icons individually through the react-icons library, so we don't have to ship all the icons to the browser.