### PR TITLE
feat(new-client): improve service workers updates

### DIFF
--- a/src/new-client/src/App/Analytics/Analytics.tsx
+++ b/src/new-client/src/App/Analytics/Analytics.tsx
@@ -3,7 +3,9 @@ import { lazy, Suspense, useRef } from "react"
 import { analytics$ } from "@/services/analytics"
 import styled from "styled-components"
 import { useHasItBeenVisible } from "@/utils/useHasItBeenVisible"
-const AnalyticsCore = lazy(() => import("./AnalyticsCore"))
+
+export const AnalyticsCoreDeferred = import("./AnalyticsCore")
+const AnalyticsCore = lazy(() => AnalyticsCoreDeferred)
 
 const AnalyticsWrapper = styled.div`
   flex: 0 0 371px;

--- a/src/new-client/src/App/Analytics/index.tsx
+++ b/src/new-client/src/App/Analytics/index.tsx
@@ -1,1 +1,1 @@
-export { Analytics } from "./Analytics"
+export * from "./Analytics"

--- a/src/new-client/src/App/LiveRates/LiveRates.tsx
+++ b/src/new-client/src/App/LiveRates/LiveRates.tsx
@@ -6,7 +6,9 @@ import { getHistoricalPrices$, getPrice$ } from "@/services/prices"
 import styled from "styled-components"
 import { combineKeys } from "@react-rxjs/utils"
 import { map } from "rxjs/operators"
-const LiveRatesCore = lazy(() => import("./LiveRatesCore"))
+
+export const LiveRatesCoreDeferred = import("./LiveRatesCore")
+const LiveRatesCore = lazy(() => LiveRatesCoreDeferred)
 
 currencyPairs$.subscribe()
 combineKeys(currencyPairs$.pipe(map(Object.keys)), (symbol: string) =>

--- a/src/new-client/src/App/LiveRates/index.ts
+++ b/src/new-client/src/App/LiveRates/index.ts
@@ -1,1 +1,1 @@
-export { LiveRates } from "./LiveRates"
+export * from "./LiveRates"

--- a/src/new-client/src/App/Trades/Trades.tsx
+++ b/src/new-client/src/App/Trades/Trades.tsx
@@ -2,7 +2,9 @@ import { Loader } from "@/components/Loader"
 import { lazy, Suspense } from "react"
 import { trades$ } from "@/services/trades"
 import styled from "styled-components"
-const TradesCore = lazy(() => import("./TradesCore"))
+
+export const TradesCoreDeferred = import("./TradesCore")
+const TradesCore = lazy(() => TradesCoreDeferred)
 
 const TradesWrapper = styled.article`
   height: 100%;

--- a/src/new-client/src/App/Trades/index.tsx
+++ b/src/new-client/src/App/Trades/index.tsx
@@ -1,1 +1,1 @@
-export { Trades } from "./Trades"
+export * from "./Trades"

--- a/src/new-client/src/index.tsx
+++ b/src/new-client/src/index.tsx
@@ -6,8 +6,31 @@ import { GlobalScrollbarStyle, ThemeProvider } from "./theme"
 import { register } from "./serviceWorkerRegistration"
 import { registerSwNotifications } from "./sw-notifications"
 
+import { AnalyticsCoreDeferred } from "./App/Analytics"
+import { LiveRatesCoreDeferred } from "./App/LiveRates"
+import { TradesCoreDeferred } from "./App/Trades"
+
 if (import.meta.env.PROD) {
-  register()
+  register({
+    onUpdate: (registration) => {
+      // If the SW got updated, then we have to be careful. We can't immediately
+      // skip the waiting phase, because if there are requests on the fly that
+      // could be a disaster. In an ideal world we should display a message to
+      // the user letting them know that a new version is available and whenever
+      // the user confirms that they want to update then we can skip the waiting
+      // phase and we reload the App. However, before we implement that feature
+      // what we can do is to skip the waiting phase after all the async chunks
+      // have been loaded. This is only an option because all our async chunks
+      // get always preloaded from the main chunk.
+      Promise.all([
+        AnalyticsCoreDeferred,
+        LiveRatesCoreDeferred,
+        TradesCoreDeferred,
+      ]).then(() => {
+        registration.waiting?.postMessage({ type: "SKIP_WAITING" })
+      })
+    },
+  })
   registerSwNotifications()
 }
 


### PR DESCRIPTION
If the SW got updated, then we have to be careful. We can't immediately skip the waiting phase, because if there are requests on the fly that could be a disaster. In an ideal world we should display a message to the user letting them know that a new version is available and whenever the user confirms that they want to update then we can skip the waiting phase and we reload the App. However, before we implement that feature what we can do is to skip the waiting phase after all the async chunks have been loaded. This is only an option because all our async chunks get always preloaded from the main chunk.