### PR TITLE
chore(new-client): improve RFQ state management

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 import { FaRedo } from "react-icons/fa"
-import { useRfqState, QuoteState } from "../Rfq"
+import { useRfqState, QuoteStateStage } from "../Rfq"
 import { symbolBind, useTileCurrencyPair } from "../Tile.context"
 import {
   InputWrapper,
@@ -81,7 +81,7 @@ export const NotionalInput: React.FC<{ isAnalytics: boolean }> = ({
   const { base, symbol } = useTileCurrencyPair()
   const defaultNotional = useDefaultNotional()
   const notional = useNotional()
-  const { state: quoteState } = useRfqState()
+  const { stage: quoteStage } = useRfqState()
 
   return (
     <NotionalInputWrapper isAnalyticsView={isAnalytics}>
@@ -90,9 +90,10 @@ export const NotionalInput: React.FC<{ isAnalytics: boolean }> = ({
         <Input
           role={"input"}
           type="text"
-          disabled={[QuoteState.Received, QuoteState.Requested].includes(
-            quoteState,
-          )}
+          disabled={[
+            QuoteStateStage.Received,
+            QuoteStateStage.Requested,
+          ].includes(quoteStage)}
           value={notional.inputValue}
           onChange={(e) => {
             onChangeNotionalValue(symbol, e.target.value)

--- a/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
@@ -10,7 +10,7 @@ import { CenteringContainer } from "@/components/CenteringContainer"
 import { AdaptiveLoader } from "@/components/AdaptiveLoader"
 import { sendExecution } from "../Tile.state"
 import { useTileCurrencyPair } from "../Tile.context"
-import { useRfqState, QuoteState } from "../Rfq"
+import { useRfqState, QuoteStateStage } from "../Rfq"
 import {
   TradeButton,
   Price,
@@ -108,7 +108,7 @@ export const PriceButton: React.FC<{
 }> = ({ direction }) => {
   const rfqState = useRfqState()
 
-  return rfqState.state === QuoteState.Requested ? (
+  return rfqState.stage === QuoteStateStage.Requested ? (
     <QuotePriceLoading>
       <AdaptiveLoader size={16} />
       Awaiting Price

--- a/src/new-client/src/App/LiveRates/Tile/Rfq/Rfq.test.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Rfq/Rfq.test.tsx
@@ -25,12 +25,12 @@ describe("RFQ/buttons", () => {
     rfqStateSpy = jest.spyOn(rs, "useRfqState")
     isRfqSpy = jest.spyOn(rs, "useIsRfq")
     onQuoteRequestSpy = jest.spyOn(rs, "onQuoteRequest")
-    onCancelRequest = jest.spyOn(rs, "onCancelRequest")
+    onCancelRequest = jest.spyOn(rs, "onCancelRfq")
   })
 
   it("should not display rfq button", () => {
     isRfqSpy.mockReturnValue(false)
-    rfqStateSpy.mockReturnValue({ state: rs.QuoteState.Init })
+    rfqStateSpy.mockReturnValue({ stage: rs.QuoteStateStage.Init })
     renderComponent(false)
 
     expect(screen.queryByText("Initiate RFQ")).toBeNull()
@@ -40,7 +40,7 @@ describe("RFQ/buttons", () => {
 
   it("should display 'Initiate RFQ' and call the onClickHandler", () => {
     isRfqSpy.mockReturnValue(true)
-    rfqStateSpy.mockReturnValue({ state: rs.QuoteState.Init })
+    rfqStateSpy.mockReturnValue({ stage: rs.QuoteStateStage.Init })
     renderComponent(false)
 
     const buttonText = "Initiate RFQ"
@@ -54,7 +54,7 @@ describe("RFQ/buttons", () => {
 
   it("should display 'Cancel RFQ'", () => {
     isRfqSpy.mockReturnValue(true)
-    rfqStateSpy.mockReturnValue({ state: rs.QuoteState.Requested })
+    rfqStateSpy.mockReturnValue({ stage: rs.QuoteStateStage.Requested })
     renderComponent(false)
 
     const buttonText = "Cancel RFQ"
@@ -68,7 +68,7 @@ describe("RFQ/buttons", () => {
 
   it("should display 'Requote'", () => {
     isRfqSpy.mockReturnValue(true)
-    rfqStateSpy.mockReturnValue({ state: rs.QuoteState.Rejected })
+    rfqStateSpy.mockReturnValue({ stage: rs.QuoteStateStage.Rejected })
     renderComponent(false)
 
     const buttonText = "Requote"

--- a/src/new-client/src/App/LiveRates/Tile/Rfq/RfqButton.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Rfq/RfqButton.tsx
@@ -6,8 +6,8 @@ import {
   useRfqState,
   useIsRfq,
   onQuoteRequest,
-  onCancelRequest,
-  QuoteState,
+  onCancelRfq,
+  QuoteStateStage,
 } from "./Rfq.state"
 import { AnalyticsPricesFirstCol } from "../Tile.styles"
 import { TileStates, useTileState } from "../Tile.state"
@@ -31,18 +31,18 @@ const RFQButtonInner = styled.button<{
   color: ${({ theme }) => theme.white};
 `
 
-const buttonState = (quoteState: QuoteState, isAnalytics: boolean) => {
+const buttonState = (quoteState: QuoteStateStage, isAnalytics: boolean) => {
   switch (quoteState) {
-    case QuoteState.Init:
+    case QuoteStateStage.Init:
       return {
         buttonText: "Initiate RFQ",
         buttonClickHandler: onQuoteRequest,
         textWrap: !isAnalytics,
       }
-    case QuoteState.Requested:
+    case QuoteStateStage.Requested:
       return {
         buttonText: "Cancel RFQ",
-        buttonClickHandler: onCancelRequest,
+        buttonClickHandler: onCancelRfq,
         textWrap: !isAnalytics,
       }
     default:
@@ -56,14 +56,14 @@ const buttonState = (quoteState: QuoteState, isAnalytics: boolean) => {
 
 const RfqButton: React.FC<{ isAnalytics: boolean }> = ({ isAnalytics }) => {
   const isRfq = useIsRfq()
-  const { state } = useRfqState()
+  const { stage } = useRfqState()
   const { symbol } = useTileCurrencyPair()
   const { buttonText, buttonClickHandler, textWrap } = buttonState(
-    state,
+    stage,
     isAnalytics,
   )
   const isExecuting = useTileState(symbol).status === TileStates.Started
-  return isRfq && state !== QuoteState.Received && !isExecuting ? (
+  return isRfq && stage !== QuoteStateStage.Received && !isExecuting ? (
     <OverlayDiv left={isAnalytics ? `calc(${AnalyticsPricesFirstCol} / 2)` : 0}>
       <CenteringContainer>
         <RFQButtonInner

--- a/src/new-client/src/App/LiveRates/Tile/Rfq/RfqTimer.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Rfq/RfqTimer.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from "react"
 import styled from "styled-components"
-import { onRejection } from "./Rfq.state"
+import { onRejectQuote } from "./Rfq.state"
 import { useTileCurrencyPair } from "../Tile.context"
 
 const TimeLeft = styled.div<{ isAnalyticsView: boolean }>`
@@ -129,7 +129,7 @@ export const RfqTimer: React.FC<{
       </ProgressBarWrapper>
       <RejectQuoteButton
         isAnalyticsView={isAnalyticsView}
-        onClick={() => onRejection(symbol)}
+        onClick={() => onRejectQuote(symbol)}
       >
         Reject
       </RejectQuoteButton>

--- a/src/new-client/src/App/LiveRates/Tile/Rfq/index.ts
+++ b/src/new-client/src/App/LiveRates/Tile/Rfq/index.ts
@@ -2,9 +2,9 @@ export { RfqButton } from "./RfqButton"
 export { RfqTimer } from "./RfqTimer"
 
 export {
-  onRejection,
+  onRejectQuote,
   useRfqState,
   getRfqState$,
   isRfq$,
-  QuoteState,
+  QuoteStateStage,
 } from "./Rfq.state"

--- a/src/new-client/src/App/LiveRates/Tile/Tile.state.ts
+++ b/src/new-client/src/App/LiveRates/Tile/Tile.state.ts
@@ -28,11 +28,10 @@ export { onDismissMessage }
 const waitForDismissal$ = (symbol: string) => dismiss$(symbol).pipe(take(1))
 
 // Executions
-const [tileExecutions$, sendExecution] = createKeyedSignal(
+export const [tileExecutions$, sendExecution] = createKeyedSignal(
   (x) => x.symbol,
   (symbol: string, direction: Direction) => ({ symbol, direction }),
 )
-export { sendExecution }
 
 // TileState
 export enum TileStates {

--- a/src/new-client/src/App/LiveRates/Tile/Tile.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Tile.tsx
@@ -22,7 +22,7 @@ import {
   RfqButton,
   getRfqState$,
   useRfqState,
-  QuoteState,
+  QuoteStateStage,
   RfqTimer,
 } from "./Rfq"
 
@@ -46,7 +46,7 @@ const Tile: React.FC<{
 }> = ({ isAnalytics }) => {
   const rfq = useRfqState()
   const timerData =
-    rfq.state === QuoteState.Received
+    rfq.stage === QuoteStateStage.Received
       ? { start: rfq.payload.time, end: rfq.payload.time + rfq.payload.timeout }
       : null
   return (


### PR DESCRIPTION
I'm preparing a presentation on react-rxjs and I'm planing to sue the rfq state as an example... Because of that, I decided to make a few improvements to make the code more readable and easier to understand, I also decided to be a bit more explicit about the types of the `useRfqState`.

One thing that I did notice, though, is that despite the fact that the behavior hasn't changed at all I've had to readjust the tests of `Rfq.test.ts`. I really think that those tests are kinda testing the internals and that we should be testing the rfq workflow through in the `Tile.test.tsx`, so let's create a task for that in our backlog.