### PR TITLE
Improve EventStore resiliency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,11 @@ jobs:
           DEPLOY_ENV: ${{ github.event.deployment.environment }}
         run: kubectl delete jobs --all --namespace $DEPLOY_ENV
 
+      - name: Delete persistent volumes
+        env:
+          DEPLOY_ENV: ${{ github.event.deployment.environment }}
+        run: kubectl delete persistentvolumeclaims --all --namespace $DEPLOY_ENV
+
       - name: Update GKE deployment definitions
         env:
           DEPLOY_ENV: ${{ github.event.deployment.environment }}

--- a/.github/workflows/pull-origin-up.yml
+++ b/.github/workflows/pull-origin-up.yml
@@ -64,7 +64,7 @@ jobs:
           docker-compose -f ./src/docker-compose.yml push
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     needs: build
 
@@ -96,6 +96,10 @@ jobs:
 
       - name: Delete GKE jobs
         run: kubectl delete jobs --all --namespace $DEPLOY_ENV
+        continue-on-error: true
+
+      - name: Delete persistent volumes
+        run: kubectl delete persistentvolumeclaims --all --namespace $DEPLOY_ENV
         continue-on-error: true
 
       - name: Create client configmap if not exists

--- a/src/services/eventstore/Dockerfile
+++ b/src/services/eventstore/Dockerfile
@@ -1,2 +1,3 @@
 FROM eventstore/eventstore:release-5.0.9
 ENV EVENTSTORE_DB=/db
+ENV EVENTSTORE_WRITE_STATS_TO_DB=false

--- a/src/services/eventstore/Dockerfile
+++ b/src/services/eventstore/Dockerfile
@@ -1,2 +1,2 @@
-FROM eventstore/eventstore:release-5.0.5
+FROM eventstore/eventstore:release-5.0.9
 ENV EVENTSTORE_DB=/db

--- a/src/services/kubernetes/per-deployment/eventstore-deployment.yaml
+++ b/src/services/kubernetes/per-deployment/eventstore-deployment.yaml
@@ -22,4 +22,11 @@ spec:
             requests:
               memory: "1G"
               cpu: "80m"
+          volumeMounts:
+            - mountPath: /db
+              name: eventstore-data
+      volumes:
+        - name: eventstore-data
+          persistentVolumeClaim:
+            claimName: eventstore-volume
 

--- a/src/services/kubernetes/per-deployment/eventstore-volume-claim.yaml
+++ b/src/services/kubernetes/per-deployment/eventstore-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: eventstore-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/src/services/kubernetes/per-deployment/initialise/initialise-job.yaml
+++ b/src/services/kubernetes/per-deployment/initialise/initialise-job.yaml
@@ -22,5 +22,5 @@ spec:
               value: '1113'
           command:
             ['sh', '-c', 'dotnet ./Adaptive.ReactiveTrader.Server.Launcher.dll config.prod.json --populate-eventstore']
-      restartPolicy: Never
+      restartPolicy: OnFailure
       


### PR DESCRIPTION
This improves the resiliency of the EventStore deployment with the following changes:
1. Data is now stored in a mounted persistent volume, which is retained across service restarts.
2. We no longer write server stats to the EventStore database. The docs suggest that this is off by default, but that was not the case. Stats are by far the heaviest part of the data, so this hugely slims down the resources used.
3. The initialisation job will restart on failure (with default backoff behaviour, failing fully after 6 unsuccessful attempts).

Once this has been deployed, I will monitor the effect on dev and uat, and then we can reduce the resource requests for this deployment. Currently, the pod scheduler sets aside 1GiB of memory for each EventStore. Without stats being written to the DB, we should not need anywhere near this and we can free up unused capacity in the cluster.