### PR TITLE
Fix: yarn start

### DIFF
--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -72,18 +72,11 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ],
   "devDependencies": {
     "@testing-library/react-hooks": "^5.1.0",
     "@types/d3": "6.3.0",

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -20,19 +20,19 @@
     "url": "git+https://github.com/AdaptiveConsulting/ReactiveTraderCloud.git"
   },
   "dependencies": {
-    "@react-rxjs/core": "0.6.5",
+    "@react-rxjs/core": "0.6.6",
     "@react-rxjs/utils": "0.6.0",
     "@stomp/rx-stomp": "^1.0.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.8.0",
+    "@testing-library/user-event": "^12.8.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.31",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
     "@types/sinon": "^9.0.10",
     "d3": "6.5.0",
-    "date-fns": "^2.17.0",
+    "date-fns": "^2.18.0",
     "polished": "^4.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -85,7 +85,7 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/react-hooks": "^5.0.3",
+    "@testing-library/react-hooks": "^5.1.0",
     "@types/d3": "6.3.0",
     "@types/recharts": "^1.8.19",
     "@types/styled-components": "^5.1.7",

--- a/src/new-client/yarn.lock
+++ b/src/new-client/yarn.lock
@@ -2171,10 +2171,10 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@react-rxjs/core@0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@react-rxjs/core/-/core-0.6.5.tgz#7519b3c4ac9c7620ff45937dac4607216bd620ae"
-  integrity sha512-D/Vskhz2P/axy1geFCgs7bN2spE3C3yFgn/ylMTD4IuAkqPe1++NIzoRSStMSoszxxyNO+DeHjhOMFyDXcR9tQ==
+"@react-rxjs/core@0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@react-rxjs/core/-/core-0.6.6.tgz#698093bd17996ca42efaee43fe1700687f114c6e"
+  integrity sha512-w6qbVcx1bapI4KyvJCoJr+ObBnkVYnNz7C9oxdw0NC5CDLvctbVUlOyEQfhrw7KuL2cWD9N4EAg78Trw0qrw+g==
 
 "@react-rxjs/utils@0.6.0":
   version "0.6.0"
@@ -2396,10 +2396,10 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.0.3.tgz#dd0d2048817b013b266d35ca45e3ea48a19fd87e"
-  integrity sha512-UrnnRc5II7LMH14xsYNm/WRch/67cBafmrSQcyFh0v+UUmSf1uzfB7zn5jQXSettGwOSxJwdQUN7PgkT0w22Lg==
+"@testing-library/react-hooks@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz#6014b7536d0e9427a1e73ce1d073c49a6af5fb3b"
+  integrity sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/react" ">=16.9.0"
@@ -2416,10 +2416,10 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^12.8.0":
-  version "12.8.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.0.tgz#e07e52d4109a606772f72fa40641b284e8686221"
-  integrity sha512-5+k4U3X6XaFDSBSu6tsD02HVfzuOiPcygQmmYFE2aQQ0e5wRSxWRoU80UH1msa9Q6wuxa0BQsAmwAAAMydcscg==
+"@testing-library/user-event@^12.8.1":
+  version "12.8.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.1.tgz#aa897d6e7f0cf2208385abc2da2ac3f5844bbd00"
+  integrity sha512-u521YhkCKip0DQNDpfj9V97PU7UlCTkW5jURUD4JipuVe/xDJ32dJSIHlT2pqAs/I91OFB8p6LtqaLZpOu8BWQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -5348,10 +5348,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
-  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+date-fns@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.18.0.tgz#08e50aee300ad0d2c5e054e3f0d10d8f9cdfe09e"
+  integrity sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Yesterday I [upgraded the dependencies of the "new-client"](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/1812) and I also [added a commit for leveraging one of the new utils of `@react-rxjs/utils`](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/1812/commits/76b098521d01c3b6cb2e6eb6f5e35c4c2ab3f8a7). After each change I made sure that the production build was working properly and I did check whether we were having improvements on the Lighthouse metrics or not, and everything was working fine.

However, a few hours later I got messages from @iprado78 and from Julie letting me know that the `yarn start` script was no longer working:

![image](https://user-images.githubusercontent.com/8620144/109648317-c528f180-7b5a-11eb-85ae-ade78640dd37.png)

The error on the image doesn't make any sense, because optional chaining it's in stage-4, it's supported by the current LTS version of node and I don't see any reason why the `esm` build of a modern library shouldn't be using it these days. Also, this problem only happens on the "dev" build, not on the prod build... So, I was really puzzled about this. First I thought about changing the target of the esm build of react-rxjs to `es2019`, but that felt wrong. So, after digging into this a lot more I found that this is a long standing issue of CRA: https://github.com/facebook/create-react-app/issues/9468, https://github.com/facebook/create-react-app/issues/9749 .

A work-around is to use the same `browserslist` for both production and development, which is what [this commit does](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/1814/commits/d909b4f556b55c0e91257342058c3d44a2cc2d74).