### PR TITLE
chore(new-client): currencyPairs improvements

### DIFF
--- a/src/new-client/src/App/Analytics/Positions/Positions.test.tsx
+++ b/src/new-client/src/App/Analytics/Positions/Positions.test.tsx
@@ -78,13 +78,16 @@ const _ccpp = require("@/services/currencyPairs/currencyPairs")
 describe("Positions", () => {
   beforeEach(() => {
     _analytics.__resetMocks()
-    _ccpp.__resetMocks()
+    _ccpp.__resetMock()
+    _ccpp.__setMock(
+      new BehaviorSubject({
+        [currencyPairMock1.symbol]: currencyPairMock1,
+        [currencyPairMock2.symbol]: currencyPairMock2,
+      }),
+    )
   })
 
   it("should render the correct price tag", () => {
-    _ccpp.__setCurrencyPairsMock(currencyPairMock1.symbol, currencyPairMock1)
-    _ccpp.__setCurrencyPairsMock(currencyPairMock2.symbol, currencyPairMock2)
-
     const positionMock$ = new BehaviorSubject<
       Record<string, CurrencyPairPosition>
     >(positionMock)
@@ -113,9 +116,6 @@ describe("Positions", () => {
   })
 
   it("should display the correct bubble chart", () => {
-    _ccpp.__setCurrencyPairsMock(currencyPairMock1.symbol, currencyPairMock1)
-    _ccpp.__setCurrencyPairsMock(currencyPairMock2.symbol, currencyPairMock2)
-
     const positionMock$ = new BehaviorSubject<
       Record<string, CurrencyPairPosition>
     >(positionMock)

--- a/src/new-client/src/App/LiveRates/MainHeader/MainHeader.test.tsx
+++ b/src/new-client/src/App/LiveRates/MainHeader/MainHeader.test.tsx
@@ -10,8 +10,6 @@ import { Tiles } from "../Tiles"
 jest.mock("@/services/currencyPairs/currencyPairs")
 jest.mock("../Tile/Tile.tsx")
 
-const currenciesMock: string[] = ["EUR", "USD"]
-
 const currencyPairMock1: CurrencyPair = {
   symbol: "EURUSD",
   base: "EUR",
@@ -42,27 +40,24 @@ const _ccpp = require("@/services/currencyPairs/currencyPairs")
 
 describe("MainHeader", () => {
   beforeEach(() => {
-    _ccpp.__resetMocks()
+    _ccpp.__resetMock()
+    _ccpp.__setMock(
+      new BehaviorSubject({
+        [currencyPairMock1.symbol]: currencyPairMock1,
+        [currencyPairMock2.symbol]: currencyPairMock2,
+      }),
+    )
   })
 
   it("should load all the currency buttons", async () => {
-    const currenciesMock$ = new BehaviorSubject<string[]>(currenciesMock)
-    _ccpp.__setCurrenciesMock(currenciesMock$)
-
     renderComponent()
 
     expect(screen.getByTestId("menuButton-Symbol(all)").textContent).toBe(`ALL`)
     expect(screen.getByTestId("menuButton-EUR").textContent).toBe(`EUR`)
-    expect(screen.getByTestId("menuButton-USD").textContent).toBe(`USD`)
+    expect(screen.getByTestId("menuButton-GBP").textContent).toBe(`GBP`)
   })
 
   it("should filter the tiles based on selection", async () => {
-    const currenciesMock$ = new BehaviorSubject<string[]>(currenciesMock)
-    _ccpp.__setCurrenciesMock(currenciesMock$)
-
-    _ccpp.__setCurrencyPairsMock(currencyPairMock1.symbol, currencyPairMock1)
-    _ccpp.__setCurrencyPairsMock(currencyPairMock2.symbol, currencyPairMock2)
-
     renderComponent()
 
     expect(
@@ -77,15 +72,18 @@ describe("MainHeader", () => {
       screen.getByTestId("workspace__tiles-workspace-items").children.length,
     ).toBe(1)
     expect(screen.getByTestId("tile-EURUSD")).not.toBeNull()
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("menuButton-GBP"))
+    })
+
+    expect(
+      screen.getByTestId("workspace__tiles-workspace-items").children.length,
+    ).toBe(1)
+    expect(screen.getByTestId("tile-GBPJPY")).not.toBeNull()
   })
 
   it("should show the charts in tiles once click toggle view button", async () => {
-    const currenciesMock$ = new BehaviorSubject<string[]>(currenciesMock)
-    _ccpp.__setCurrenciesMock(currenciesMock$)
-
-    _ccpp.__setCurrencyPairsMock(currencyPairMock1.symbol, currencyPairMock1)
-    _ccpp.__setCurrencyPairsMock(currencyPairMock2.symbol, currencyPairMock2)
-
     renderComponent()
 
     act(() => {

--- a/src/new-client/src/App/LiveRates/MainHeader/MainHeader.tsx
+++ b/src/new-client/src/App/LiveRates/MainHeader/MainHeader.tsx
@@ -1,4 +1,3 @@
-import { useCurrencies, currencies$ } from "@/services/currencyPairs"
 import {
   Header,
   LeftNav,
@@ -15,7 +14,21 @@ import {
 } from "../selectedCurrency"
 import { ToggleView } from "./ToggleView"
 import { CurrencyOptions } from "./CurrencyOptions"
+import { currencyPairs$ } from "@/services/currencyPairs"
+import { bind } from "@react-rxjs/core"
+import { map } from "rxjs/operators"
 
+const [useCurrencies, mainHeader$] = bind(
+  currencyPairs$.pipe(
+    map((currencyPairs) => [
+      ...new Set(
+        Object.values(currencyPairs).map((currencyPair) => currencyPair.base),
+      ),
+    ]),
+  ),
+)
+
+export { mainHeader$ }
 export const MainHeader: React.FC = () => {
   const currencies = useCurrencies()
   const currency = useSelectedCurrency()
@@ -52,5 +65,3 @@ export const MainHeader: React.FC = () => {
     </Header>
   )
 }
-
-export const mainHeader$ = currencies$

--- a/src/new-client/src/App/LiveRates/Tile/Tile.test.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Tile.test.tsx
@@ -32,7 +32,7 @@ const priceMock: Price = {
   bid: 1.53816,
   creationTimestamp: 5318479648168,
   mid: 1.53825,
-  symbol: "EURCAD",
+  symbol: "EURUSD",
   valueDate: "2021-02-10T19:10:28.4919591+00:00",
   movementType: PriceMovementType.NONE,
 }
@@ -56,7 +56,7 @@ const _exec = require("@/services/executions/executions")
 describe("Tile", () => {
   beforeEach(() => {
     _prices.__resetMocks()
-    _ccpp.__resetMocks()
+    _ccpp.__resetMock()
     _exec.__resetMocks()
   })
 
@@ -67,8 +67,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     renderComponent()
 
@@ -88,8 +90,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     renderComponent()
 
@@ -120,8 +124,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     const response$ = new Subject<ExecutionTrade | TimeoutExecution>()
 
@@ -191,8 +197,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     const response$ = new Subject<ExecutionTrade | TimeoutExecution>()
 
@@ -271,8 +279,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     const response$ = new Subject<ExecutionTrade | TimeoutExecution>()
 
@@ -340,8 +350,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     const response$ = new Subject<ExecutionTrade | TimeoutExecution>()
 
@@ -412,8 +424,10 @@ describe("Tile", () => {
     const hPriceMock$ = new Subject<HistoryPrice>()
     _prices.__setHistoricalPricesMock(hPriceMock$)
 
-    const ccPairMock$ = new BehaviorSubject<CurrencyPair>(currencyPairMock)
-    _ccpp.__setCurrencyPairMock(currencyPairMock.symbol, ccPairMock$)
+    const ccPairMock$ = new BehaviorSubject({
+      [currencyPairMock.symbol]: currencyPairMock,
+    })
+    _ccpp.__setMock(ccPairMock$)
 
     const response$ = new Subject<ExecutionTrade | TimeoutExecution>()
 

--- a/src/new-client/src/services/currencyPairs/__mocks__/currencyPairs.ts
+++ b/src/new-client/src/services/currencyPairs/__mocks__/currencyPairs.ts
@@ -1,100 +1,39 @@
 import { bind } from "@react-rxjs/core"
-import { split } from "@react-rxjs/utils"
-import { concat, defer, Observable, of } from "rxjs"
-import {
-  distinctUntilChanged,
-  map,
-  mergeAll,
-  mergeMap,
-  switchMap,
-  take,
-} from "rxjs/operators"
+import { defer, Observable, of } from "rxjs"
+import { map, mergeMap } from "rxjs/operators"
 import { UpdateType } from "@/services/utils"
 import { CurrencyPair } from "../types"
 
-let ccMocks$: Record<string, Observable<CurrencyPair>> = {}
-let currenciesMocks$: Observable<String[]> = of([])
-let currencyPairsMocks$: Record<string, CurrencyPair> = {}
-let currencyUpdateMocks$: any = {}
+let currencyPairsMocks$: Observable<Record<string, CurrencyPair>> = of({})
 
-export const __setCurrencyPairMock = (
-  key: string,
-  value: Observable<CurrencyPair>,
-) => {
-  ccMocks$[key] = value
+export const __setMock = (value: Observable<Record<string, CurrencyPair>>) => {
+  currencyPairsMocks$ = value
 }
 
-export const __resetCurrencyPairMocks = () => {
-  ccMocks$ = {}
+export const __resetMock = () => {
+  currencyPairsMocks$ = of({})
 }
 
 export const [useCurrencyPair, getCurrencyPair$] = bind((symbol: string) =>
-  defer(() => ccMocks$[symbol]),
+  defer(() => currencyPairsMocks$.pipe(map((entries) => entries[symbol]))),
 )
-
-export const __setCurrenciesMock = (value: Observable<String[]>) => {
-  currenciesMocks$ = value
-}
-
-export const __resetCurrenciesMocks = () => {
-  currenciesMocks$ = of([])
-}
-
-export const [useCurrencies, currencies$] = bind(
-  defer(() => {
-    return currenciesMocks$
-  }),
-)
-
-export const __setCurrencyPairsMock = (key: string, value: CurrencyPair) => {
-  currencyPairsMocks$[key] = value
-}
-
-export const __resetCurrencyPairsMocks = () => {
-  currencyPairsMocks$ = {}
-}
 
 export const [useCurrencyPairs, currencyPairs$] = bind(
-  defer(() => of(currencyPairsMocks$)),
+  defer(() => currencyPairsMocks$),
 )
 
-export const __setCurrencyUpdateMock = (value: any) => {
-  currencyUpdateMocks$ = value
-}
-
-export const __resetCurrencyUpdateMocks = () => {
-  currencyUpdateMocks$ = {}
-}
-
-export const currencyPairUpdates$ = defer(() => of(currencyUpdateMocks$))
-
-export const __resetMocks = () => {
-  __resetCurrencyPairMocks()
-  __resetCurrenciesMocks()
-  __resetCurrencyPairsMocks()
-}
+export const currencyPairUpdates$ = currencyPairs$.pipe(
+  map((entries) =>
+    Object.values(entries).map((currencyPair) => ({
+      updateType: UpdateType.Added,
+      currencyPair,
+    })),
+  ),
+)
 
 export const currencyPairDependant$ = (
   input: (symbol: string) => Observable<any>,
 ) =>
-  concat(
-    currencyPairs$.pipe(
-      take(1),
-      mergeMap((ccPairs) => Object.values(ccPairs)),
-      map((currencyPair) => ({ currencyPair, updateType: UpdateType.Added })),
-    ),
-    currencyPairUpdates$,
-  ).pipe(
-    split(
-      (update) => update.currencyPair.symbol,
-      (update$, key) =>
-        update$.pipe(
-          distinctUntilChanged((a, b) => a.updateType === b.updateType),
-          take(2),
-          switchMap((update) =>
-            update.updateType === UpdateType.Removed ? [] : input(key),
-          ),
-        ),
-    ),
-    mergeAll(),
+  currencyPairs$.pipe(
+    mergeMap((entries) => Object.values(entries).map((cc) => input(cc.symbol))),
   )

--- a/src/new-client/src/services/currencyPairs/currencyPairs.ts
+++ b/src/new-client/src/services/currencyPairs/currencyPairs.ts
@@ -61,16 +61,6 @@ export const [useCurrencyPair, getCurrencyPair$] = bind((symbol: string) =>
   ),
 )
 
-export const [useCurrencies, currencies$] = bind(
-  currencyPairs$.pipe(
-    map((currencyPairs) => [
-      ...new Set(
-        Object.values(currencyPairs).map((currencyPair) => currencyPair.base),
-      ),
-    ]),
-  ),
-)
-
 export const currencyPairDependant$ = (
   input: (symbol: string) => Observable<any>,
 ) =>


### PR DESCRIPTION
As I was working on the tests for #1839 I noticed that the mocks of the currency-pairs service are a lot more complicated than what they should be. I also noticed that there were was a hook that had been lifted into the service, that belonged into the `LivesRates` component.. So, I decided to address this first, instead of making things even more convoluted. My intention is to have this merged first, and then rebase #1839 