### PR TITLE
fix(new-client): improve buble-chart

### DIFF
--- a/src/new-client/src/App/Analytics/Positions/Positions.test.tsx
+++ b/src/new-client/src/App/Analytics/Positions/Positions.test.tsx
@@ -1,5 +1,5 @@
 import { Subscribe } from "@react-rxjs/core"
-import { render, screen, act, fireEvent } from "@testing-library/react"
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react"
 import { BehaviorSubject } from "rxjs"
 import { TestThemeProvider } from "@/utils/testUtils"
 import { Positions, positions$ } from "./Positions"
@@ -89,13 +89,17 @@ describe("Positions", () => {
     )
   })
 
-  it("should render the correct price tag", () => {
+  it("should render the correct price tag", async () => {
     const positionMock$ = new BehaviorSubject<
       Record<string, CurrencyPairPosition>
     >(positionMock)
     _analytics.__setPositionMock(positionMock$)
 
     renderComponent()
+
+    await waitFor(() =>
+      expect(screen.getByTestId("positions-label-JPY")).not.toBeNull(),
+    )
 
     act(() => {
       fireEvent.mouseOver(screen.getByTestId("positions-label-JPY"))
@@ -111,13 +115,19 @@ describe("Positions", () => {
 
     act(() => {
       positionMock$.next(positionMock2)
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId("positions-label-AUD")).not.toBeNull(),
+    )
+
+    act(() => {
       fireEvent.mouseOver(screen.getByTestId("positions-label-AUD"))
     })
 
     expect(screen.getByTestId("tooltip").textContent).toBe("AUD -1,557,031")
   })
 
-  it("should display the correct bubble chart", () => {
+  it("should display the correct bubble chart", async () => {
     const positionMock$ = new BehaviorSubject<
       Record<string, CurrencyPairPosition>
     >(positionMock)
@@ -137,6 +147,8 @@ describe("Positions", () => {
     act(() => {
       positionMock$.next(positionMock2)
     })
+
+    await new Promise((res) => setTimeout(res, 2200))
 
     expect(container.firstChild).toMatchSnapshot()
 

--- a/src/new-client/src/App/Analytics/Positions/__snapshots__/Positions.test.tsx.snap
+++ b/src/new-client/src/App/Analytics/Positions/__snapshots__/Positions.test.tsx.snap
@@ -58,57 +58,6 @@ exports[`Positions should display the correct bubble chart 1`] = `
           </femerge>
         </filter>
       </defs>
-      <g
-        class="node"
-      >
-        <circle
-          cx="0"
-          cy="0"
-          r="17.048166533483364"
-          style="fill: #ff274b; filter: url(#drop-shadow);"
-        />
-        <text
-          class="analytics__positions-label"
-          data-testid="positions-label-EUR"
-          text-anchor="middle"
-        >
-          EUR
-        </text>
-      </g>
-      <g
-        class="node"
-      >
-        <circle
-          cx="0"
-          cy="0"
-          r="15"
-          style="fill: #ff274b; filter: url(#drop-shadow);"
-        />
-        <text
-          class="analytics__positions-label"
-          data-testid="positions-label-AUD"
-          text-anchor="middle"
-        >
-          AUD
-        </text>
-      </g>
-      <g
-        class="node"
-      >
-        <circle
-          cx="0"
-          cy="0"
-          r="60"
-          style="fill: #01c38d; filter: url(#drop-shadow);"
-        />
-        <text
-          class="analytics__positions-label"
-          data-testid="positions-label-JPY"
-          text-anchor="middle"
-        >
-          JPY
-        </text>
-      </g>
     </svg>
   </div>
 </div>
@@ -161,27 +110,31 @@ exports[`Positions should display the correct bubble chart 2`] = `
       </defs>
       <g
         class="node"
+        style="visibility: visible;"
       >
         <circle
-          cx="0"
-          cy="0"
-          r="17.048166533483364"
+          cx="22.366362534396142"
+          cy="65.17120150536171"
+          r="15.240588068460097"
           style="fill: #ff274b; filter: url(#drop-shadow);"
         />
         <text
           class="analytics__positions-label"
           data-testid="positions-label-EUR"
           text-anchor="middle"
+          x="22.366362534396142"
+          y="69.17120150536171"
         >
           EUR
         </text>
       </g>
       <g
         class="node"
+        style="visibility: visible;"
       >
         <circle
-          cx="0"
-          cy="0"
+          cx="-24.09298211184919"
+          cy="64.28187563887715"
           r="15"
           style="fill: #ff274b; filter: url(#drop-shadow);"
         />
@@ -189,16 +142,19 @@ exports[`Positions should display the correct bubble chart 2`] = `
           class="analytics__positions-label"
           data-testid="positions-label-AUD"
           text-anchor="middle"
+          x="-24.09298211184919"
+          y="68.28187563887715"
         >
           AUD
         </text>
       </g>
       <g
         class="node"
+        style="visibility: visible;"
       >
         <circle
-          cx="0"
-          cy="0"
+          cx="0.13455356501548343"
+          cy="-10.50968065293873"
           r="60"
           style="fill: #01c38d; filter: url(#drop-shadow);"
         />
@@ -206,6 +162,8 @@ exports[`Positions should display the correct bubble chart 2`] = `
           class="analytics__positions-label"
           data-testid="positions-label-JPY"
           text-anchor="middle"
+          x="0.13455356501548343"
+          y="-6.50968065293873"
         >
           JPY
         </text>


### PR DESCRIPTION
I noticed some odd behaviors with the current implementation: mostly issues when there are no trades and therefore no positions and then new trades of different currencies add bubbles into the chart. This PR addresses that, while also makes an improvement so that the movement of the bubbles don't trigger long ending updates on the DOM.