### PR TITLE
feat(new-client): broadcast symbol on blotter row click

### DIFF
--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -1207,6 +1207,12 @@
         }
       }
     },
+    "@finos/fdc3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-1.2.0.tgz",
+      "integrity": "sha512-im/vqpS96qsCKMPkwR/Fg2t2FQtwh+/LOvTekIY0eYyuz/CZQoqhwcxwk/Re0pqJiA3inisV7DSfQ1JYLi+bxw==",
+      "dev": true
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@adaptive/hydra-platform": "^2.36.0",
+    "@finos/fdc3": "^1.2.0",
     "@react-rxjs/core": "^0.6.6",
     "@react-rxjs/utils": "^0.8.2",
     "axios": "^0.21.1",

--- a/src/new-client/src/App/Trades/TradesGrid/TradesGrid.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/TradesGrid.tsx
@@ -1,3 +1,4 @@
+import { broadcast } from "@finos/fdc3"
 import styled, { css } from "styled-components"
 import { TradeStatus } from "@/services/trades"
 import { colConfigs, colFields, useTableTrades } from "../TradesState"
@@ -79,6 +80,15 @@ const StatusIndicatorSpacer = styled.th`
 export const TradesGrid: React.FC = () => {
   const trades = useTableTrades()
 
+  const tryBroadcastContext = (symbol: string) => {
+    if (window.fdc3) {
+      broadcast({
+        type: "fdc3.instrument",
+        id: { ticker: symbol },
+      })
+    }
+  }
+
   return (
     <TableWrapper>
       <Table>
@@ -99,6 +109,7 @@ export const TradesGrid: React.FC = () => {
               <TableBodyRow
                 key={trade.tradeId}
                 pending={trade.status === TradeStatus.Pending}
+                onClick={() => tryBroadcastContext(trade.symbol)}
               >
                 <StatusIndicator
                   status={trade.status}


### PR DESCRIPTION
When clicking the blotter row, broadcast the currency pair symbol as FDC3 context (if an FDC3 Desktop Agent is running).