### PR TITLE
Run integration tests during PR and main CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: ./deploy/build.sh
 
-    # - name: Run integration tests
-    #   env:
-    #     DOCKER_USER: ${{ secrets.DOCKER_USER }}
-    #     BUILD_VERSION: ${{ env.TAG }}
-    #   run: docker-compose -f ./src/docker-compose.e2e.yml -f ./src/docker-compose.yml run integration
+    - name: Run integration tests
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: ./deploy/test.sh
 
     - name: Autheticate with Docker Hub
       env:

--- a/.github/workflows/pull-origin-up.yml
+++ b/.github/workflows/pull-origin-up.yml
@@ -41,7 +41,7 @@ jobs:
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
       run: ./deploy/push.sh
 
-  test:
+  unit-test:
     name: Run unit tests
 
     runs-on: ubuntu-20.04
@@ -69,6 +69,28 @@ jobs:
 
     - name: Run unit tests
       run: npm test
+
+  integration-test:
+    name: Run integration tests
+
+    runs-on: ubuntu-20.04
+
+    needs: build
+
+    if: "!github.event.pull_request.head.repo.fork"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Test
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: ./deploy/test.sh
 
   deploy:
     name: Create new deployment

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -47,5 +47,5 @@ while IFS= read -r image; do
   name=$(echo $image | awk '{print $1}')
   context=$(echo $image | awk '{print $2}')
   build_image $name $context
-done <<< "$images"
+done < <(echo "$images")
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -50,7 +50,7 @@ check_images_exist () {
       echo "Preflight failed: could not find remote image $name:$version."
       exit 1
     fi
-  done <<< "$images"
+  done < <(echo "$images")
 }
 
 deploy_service () {

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -56,5 +56,5 @@ while IFS= read -r image; do
   name=$(echo $image | awk '{print $1}')
   context=$(echo $image | awk '{print $2}')
   push_image $name $context
-done <<< "$images"
+done < <(echo "$images")
 

--- a/deploy/test.sh
+++ b/deploy/test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ ! -v DOCKER_USER ]; then
+  echo "Docker registry user must be specified in DOCKER_USER variable."
+  exit 1
+fi
+
+build_version () {
+  if [ -v TAG ]; then
+    echo $TAG
+  else
+    git ls-tree HEAD -- $1 | awk '{print $3 }'
+  fi
+}
+
+images=$(cat <<-END
+eventstore/eventstore release-5.0.9
+$DOCKER_USER/broker   $(build_version ./src/services/broker)
+$DOCKER_USER/servers  $(build_version ./src/server)
+END
+)
+
+local_tag_exists () {
+  docker image inspect $1:$2 > /dev/null 2>&1
+}
+
+remote_tag_exists () {
+  curl --silent -f -lL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
+}
+
+pull_image_if_not_exists () {
+  if ! local_tag_exists $1 $2; then
+    if ! remote_tag_exists $1 $2; then
+      echo "Cannot find image for '$1' tagged with '$2'."
+      exit 1
+    fi
+
+    docker pull $1:$2
+  fi
+}
+
+tag_image () {
+  docker tag $1:$2 $1:test-build
+}
+
+run_integration_tests () {
+  BUILD_VERSION=test-build \
+  docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.test.yml run integration
+  
+  BUILD_VERSION=test-build \
+  docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.test.yml rm -s -f
+}
+
+while IFS= read -r image; do
+  name=$(echo $image | awk '{print $1}')
+  version=$(echo $image | awk '{print $2}')
+  pull_image_if_not_exists $name $version
+  tag_image $name $version
+done < <(echo "$images")
+
+run_integration_tests

--- a/src/docker-compose.e2e.yml
+++ b/src/docker-compose.e2e.yml
@@ -1,17 +1,5 @@
 version: '3'
 services:
-  integration:
-    image: ${DOCKER_USER}/servers:${BUILD_VERSION}
-    hostname: integration
-    container_name: integration
-    depends_on:
-      - initialise
-      - analytics
-      - referencedataread
-      - pricing
-      - blotter
-      - tradeexecution
-    command: dotnet vstest ./Adaptive.ReactiveTrader.Server.IntegrationTests.dll
   e2e:
     image: ${DOCKER_USER}/e2e:${BUILD_VERSION}
     build:

--- a/src/docker-compose.test.yml
+++ b/src/docker-compose.test.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  integration:
+    image: ${DOCKER_USER}/servers:${BUILD_VERSION}
+    hostname: integration
+    container_name: integration
+    depends_on:
+      - initialise
+      - analytics
+      - referencedataread
+      - pricing
+      - blotter
+      - tradeexecution
+    command: dotnet vstest ./Adaptive.ReactiveTrader.Server.IntegrationTests.dll


### PR DESCRIPTION
This adds our server integration tests back into the CI workflows.

* For pull requests, the integration tests are run in parallel with the deployment phase, so there should be no slowdown in bringing up a preview environment for testing.
* During the main CI build (i.e. after a merge) the integration tests will run _before_ the deployment. This is to ensure that we do not deploy a broken build to any of our permanent environments.
* During the PR build, we do not necessarily build the server image (since we only build Docker images where the source has changed), so in this event we pull the relevant image from Docker Hub and use that for integration tests. Arguably we could skip integration tests altogether in this case.

Hopefully this will give the right balance between correctness and development experience.