### PR TITLE
chore(new-client): deal with execution timeout situation

### DIFF
--- a/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/ExecutionStatusAlertSwitch.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/ExecutionStatusAlertSwitch.tsx
@@ -1,6 +1,6 @@
 import { useExecution, ExecutionStatus } from "services/executions"
 import { SymbolContext } from "../Tile"
-import { Done, Rejected } from "./Response"
+import { Done, Rejected, TakingTooLong, RequestTimeout } from "./Response"
 import Pending from "./Pending"
 import { useContext } from "react"
 
@@ -15,6 +15,10 @@ const ExecutionStatusAlertSwitch = () => {
       return <Pending />
     case ExecutionStatus.Done:
       return <Done />
+    case ExecutionStatus.TakingTooLong:
+      return <TakingTooLong />
+    case ExecutionStatus.RequestTimeout:
+      return <RequestTimeout />
     case ExecutionStatus.Rejected:
       return <Rejected />
   }

--- a/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/Response.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/Response.tsx
@@ -123,4 +123,34 @@ const Rejected = () => (
   </ResponseContainer>
 )
 
-export { Done, Rejected }
+const TakingTooLong = () => {
+  const symbol = useContext(SymbolContext)
+  const baseTerm = useBaseTerm(symbol)
+  return (
+    <ExecutionStatusAlertContainer status={ExecutionStatus.TakingTooLong}>
+      <CurrencyPairDiv>
+        <AlignedTriangle />
+        {baseTerm}
+      </CurrencyPairDiv>
+      <TradeMessageDiv>
+        Trade execution taking longer than expected
+      </TradeMessageDiv>
+    </ExecutionStatusAlertContainer>
+  )
+}
+
+const RequestTimeout = () => {
+  const symbol = useContext(SymbolContext)
+  const baseTerm = useBaseTerm(symbol)
+  return (
+    <ExecutionStatusAlertContainer status={ExecutionStatus.RequestTimeout}>
+      <CurrencyPairDiv>
+        <AlignedTriangle />
+        {baseTerm}
+      </CurrencyPairDiv>
+      <TradeMessageDiv>Trade execution timeout exceeded</TradeMessageDiv>
+    </ExecutionStatusAlertContainer>
+  )
+}
+
+export { Done, Rejected, TakingTooLong, RequestTimeout }

--- a/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/styled.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles/ExecutionStatusAlertSwitch/styled.tsx
@@ -20,6 +20,10 @@ export const ExecutionStatusAlertContainer = styled(OverlayDiv)<{
         return `${theme.colors.accents.positive.darker} `
       case "Rejected":
         return `${theme.colors.accents.negative.darker} `
+      case "TakingTooLong":
+        return `${theme.colors.accents.aware.darker} `
+      case "RequestTimeout":
+        return `${theme.colors.accents.negative.darker} `
       default:
         return ""
     }


### PR DESCRIPTION
EUR/JPY request is intentionally set a 5 seconds delay in backend, in order to demo timeout situation. Now new client can deal with execution time out situations as the previous client. 