### PR TITLE
Compatibility with Finsemble build

### DIFF
--- a/src/client/src/apps/MainRoute/routes/SpotRoute.tsx
+++ b/src/client/src/apps/MainRoute/routes/SpotRoute.tsx
@@ -22,6 +22,7 @@ const SpotRoute: React.FC<RouteComponentProps<{ symbol: string }>> = ({
 }) => {
   const platform = usePlatform()
   const [ccyPairFromInterop, setCcyPairFromInterop] = useState<ReadonlyArray<string>>()
+  const queryParams = new URLSearchParams(search)
 
   // TODO: ccyPair from interop has to be in the hook or in the  store, same for BlotterRoute, but don't leave them here (side-effects)
   useEffect(() => {
@@ -38,7 +39,12 @@ const SpotRoute: React.FC<RouteComponentProps<{ symbol: string }>> = ({
     return () => ccyPairSubscription && ccyPairSubscription.unsubscribe()
   }, [platform])
 
-  const [tileView] = useLocalStorage('tileView', TileView.Analytics)
+  let [tileView] = useLocalStorage('tileView', TileView.Analytics)
+
+  if (queryParams.has('tileView')) {
+    tileView = queryParams.get('tileView')
+  }
+
   const id = (ccyPairFromInterop && ccyPairFromInterop[0]) || match.params.symbol
 
   return (

--- a/src/client/src/rt-platforms/finsemble/finsemble.ts
+++ b/src/client/src/rt-platforms/finsemble/finsemble.ts
@@ -11,9 +11,7 @@ export class Finsemble implements Platform {
   readonly name = 'finsemble'
   readonly type = 'desktop'
   readonly allowTearOff = true
-  style = {
-    height: 'calc(100% - 25px)',
-  }
+  style = {}
   epics = []
   PlatformHeader = () => null
   PlatformFooter = () => null
@@ -87,7 +85,6 @@ export class Finsemble implements Platform {
   }
 
   notification = {
-    notify: (message: object) =>
-      finsembleClient.alert(message),
+    notify: (message: object) => finsembleClient.alert(message),
   }
 }


### PR DESCRIPTION
This fixes two regressions relating to the Finsemble build:
1. We no longer need to deduct the height of the window title from the content height.
2. Spot tile views (normal or with analytics) should be toggled by query-string parameter in addition to local storage.

Tile views
Normal: https://pr1800.lb.adaptivecluster.com/spot/EURUSD?tileView=Normal
Analytics: https://pr1800.lb.adaptivecluster.com/spot/EURUSD?tileView=Analytics

Related:
https://github.com/AdaptiveConsulting/ReactiveTraderCloud-Finsemble/pull/40