### PR TITLE
Environment matcher should detect "classic" URLs

### DIFF
--- a/src/client/src/rt-util/getEnvironment.ts
+++ b/src/client/src/rt-util/getEnvironment.ts
@@ -6,7 +6,7 @@ export function getEnvironment(): string {
     return 'local'
   }
 
-  if (serviceUrl === 'www.reactivetrader.com') {
+  if (serviceUrl === 'www.reactivetrader.com' || serviceUrl === 'classic.reactivetrader.com') {
     return 'demo'
   }
 
@@ -22,7 +22,7 @@ export function getEnvironment(): string {
     return envMatch['groups'].env
   }
 
-  envMatch = /^(?<env>\w+)\.lb\.adaptivecluster\.com/.exec(serviceUrl)
+  envMatch = /^(?<env>\w+)(:?\.classic)?\.lb\.adaptivecluster\.com/.exec(serviceUrl)
 
   if (envMatch) {
     return envMatch['groups'].env


### PR DESCRIPTION
The environment matcher currently falls back to "UNKNOWN" for classic environments. Aside from breaking the title in platform windows, this prevents Launcher from opening Reactive Analytics, as the URL is derived from the current environment.