### PR TITLE
fix: date formatting in launcher trade execution overlay

### DIFF
--- a/src/client/src/apps/SimpleLauncher/spotlight/components/TradeExecutionOverlay.tsx
+++ b/src/client/src/apps/SimpleLauncher/spotlight/components/TradeExecutionOverlay.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon'
 import numeral from 'numeral'
 import React, { FC, useEffect, useMemo, useState } from 'react'
 import { Subscription, fromEvent } from 'rxjs'
@@ -127,7 +128,7 @@ export const TradeExecutionOverlay: FC<TradeExecutionProps> = ({
     const directionString = direction.toLowerCase() === 'buy' ? 'bought' : 'sold'
     const tradeAcceptedMessage = `You ${directionString} ${symbol} for ${dealtCurrency}${numeral(
       notional
-    ).format()} @ ${spotRate} settling ${tradeDate.toLocaleDateString()}`
+    ).format()} @ ${spotRate} settling ${DateTime.fromJSDate(tradeDate).toFormat('dd-LLL-yyyy / HH:mm:ss')}`
 
     return (
       <>


### PR DESCRIPTION
The date formatting should match the inline quote table.

![nlp_trade_date_formatting](https://user-images.githubusercontent.com/43469524/109309159-d57b5c80-783a-11eb-9ebe-05a907a5b90e.png)
