### PR TITLE
fix(new-client): center-align notional input in normal tile view

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/Rfq/RfqTimer.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Rfq/RfqTimer.tsx
@@ -72,6 +72,7 @@ const RejectQuoteButton = styled.button<{ isAnalyticsView: boolean }>`
 const TimerWrapper = styled.div<{ isAnalyticsView: boolean }>`
   display: flex;
   align-items: center;
+  align-self: stretch;
   z-index: 3;
 `
 

--- a/src/new-client/src/App/LiveRates/Tile/Tile.styles.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Tile.styles.tsx
@@ -29,9 +29,11 @@ export const PriceControlsStyle = styled("div")<{
     `}
 `
 
-export const InputTimerStyle = styled("div")`
+export const InputTimerStyle = styled.div<{ isAnalyticsView: boolean }>`
   display: flex;
   flex-direction: column;
+  align-items: ${({ isAnalyticsView }) =>
+    isAnalyticsView ? "flex-start" : "center"};
 `
 
 export const PanelItem = styled.div`

--- a/src/new-client/src/App/LiveRates/Tile/Tile.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Tile.tsx
@@ -52,14 +52,14 @@ const Tile: React.FC<{
       ? { start: rfq.payload.time, end: rfq.payload.time + rfq.payload.timeout }
       : null
 
-  const InputTimerWrapper: React.FC<{ isAnalytics: boolean }> = ({
+  const InputTimerWrapper: React.FC<{ isAnalytics?: boolean }> = ({
     isAnalytics,
   }) => {
     return (
-      <InputTimerStyle>
+      <InputTimerStyle isAnalyticsView={!!isAnalytics}>
         <NotionalInput />
         {timerData ? (
-          <RfqTimer {...timerData} isAnalyticsView={isAnalytics} />
+          <RfqTimer {...timerData} isAnalyticsView={!!isAnalytics} />
         ) : null}
       </InputTimerStyle>
     )
@@ -84,7 +84,7 @@ const Tile: React.FC<{
               <RfqButton isAnalytics={isAnalytics} />
             </PriceControlsStyle>
           </PriceControlWrapper>
-          {!isAnalytics ? <InputTimerWrapper isAnalytics /> : null}
+          {!isAnalytics ? <InputTimerWrapper /> : null}
         </Body>
       </Main>
       <ExecutionResponse />


### PR DESCRIPTION
The notional input should be center-aligned in the normal tile view and left-aligned in the analytics tile view.