### PR TITLE
chore(new-client): preload key requests

### DIFF
--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -60,6 +60,7 @@
         "lint-staged": "^10.5.4",
         "prettier": "^2.2.1",
         "react-test-renderer": "^17.0.1",
+        "rollup-plugin-modulepreload": "^1.2.3",
         "sinon": "^9.2.4",
         "ts-jest": "^26.5.3",
         "typescript": "^4.1.2",
@@ -4360,6 +4361,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/crocks": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/crocks/-/crocks-0.12.4.tgz",
+      "integrity": "sha512-paln6xJUrR9e/OWMFsyTi4dLyr+q99C5f7PQbGgSDHtwsfW0sCNZvnpHzvniI2dAE0uoBgeIP1Ukmme8Z0HxxA==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6340,6 +6347,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.promises": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
+      "integrity": "sha512-LNfkXdN6EToumV455EbdJaNxqLmEFqKqNZVIEyI2whtdpIppTsne2fHWgx05s+B2Aif29Lhzdz0AaOXKLvMGsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.9"
       }
     },
     "node_modules/fs.realpath": {
@@ -11382,6 +11398,33 @@
       "optionalDependencies": {
         "fsevents": "~2.3.1"
       }
+    },
+    "node_modules/rollup-plugin-modulepreload": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-modulepreload/-/rollup-plugin-modulepreload-1.2.3.tgz",
+      "integrity": "sha512-jswWiu6veSdZtyOwCO49NlNaxFxKQXC3c23A3fbUDo3q3vQTBigIZ3DXb9Y5NZ4ybti36Wc7HiK3N2dUef2WXw==",
+      "dev": true,
+      "dependencies": {
+        "crocks": "^0.12.4",
+        "fs.promises": "^0.1.2",
+        "jsdom": "^16.4.0",
+        "rollup-pluginutils": "^2.4.1"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -17068,6 +17111,12 @@
         "yaml": "^1.10.0"
       }
     },
+    "crocks": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/crocks/-/crocks-0.12.4.tgz",
+      "integrity": "sha512-paln6xJUrR9e/OWMFsyTi4dLyr+q99C5f7PQbGgSDHtwsfW0sCNZvnpHzvniI2dAE0uoBgeIP1Ukmme8Z0HxxA==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -18627,6 +18676,12 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fs.promises": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
+      "integrity": "sha512-LNfkXdN6EToumV455EbdJaNxqLmEFqKqNZVIEyI2whtdpIppTsne2fHWgx05s+B2Aif29Lhzdz0AaOXKLvMGsA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -22415,6 +22470,35 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
+      }
+    },
+    "rollup-plugin-modulepreload": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-modulepreload/-/rollup-plugin-modulepreload-1.2.3.tgz",
+      "integrity": "sha512-jswWiu6veSdZtyOwCO49NlNaxFxKQXC3c23A3fbUDo3q3vQTBigIZ3DXb9Y5NZ4ybti36Wc7HiK3N2dUef2WXw==",
+      "dev": true,
+      "requires": {
+        "crocks": "^0.12.4",
+        "fs.promises": "^0.1.2",
+        "jsdom": "^16.4.0",
+        "rollup-pluginutils": "^2.4.1"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "rsvp": {

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -82,6 +82,7 @@
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
     "react-test-renderer": "^17.0.1",
+    "rollup-plugin-modulepreload": "^1.2.3",
     "sinon": "^9.2.4",
     "ts-jest": "^26.5.3",
     "typescript": "^4.1.2",

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -2,9 +2,25 @@ import { resolve } from "path"
 import { defineConfig } from "vite"
 import reactRefresh from "@vitejs/plugin-react-refresh"
 import eslint from "@rollup/plugin-eslint"
+import modulepreload from "rollup-plugin-modulepreload"
+
+// TODO: This is a workaround until the following issue gets
+// confirmed/resolved: https://github.com/vitejs/vite/issues/2460
+const customPreloadPlugin = () => {
+  const result: any = {
+    ...((modulepreload as any)({
+      index: resolve(__dirname, "dist", "index.html"),
+      prefix: "",
+    }) as any),
+    enforce: "post",
+  }
+  result.writeBundle = result.generateBundle
+  delete result.generateBundle
+  return result
+}
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   esbuild: {
     jsxInject: `import React from 'react'`,
   },
@@ -16,8 +32,14 @@ export default defineConfig({
       "@": resolve(__dirname, "src"),
     },
   },
-  plugins: [
-    { ...eslint({ include: "src/**/*.+(js|jsx|ts|tsx)" }), enforce: "pre" },
-    reactRefresh(),
-  ],
-})
+  plugins:
+    mode === "development"
+      ? [
+          {
+            ...eslint({ include: "src/**/*.+(js|jsx|ts|tsx)" }),
+            enforce: "pre",
+          },
+          reactRefresh(),
+        ]
+      : [customPreloadPlugin()],
+}))


### PR DESCRIPTION
Currently when we run the Lighthouse performance test we can appreciate the following suggestion: "Preload key requests", and then the report shows a list with 6-7 assets that should have been pre-loaded with a `<link rel="preload />` tag.

Lighthouse is correct, those assets are being loaded immediately after the parser evaluates the "shell" bundle, so it makes sense to have them as "preload" links in the `index.html` file. I thought that Vite would be able to do that automatically if instead of declaring our lazy components like this:

```ts
const LiveRatesCore = lazy(() => import("./LiveRatesCore"))
```

we declared them like this:

```ts
const mod = import("./LiveRatesCore")
const LiveRatesCore = lazy(() => mod)
```

The reason being that with the first declaration the bundler can't know when that component would be used (mounted). However, with the second declaration the bundler should IMO be able to figure out that the dynamic import is being requested during bootstrap time... So, I think that ideally Vite should handle those cases, that's why I've opened this issuse: https://github.com/vitejs/vite/issues/2460 .

In the meanwhile, though, I've found [a rollup plugin](https://github.com/bennypowers/rollup-plugin-modulepreload) that we can use with Vite for now if we tweak it a bit... So, that's what this PR is about.