### PR TITLE
Prevent occasional runtime errors in dotnet services

### DIFF
--- a/src/server/dotNet/Adaptive.ReactiveTrader.Messaging/Adaptive.ReactiveTrader.Messaging.csproj
+++ b/src/server/dotNet/Adaptive.ReactiveTrader.Messaging/Adaptive.ReactiveTrader.Messaging.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />


### PR DESCRIPTION
We occasionally see the following error that crashes at runtime:

```
Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed'. The located assembly's manifest definition does not match the assembly reference.
```

We use multiple versions of this package across different assemblies, which seems to cause problems if the packages when the packages are built in different orders (I believe this is parallel and so non-deterministic). This PR pins all assemblies to the same package version.