### PR TITLE
Exclude storybook and styleguide from service worker routing

### DIFF
--- a/src/new-client/src/sw.js
+++ b/src/new-client/src/sw.js
@@ -34,6 +34,14 @@ registerRoute(
       return false
     }
 
+    if (url.pathname.startsWith("/storybook")) {
+      return false
+    }
+
+    if (url.pathname.startsWith("/styleguide")) {
+      return false
+    }
+
     // If this is a URL that starts with /_, skip.
     if (url.pathname.startsWith("/_")) {
       return false


### PR DESCRIPTION
Once registered, the service worker of the new client intercepts requests to /storybook and /styleguide and redirects to the Reactive Trader UI. This PR adds exceptions for those two path prefixes.

For comparison, visit: https://www.reactivetrader.com/storybook and https://pr1887.lb.adaptivecluster.com/storybook. In the former, it is not possible to open storybook once the service worker is registered (without force-reloading). The latter always works.