### PR TITLE
feat(new-client): implement column filter for trades grid (719)

### DIFF
--- a/src/new-client/.env.development
+++ b/src/new-client/.env.development
@@ -1,4 +1,4 @@
-REACT_APP_BROKER_HOST=web-dev.adaptivecluster.com
+REACT_APP_BROKER_HOST=web-demo.adaptivecluster.com
 REACT_APP_BROKER_PORT=80
 REACT_APP_SYMPHONY_APP_ID=reactiveTrader-dev
 ENVIRONMENT_NAME=local

--- a/src/new-client/src/App/Trades/Trades.tsx
+++ b/src/new-client/src/App/Trades/Trades.tsx
@@ -4,7 +4,12 @@ import { Loader } from "components/Loader"
 import { TradesGrid } from "./TradesGrid"
 import { TradesFooter } from "./TradesFooter"
 import { TradesHeader } from "./TradesHeader"
-import { tableTrades$ } from "./services"
+import {
+  appliedFilters$,
+  distinctFieldValues$,
+  tableTrades$,
+} from "./TradesState"
+import { merge } from "rxjs"
 
 const TradesWrapper = styled.article`
   height: 100%;
@@ -17,9 +22,16 @@ const TradesStyle = styled.div`
   color: ${({ theme }) => theme.core.textColor};
   font-size: 0.8125rem;
 `
+
+const dataDependencies$ = merge(
+  tableTrades$,
+  distinctFieldValues$,
+  appliedFilters$,
+)
+
 export const Trades: React.FC = () => (
   <TradesWrapper>
-    <Subscribe source$={tableTrades$} fallback={<Loader />}>
+    <Subscribe source$={dataDependencies$} fallback={<Loader />}>
       <TradesStyle>
         <TradesHeader />
         <TradesGrid />

--- a/src/new-client/src/App/Trades/TradesFooter.tsx
+++ b/src/new-client/src/App/Trades/TradesFooter.tsx
@@ -2,7 +2,7 @@ import { bind } from "@react-rxjs/core"
 import { map } from "rxjs/operators"
 import styled from "styled-components"
 import { trades$ } from "services/trades"
-import { tableTrades$ } from "./services"
+import { tableTrades$ } from "./TradesState"
 
 const TradesFooterStyled = styled("div")`
   height: 2rem;

--- a/src/new-client/src/App/Trades/TradesGrid/SetFilter.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/SetFilter.tsx
@@ -1,0 +1,101 @@
+import React from "react"
+import styled from "styled-components/macro"
+import { FaCheck } from "react-icons/fa"
+import { ColField, onColFilterSelect } from "../TradesState"
+
+export const MultiSelectWrapper = styled.span`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.core.lightBackground};
+  border-radius: 4px;
+  color: ${({ theme }) => theme.core.textColor};
+  font-size: 12px;
+  padding: 8px 15px 5px 15px;
+  cursor: pointer;
+  display: inline-block;
+
+  @media (max-width: 400px) {
+    display: none;
+  }
+`
+
+export const MultiSelectMenu = styled.div`
+  position: absolute;
+  width: fit-content;
+  min-height: 100%;
+  max-height: 8rem;
+  overflow-y: auto;
+  top: 0px;
+  right: 0px;
+  background-color: ${({ theme }) => theme.primary.base};
+  padding: 6px;
+  box-shadow: ${({ theme }) => theme.core.textColor} 0px 0px 0.3125rem 0px;
+`
+
+export const MultiSelectOption = styled.div<{
+  selected: boolean
+  children: React.ReactNode
+}>`
+  padding: 8px 8px 5px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: ${({ selected }) => (selected ? "bold" : "normal")};
+  background-color: ${({ selected, theme }) =>
+    selected ? theme.core.activeColor : "inherit"};
+  border-radius: 2px;
+  margin-bottom: 5px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.core.backgroundHoverColor};
+    font-weight: ${({ selected }) => (selected ? "bold" : "normal")};
+    text-decoration: underline;
+  }
+`
+const AlignedChecked = styled.span`
+  margin-left: 0.675rem;
+  min-width: 0.675rem;
+`
+
+interface SetFilterProps {
+  options: unknown[]
+  field: ColField
+  selected: Set<unknown>
+  ref: React.RefObject<HTMLDivElement>
+}
+
+export const SetFilter: React.FC<SetFilterProps> = ({
+  options,
+  field,
+  selected,
+  ref,
+}) => {
+  return (
+    <MultiSelectWrapper>
+      <MultiSelectMenu ref={ref}>
+        {options.map((option) => {
+          const isSelected = selected.has(option)
+          return (
+            <MultiSelectOption
+              key={`${option}-filter`}
+              onClick={() => {
+                const nextSelections = new Set(selected)
+                if (isSelected) {
+                  nextSelections.delete(option)
+                } else {
+                  nextSelections.add(option)
+                }
+                onColFilterSelect([field, nextSelections])
+              }}
+              selected={isSelected}
+            >
+              {option}
+              <AlignedChecked>{isSelected && <FaCheck />}</AlignedChecked>
+            </MultiSelectOption>
+          )
+        })}
+      </MultiSelectMenu>
+    </MultiSelectWrapper>
+  )
+}

--- a/src/new-client/src/App/Trades/TradesGrid/TableHeadCell.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/TableHeadCell.tsx
@@ -1,0 +1,99 @@
+import styled from "styled-components/macro"
+import { FaFilter, FaLongArrowAltDown, FaLongArrowAltUp } from "react-icons/fa"
+import {
+  onSortFieldSelect,
+  TableSort,
+  ColConfig,
+  DistinctValues,
+  ColField,
+} from "../TradesState"
+import { SetFilter } from "./SetFilter"
+import { useRef, useState } from "react"
+import { usePopUpMenu } from "utils"
+import { Trade } from "services/trades"
+
+const TableHeadCell = styled.th`
+  text-align: left;
+  font-weight: unset;
+  top: 0;
+  position: sticky;
+  background-color: ${({ theme }) => theme.core.lightBackground};
+  border-bottom: 0.25rem solid ${({ theme }) => theme.core.darkBackground};
+  cursor: pointer;
+
+  svg {
+    width: 0.675rem;
+    vertical-align: text-bottom;
+  }
+
+  span.spacer {
+    min-width: 0.675rem;
+    display: inline-block;
+  }
+
+  span.spacer-2 {
+    min-width: 1rem;
+    display: inline-block;
+  }
+`
+
+export const TableHeadCellContainer: React.FC<
+  ColConfig & {
+    field: ColField
+    tableSort: TableSort
+    filterOptions: DistinctValues
+    appliedFilters: DistinctValues
+  }
+> = ({
+  field,
+  filterType,
+  tableSort,
+  headerName,
+  valueFormatter,
+  filterOptions,
+  appliedFilters,
+}) => {
+  const [showFilter, setShowFilter] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const { displayMenu, setDisplayMenu } = usePopUpMenu(ref)
+  return (
+    <TableHeadCell
+      onClick={() => onSortFieldSelect(field)}
+      onMouseEnter={() => filterType === "set" && setShowFilter(true)}
+      onMouseLeave={() => setShowFilter(false)}
+    >
+      {displayMenu && (
+        <SetFilter
+          field={field}
+          selected={appliedFilters[field as keyof Trade]}
+          ref={ref}
+          options={
+            [...filterOptions[field as keyof Trade]].map((value) =>
+              valueFormatter === undefined ? value : valueFormatter(value),
+            ) as string[]
+          }
+        />
+      )}
+      {headerName}
+      {tableSort.field === field ? (
+        tableSort.direction === "ASC" ? (
+          <FaLongArrowAltUp />
+        ) : (
+          <FaLongArrowAltDown />
+        )
+      ) : (
+        <span className="spacer" />
+      )}
+      {showFilter ? (
+        <FaFilter
+          onClick={(e) => {
+            e.stopPropagation()
+            setDisplayMenu((current) => !current)
+          }}
+        />
+      ) : (
+        <span className="spacer" />
+      )}
+    </TableHeadCell>
+  )
+}

--- a/src/new-client/src/App/Trades/TradesGrid/TradesGrid.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/TradesGrid.tsx
@@ -1,73 +1,14 @@
 import styled from "styled-components/macro"
-import { FaLongArrowAltDown, FaLongArrowAltUp } from "react-icons/fa"
-import { Trade, TradeStatus } from "services/trades"
+import { TradeStatus } from "services/trades"
 import {
-  significantDigitsNumberFormatter,
-  formatAsWholeNumber,
-} from "utils/formatNumber"
-import { capitalize } from "utils/capitalize"
-import { format as formatDate } from "date-fns"
-import { useTableTrades, sortFieldSelections$, useTableSort } from "../services"
-
-export type ColField = keyof Trade
-export interface ColConfig {
-  field: ColField
-  valueFormatter?: (val: unknown) => string
-  headerName: string
-  numeric?: boolean
-}
-
-type CellConfig = Pick<ColConfig, "numeric">
-
-export const colConfigs: ColConfig[] = [
-  {
-    headerName: "Trade ID",
-    field: "tradeId",
-  },
-  {
-    headerName: "Status",
-    field: "status",
-    valueFormatter: capitalize,
-  },
-  {
-    headerName: "Trade Date",
-    field: "tradeDate",
-    valueFormatter: (v) => formatDate(v as Date, DATE_FORMAT),
-  },
-  {
-    headerName: "Direction",
-    field: "direction",
-  },
-  {
-    headerName: "CCYCCY",
-    field: "symbol",
-  },
-  {
-    headerName: "Deal CCY",
-    field: "dealtCurrency",
-  },
-  {
-    headerName: "Notional",
-    field: "notional",
-    valueFormatter: (v) => formatAsWholeNumber(v as number),
-    numeric: true,
-  },
-  {
-    headerName: "Rate",
-    field: "spotRate",
-    valueFormatter: (v) => formatTo6Digits(v as number),
-    numeric: true,
-  },
-  {
-    headerName: "Value Date",
-    field: "valueDate",
-    valueFormatter: (v) => formatDate(v as Date, DATE_FORMAT),
-  },
-  {
-    headerName: "Trader",
-    field: "traderName",
-  },
-]
+  useTableTrades,
+  useTableSort,
+  useDistinctFieldValues as useFilterOptions,
+  useAppliedFilters,
+  colFields,
+  colConfigs,
+} from "../TradesState"
+import { TableHeadCellContainer } from "./TableHeadCell"
 
 const TableWrapper = styled.div`
   height: calc(100% - 4.75rem);
@@ -99,29 +40,10 @@ const TableBodyRow = styled.tr`
   }
   height: 2rem;
 `
-const TableHeadCell = styled.th<CellConfig>`
-  text-align: ${(props) => (props.numeric ? "right" : "left")};
-  font-weight: unset;
-  padding-right: ${(props) => (props.numeric ? "1rem" : "0")};
-  top: 0;
-  position: sticky;
-  background-color: ${({ theme }) => theme.core.lightBackground};
-  border-bottom: 0.25rem solid ${({ theme }) => theme.core.darkBackground};
-  pointer: cursor;
 
-  svg {
-    height: 0.675rem;
-    vertical-align: text-bottom;
-  }
-
-  span.spacer {
-    min-width: 0.675rem;
-    display: inline-block;
-  }
-`
-const TableBodyCell = styled.td<CellConfig>`
-  padding-right: ${(props) => (props.numeric ? "1rem" : ".1rem")};
-  text-align: ${(props) => (props.numeric ? "right" : "left")};
+const TableBodyCell = styled.td`
+  padding-right: 0.1rem;
+  text-align: left;
 `
 const StatusIndicator = styled.td<{ status: TradeStatus }>`
   width: 18px;
@@ -141,36 +63,25 @@ const StatusIndicatorSpacer = styled.th`
   border-bottom: 0.25rem solid ${({ theme }) => theme.core.darkBackground};
 `
 
-const DATE_FORMAT = "dd-MMM-yyyy"
-
-const formatTo6Digits = significantDigitsNumberFormatter(6)
-
 export const TradesGrid: React.FC = () => {
   const trades = useTableTrades()
   const tableSort = useTableSort()
+  const filterOptions = useFilterOptions()
+  const appliedFilters = useAppliedFilters()
   return (
     <TableWrapper>
       <Table>
         <TableHead>
           <TableHeadRow>
             <StatusIndicatorSpacer />
-            {colConfigs.map(({ field, headerName, numeric }) => (
-              <TableHeadCell
-                key={field}
-                numeric={numeric}
-                onClick={() => sortFieldSelections$.next(field)}
-              >
-                {headerName}
-                {tableSort.field === field ? (
-                  tableSort.direction === "ASC" ? (
-                    <FaLongArrowAltUp />
-                  ) : (
-                    <FaLongArrowAltDown />
-                  )
-                ) : (
-                  <span className="spacer" />
-                )}
-              </TableHeadCell>
+            {colFields.map((field) => (
+              <TableHeadCellContainer
+                {...colConfigs[field]}
+                field={field}
+                tableSort={tableSort}
+                appliedFilters={appliedFilters}
+                filterOptions={filterOptions}
+              ></TableHeadCellContainer>
             ))}
           </TableHeadRow>
         </TableHead>
@@ -178,9 +89,10 @@ export const TradesGrid: React.FC = () => {
           {trades.map((trade) => (
             <TableBodyRow key={trade.tradeId}>
               <StatusIndicator status={trade.status} />
-              {colConfigs.map(({ field, numeric, valueFormatter }) => (
-                <TableBodyCell key={field} numeric={numeric}>
-                  {valueFormatter?.(trade[field]) ?? trade[field]}
+              {colFields.map((field) => (
+                <TableBodyCell key={field}>
+                  {colConfigs[field].valueFormatter?.(trade[field]) ??
+                    trade[field]}
                 </TableBodyCell>
               ))}
             </TableBodyRow>

--- a/src/new-client/src/App/Trades/TradesGrid/index.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/index.tsx
@@ -1,2 +1,1 @@
 export { TradesGrid } from "./TradesGrid"
-export type { ColField, ColConfig } from "./TradesGrid"

--- a/src/new-client/src/App/Trades/TradesHeader/AppliedFilters.tsx
+++ b/src/new-client/src/App/Trades/TradesHeader/AppliedFilters.tsx
@@ -1,5 +1,11 @@
+import { FaTimes } from "react-icons/fa"
 import styled from "styled-components/macro"
-import { ColConfig } from "../TradesGrid"
+import {
+  colConfigs,
+  ColField,
+  onColFilterSelect,
+  useAppliedFilterEntries,
+} from "../TradesState"
 
 const FilterButton = styled("button")`
   opacity: 0.59;
@@ -7,7 +13,7 @@ const FilterButton = styled("button")`
 
 const FilterField = styled("div")`
   display: flex;
-  align-items: center;
+  align-items: normal;
   font-size: 0.6875rem;
   text-transform: uppercase;
   background-color: ${({ theme }) => theme.core.lightBackground};
@@ -29,19 +35,17 @@ const FilterName = styled("div")`
   padding-right: 0.625rem;
 `
 
-const FilterIcon = styled("i")`
-  line-height: 1rem;
-`
-
 export const AppliedFilters: React.FC = () => {
-  const filteredColDefs: ColConfig[] = []
+  const filteredFields = useAppliedFilterEntries().map(
+    ([field]) => field,
+  ) as ColField[]
   return (
     <>
-      {filteredColDefs.map((colDef) => (
-        <FilterField key={colDef.field}>
-          <FilterName>{colDef.headerName}</FilterName>
+      {filteredFields.map((field) => (
+        <FilterField key={field}>
+          <FilterName>{colConfigs[field].headerName}</FilterName>
           <FilterButton>
-            <FilterIcon className="fas fa-times" />
+            <FaTimes onClick={() => onColFilterSelect([field, new Set()])} />
           </FilterButton>
         </FilterField>
       ))}

--- a/src/new-client/src/App/Trades/TradesHeader/ExcelButton.tsx
+++ b/src/new-client/src/App/Trades/TradesHeader/ExcelButton.tsx
@@ -1,7 +1,6 @@
 import { map, take } from "rxjs/operators"
 import styled from "styled-components/macro"
-import { tableTrades$ } from "../services"
-import { colConfigs } from "../TradesGrid/TradesGrid"
+import { tableTrades$, colConfigs, colFields } from "../TradesState"
 
 const ExcelIcon = () => (
   <svg
@@ -46,8 +45,9 @@ const Button = styled("button")`
 export const exportTable$ = tableTrades$.pipe(
   map((trades) =>
     trades.map((trade) =>
-      colConfigs.map(({ field, numeric, valueFormatter }) => {
-        let res = valueFormatter?.(trade[field]) ?? trade[field]
+      colFields.map((field) => {
+        let res =
+          colConfigs[field].valueFormatter?.(trade[field]) ?? trade[field]
         if (typeof res === "string" && res?.includes(",")) {
           res = '"' + res + '"'
         }
@@ -61,8 +61,8 @@ export const exportTable$ = tableTrades$.pipe(
 const downloadCsv = () => {
   exportTable$.subscribe((trades) => {
     let csv = ""
-    colConfigs.forEach((col) => {
-      csv += col.headerName + ","
+    colFields.forEach((field) => {
+      csv += colConfigs[field].headerName + ","
     })
     csv += "\n"
 

--- a/src/new-client/src/App/Trades/TradesHeader/QuickFilter.tsx
+++ b/src/new-client/src/App/Trades/TradesHeader/QuickFilter.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { FaFilter, FaTimes } from "react-icons/fa"
 import styled from "styled-components/macro"
-import { quickFilterInputs$ } from "../services"
+import { onQuickFilterInput } from "../TradesState"
 
 const QuickFilterStyle = styled("div")`
   width: 10rem;
@@ -15,6 +15,7 @@ const QuickFilterInput = styled("input")`
   opacity: 0.59;
   background: none;
   border: none;
+  color: ${({ theme }) => theme.core.textColor};
   box-shadow: 0 0.0625rem 0 ${({ theme }) => theme.core.textColor};
   width: 100%;
   font-size: 0.75rem;
@@ -58,7 +59,7 @@ export const QuickFilter: React.FC = () => {
   const [quickFilterText, setQuickFilterText] = useState<string>("")
 
   useEffect(() => {
-    quickFilterInputs$.next(quickFilterText.toLowerCase())
+    onQuickFilterInput(quickFilterText.toLowerCase())
   }, [quickFilterText])
 
   return (

--- a/src/new-client/src/App/Trades/TradesState/colConfig.ts
+++ b/src/new-client/src/App/Trades/TradesState/colConfig.ts
@@ -1,0 +1,71 @@
+import { Trade } from "services/trades"
+import { capitalize } from "utils/capitalize"
+import { format as formatDate } from "date-fns"
+import {
+  significantDigitsNumberFormatter,
+  formatAsWholeNumber,
+} from "utils/formatNumber"
+
+export type ColField = keyof Trade
+
+type FilterType = "set" | "date" | "number"
+
+export interface ColConfig {
+  headerName: string
+  filterType: FilterType
+  valueFormatter?: (val: unknown) => string
+}
+
+export const DATE_FORMAT = "dd-MMM-yyyy"
+
+const formatTo6Digits = significantDigitsNumberFormatter(6)
+
+export const colConfigs: Record<ColField, ColConfig> = {
+  tradeId: {
+    headerName: "Trade ID",
+    filterType: "number",
+  },
+  status: {
+    headerName: "Status",
+    filterType: "set",
+    valueFormatter: capitalize,
+  },
+  tradeDate: {
+    headerName: "Trade Date",
+    filterType: "date",
+    valueFormatter: (v) => formatDate(v as Date, DATE_FORMAT),
+  },
+  direction: {
+    headerName: "Direction",
+    filterType: "set",
+  },
+  symbol: {
+    headerName: "CCYCCY",
+    filterType: "set",
+  },
+  dealtCurrency: {
+    headerName: "Deal CCY",
+    filterType: "set",
+  },
+  notional: {
+    headerName: "Notional",
+    filterType: "number",
+    valueFormatter: (v) => formatAsWholeNumber(v as number),
+  },
+  spotRate: {
+    headerName: "Rate",
+    filterType: "number",
+    valueFormatter: (v) => formatTo6Digits(v as number),
+  },
+  valueDate: {
+    headerName: "Value Date",
+    filterType: "date",
+    valueFormatter: (v) => formatDate(v as Date, DATE_FORMAT),
+  },
+  traderName: {
+    headerName: "Trader",
+    filterType: "set",
+  },
+}
+
+export const colFields: ColField[] = Object.keys(colConfigs) as ColField[]

--- a/src/new-client/src/App/Trades/TradesState/filterState.ts
+++ b/src/new-client/src/App/Trades/TradesState/filterState.ts
@@ -1,0 +1,66 @@
+import { bind } from "@react-rxjs/core"
+import { map, scan, startWith } from "rxjs/operators"
+import { mapObject } from "utils"
+import { Trade, trades$ } from "services/trades"
+import { ColField, colFields } from "./colConfig"
+import { createListener } from "@react-rxjs/utils"
+
+export type DistinctValues = {
+  [K in ColField]: Set<Trade[K]>
+}
+
+export const fieldValuesContainer = Object.freeze(
+  colFields.reduce((valuesContainer, field) => {
+    return {
+      ...valuesContainer,
+      [field]: new Set(),
+    }
+  }, {} as DistinctValues),
+)
+
+const ClonedFieldValuesContainer = () =>
+  mapObject(fieldValuesContainer, () => new Set()) as DistinctValues
+
+export const [useDistinctFieldValues, distinctFieldValues$] = bind(
+  trades$.pipe(
+    map((trades) =>
+      trades.reduce((distinctValues, trade) => {
+        for (const field in trade) {
+          ;(distinctValues[field as keyof Trade] as Set<unknown>).add(
+            trade[field as keyof Trade],
+          )
+        }
+        return distinctValues
+      }, ClonedFieldValuesContainer()),
+    ),
+  ),
+)
+
+export const [colFilterSelections$, onColFilterSelect] = createListener<
+  [ColField, Set<unknown>]
+>()
+
+export const [useAppliedFilters, appliedFilters$] = bind(
+  colFilterSelections$.pipe(
+    scan((appliedFilters, [field, filterSet]) => {
+      return {
+        ...appliedFilters,
+        [field]: filterSet,
+      }
+    }, ClonedFieldValuesContainer()),
+    startWith(ClonedFieldValuesContainer()),
+  ),
+)
+
+export const [quickFilterInputs$, onQuickFilterInput] = createListener<string>()
+
+export const [useAppliedFilterEntries, appliedFilterEntries$] = bind(
+  appliedFilters$.pipe(
+    map((appliedFilters) =>
+      Object.entries(appliedFilters).filter(
+        ([_, valueSet]) => valueSet.size !== 0,
+      ),
+    ),
+  ),
+  [],
+)

--- a/src/new-client/src/App/Trades/TradesState/index.ts
+++ b/src/new-client/src/App/Trades/TradesState/index.ts
@@ -1,0 +1,14 @@
+export type { ColField, ColConfig } from "./colConfig"
+export { colConfigs, colFields } from "./colConfig"
+export type { DistinctValues } from "./filterState"
+export {
+  useDistinctFieldValues,
+  onQuickFilterInput,
+  onColFilterSelect,
+  useAppliedFilterEntries,
+  useAppliedFilters,
+  appliedFilters$,
+  distinctFieldValues$,
+} from "./filterState"
+export { useTableSort, TableSort, onSortFieldSelect } from "./sortState"
+export { tableTrades$, useTableTrades } from "./tableTrades"

--- a/src/new-client/src/App/Trades/TradesState/sortState.ts
+++ b/src/new-client/src/App/Trades/TradesState/sortState.ts
@@ -1,0 +1,49 @@
+import { bind } from "@react-rxjs/core"
+import { createListener } from "@react-rxjs/utils"
+import { scan, startWith } from "rxjs/operators"
+import { ColField } from "./colConfig"
+
+export type SortDirection = "ASC" | "DESC"
+
+export class TableSort {
+  constructor(public direction?: SortDirection, public field?: ColField) {}
+}
+
+export const [
+  sortFieldSelections$,
+  onSortFieldSelect,
+] = createListener<ColField>()
+
+const descDefaultFields = new Set<ColField>([
+  "tradeDate",
+  "valueDate",
+  "tradeId",
+])
+
+export const [useTableSort, tableSort$] = bind(
+  sortFieldSelections$.pipe(
+    scan((tableSort, sortFieldSelection) => {
+      if (tableSort.field === sortFieldSelection) {
+        if (
+          descDefaultFields.has(sortFieldSelection) &&
+          tableSort.direction === "DESC"
+        ) {
+          return new TableSort("ASC", sortFieldSelection)
+        } else if (
+          !descDefaultFields.has(sortFieldSelection) &&
+          tableSort.direction === "ASC"
+        ) {
+          return new TableSort("DESC", sortFieldSelection)
+        } else {
+          return new TableSort()
+        }
+      }
+
+      return new TableSort(
+        descDefaultFields.has(sortFieldSelection) ? "DESC" : "ASC",
+        sortFieldSelection,
+      )
+    }, new TableSort()),
+    startWith(new TableSort()),
+  ),
+)

--- a/src/new-client/src/utils/mapObject.ts
+++ b/src/new-client/src/utils/mapObject.ts
@@ -1,9 +1,9 @@
 export const mapObject = <K extends string | number | symbol, I, O>(
   input: Record<K, I>,
-  mapper: (i: I) => O,
+  mapper: (i: I, k?: K) => O,
 ): Record<K, O> =>
   Object.fromEntries(
     Object.entries(input).map(
-      ([key, value]: any) => [key, mapper(value)] as const,
+      ([key, value]: any) => [key, mapper(value, key)] as const,
     ),
   ) as any

--- a/src/new-client/src/utils/usePopUpMenu.ts
+++ b/src/new-client/src/utils/usePopUpMenu.ts
@@ -13,7 +13,9 @@ const isParentOf = (
   return isParentOf(parent, child.parentElement)
 }
 
-export const usePopUpMenu = (ref: React.RefObject<HTMLDivElement>) => {
+export const usePopUpMenu = <T extends HTMLElement>(
+  ref: React.RefObject<T>,
+) => {
   const [displayMenu, setDisplayMenu] = useState(false)
   const hidePopUpMenu = useRef<(e: MouseEvent) => void>()
   if (!hidePopUpMenu.current) {


### PR DESCRIPTION
This implements a column "set filter" for the trades table.  Core part of the PR is:

1. Stage logic for managing the filters (and aggregating with the quick filter)
2. A provisional UI for a drop-down menu (based on the design we use for currency filters on the Tiles header in mobile view)

ToDo:
1. [Convert appliedFilters$ and distinctValues$ to parametric streams](https://adaptive.kanbanize.com/ctrl_board/18/cards/731/details/) - 
2. [Filter SetTypeFilter options with a text input](https://adaptive.kanbanize.com/ctrl_board/18/cards/732/details/)
3. [Create a "Select All" switch](https://adaptive.kanbanize.com/ctrl_board/18/cards/733/details/)
4. [Create a NumberTypeFilter](https://adaptive.kanbanize.com/ctrl_board/18/cards/736/details/)
5. [Create a DateTypeFilter](https://adaptive.kanbanize.com/ctrl_board/18/cards/735/details/)
6. [Address UX Bugs](https://adaptive.kanbanize.com/ctrl_board/18/cards/734/details/)
