### PR TITLE
fix(notifications): fixes for notifications

### DIFF
--- a/src/new-client/src/services/trades/trades.ts
+++ b/src/new-client/src/services/trades/trades.ts
@@ -1,5 +1,5 @@
 import { bind } from "@react-rxjs/core"
-import { map, mergeAll, scan, share, skip } from "rxjs/operators"
+import { map, scan } from "rxjs/operators"
 import { getStream$ } from "../client"
 import { Trade, RawTradeUpdate } from "./types"
 
@@ -22,10 +22,7 @@ const tradesStream$ = getStream$<RawTradeUpdate>(
       valueDate: new Date(rawTrade.ValueDate),
     })),
   ),
-  share(),
 )
-
-export const newTrades$ = tradesStream$.pipe(skip(1), mergeAll())
 
 export const [useTrades, trades$] = bind<Trade[]>(
   tradesStream$.pipe(


### PR DESCRIPTION
I thought that we were supposed to notify the user about all new trades that were taking place... @garyadaptive told me that the user is only supposed to be notified about the executions that they trigger from that particular browser, sorry about that! :sweat_smile: 

Anyways this should fix it! :slightly_smiling_face: j

I've added other fixes like: preventing an odd issue with some chrome versions and fixing the notifications for Safari.