### PR TITLE
chore(new-client): mock services

### DIFF
--- a/src/new-client/src/OpenFin/index.tsx
+++ b/src/new-client/src/OpenFin/index.tsx
@@ -8,11 +8,13 @@ import { OpenFinApp } from "./OpenFinApp"
 import { connectToGateway } from "@adaptive/hydra-platform"
 import { noop } from "rxjs"
 
-connectToGateway({
-  url: import.meta.env.VITE_HYDRA_URL as string,
-  interceptor: noop,
-  useJson: true,
-})
+if (!import.meta.env.VITE_MOCKS) {
+  connectToGateway({
+    url: import.meta.env.VITE_HYDRA_URL as string,
+    interceptor: noop,
+    useJson: true,
+  })
+}
 
 ReactDOM.render(
   <StrictMode>

--- a/src/new-client/src/Web/index.tsx
+++ b/src/new-client/src/Web/index.tsx
@@ -13,11 +13,13 @@ import { TradesCoreDeferred } from "@/App/Trades"
 import { connectToGateway } from "@adaptive/hydra-platform"
 import { noop } from "rxjs"
 
-connectToGateway({
-  url: import.meta.env.VITE_HYDRA_URL as string,
-  interceptor: noop,
-  // useJson: true,
-})
+if (!import.meta.env.VITE_MOCKS) {
+  connectToGateway({
+    url: import.meta.env.VITE_HYDRA_URL as string,
+    interceptor: noop,
+    // useJson: true,
+  })
+}
 
 if (import.meta.env.PROD) {
   register({

--- a/src/new-client/src/services/analytics/analytics-mock.ts
+++ b/src/new-client/src/services/analytics/analytics-mock.ts
@@ -1,0 +1,110 @@
+import { bind, shareLatest } from "@react-rxjs/core"
+import { combineLatest, NEVER, Observable, of } from "rxjs"
+import { map } from "rxjs/operators"
+import { withIsStaleData } from "../connection"
+import { CurrencyPairPosition, HistoryEntry } from "./types"
+
+export const analytics$ = NEVER
+
+export const history$: Observable<HistoryEntry[]> = new Observable<
+  HistoryEntry[]
+>((observer) => {
+  let currentPrice = Math.random() * 10_000 - 5_000
+  let currentTime = Date.now()
+
+  let result: HistoryEntry[] = []
+
+  while (result.length < 90) {
+    result.unshift({
+      usPnl: currentPrice,
+      timestamp: currentTime,
+    })
+    currentPrice *= 1 + (Math.random() - 0.5) / 100
+    currentTime -= 10_000
+  }
+
+  observer.next(result)
+
+  const token = setInterval(() => {
+    currentPrice *= 1 + (Math.random() - 0.5) / 100
+    result = [
+      ...result.slice(1),
+      { usPnl: currentPrice, timestamp: Date.now() },
+    ]
+    observer.next(result)
+  }, 10_000)
+
+  return () => {
+    clearInterval(token)
+  }
+}).pipe(shareLatest())
+
+export const [useCurrentPositions, currentPositions$] = bind<
+  Record<string, CurrencyPairPosition>
+>(
+  of(
+    JSON.parse(`
+{
+  "NZDUSD": {
+    "symbol": "NZDUSD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "USDJPY": {
+    "symbol": "USDJPY",
+    "basePnl": 1382.312284932821,
+    "baseTradedAmount": -1000000,
+    "counterTradedAmount": 102144000
+  },
+  "GBPJPY": {
+    "symbol": "GBPJPY",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURJPY": {
+    "symbol": "EURJPY",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURCAD": {
+    "symbol": "EURCAD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURUSD": {
+    "symbol": "EURUSD",
+    "basePnl": 564.9717514123768,
+    "baseTradedAmount": -2000000,
+    "counterTradedAmount": 2726570
+  },
+  "EURAUD": {
+    "symbol": "EURAUD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "GBPUSD": {
+    "symbol": "GBPUSD",
+    "basePnl": -1656.8191508800955,
+    "baseTradedAmount": -1000000,
+    "counterTradedAmount": 1638980
+  },
+  "AUDUSD": {
+    "symbol": "AUDUSD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  }
+}
+            `),
+  ),
+)
+
+export const isAnalyticsDataStale$ = combineLatest([
+  withIsStaleData(currentPositions$),
+  withIsStaleData(history$),
+]).pipe(map(([current, historyPos]) => current || historyPos))

--- a/src/new-client/src/services/analytics/analytics.service-mock.ts
+++ b/src/new-client/src/services/analytics/analytics.service-mock.ts
@@ -1,0 +1,110 @@
+import { bind, shareLatest } from "@react-rxjs/core"
+import { combineLatest, NEVER, Observable, of } from "rxjs"
+import { map } from "rxjs/operators"
+import { withIsStaleData } from "../connection"
+import { CurrencyPairPosition, HistoryEntry } from "./types"
+
+export const analytics$ = NEVER
+
+export const history$: Observable<HistoryEntry[]> = new Observable<
+  HistoryEntry[]
+>((observer) => {
+  let currentPrice = Math.random() * 10_000 - 5_000
+  let currentTime = Date.now()
+
+  let result: HistoryEntry[] = []
+
+  while (result.length < 90) {
+    result.unshift({
+      usPnl: currentPrice,
+      timestamp: currentTime,
+    })
+    currentPrice *= 1 + (Math.random() - 0.5) / 100
+    currentTime -= 10_000
+  }
+
+  observer.next(result)
+
+  const token = setInterval(() => {
+    currentPrice *= 1 + (Math.random() - 0.5) / 100
+    result = [
+      ...result.slice(1),
+      { usPnl: currentPrice, timestamp: Date.now() },
+    ]
+    observer.next(result)
+  }, 10_000)
+
+  return () => {
+    clearInterval(token)
+  }
+}).pipe(shareLatest())
+
+export const [useCurrentPositions, currentPositions$] = bind<
+  Record<string, CurrencyPairPosition>
+>(
+  of(
+    JSON.parse(`
+{
+  "NZDUSD": {
+    "symbol": "NZDUSD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "USDJPY": {
+    "symbol": "USDJPY",
+    "basePnl": 1382.312284932821,
+    "baseTradedAmount": -1000000,
+    "counterTradedAmount": 102144000
+  },
+  "GBPJPY": {
+    "symbol": "GBPJPY",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURJPY": {
+    "symbol": "EURJPY",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURCAD": {
+    "symbol": "EURCAD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "EURUSD": {
+    "symbol": "EURUSD",
+    "basePnl": 564.9717514123768,
+    "baseTradedAmount": -2000000,
+    "counterTradedAmount": 2726570
+  },
+  "EURAUD": {
+    "symbol": "EURAUD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  },
+  "GBPUSD": {
+    "symbol": "GBPUSD",
+    "basePnl": -1656.8191508800955,
+    "baseTradedAmount": -1000000,
+    "counterTradedAmount": 1638980
+  },
+  "AUDUSD": {
+    "symbol": "AUDUSD",
+    "basePnl": 0,
+    "baseTradedAmount": 0,
+    "counterTradedAmount": 0
+  }
+}
+            `),
+  ),
+)
+
+export const isAnalyticsDataStale$ = combineLatest([
+  withIsStaleData(currentPositions$),
+  withIsStaleData(history$),
+]).pipe(map(([current, historyPos]) => current || historyPos))

--- a/src/new-client/src/services/analytics/analytics.ts
+++ b/src/new-client/src/services/analytics/analytics.ts
@@ -1,7 +1,7 @@
 import { AnalyticsService } from "@/generated/TradingGateway"
 import { bind, shareLatest } from "@react-rxjs/core"
 import { combineLatest, Observable } from "rxjs"
-import { filter, map, tap } from "rxjs/operators"
+import { filter, map } from "rxjs/operators"
 import { withIsStaleData } from "../connection"
 import { withConnection } from "../withConnection"
 import { CurrencyPairPosition, HistoryEntry } from "./types"
@@ -37,9 +37,4 @@ export const [useCurrentPositions, currentPositions$] = bind<
 export const isAnalyticsDataStale$ = combineLatest([
   withIsStaleData(currentPositions$),
   withIsStaleData(history$),
-]).pipe(
-  tap((x) => {
-    console.log("isAnalyticsDataStale$", x)
-  }),
-  map(([current, historyPos]) => current || historyPos),
-)
+]).pipe(map(([current, historyPos]) => current || historyPos))

--- a/src/new-client/src/services/connection.ts
+++ b/src/new-client/src/services/connection.ts
@@ -3,7 +3,7 @@ import {
   ConnectionStatus as HConnectionStatus,
 } from "@adaptive/hydra-platform"
 import { bind } from "@react-rxjs/core"
-import { combineLatest, Observable } from "rxjs"
+import { combineLatest, Observable, of } from "rxjs"
 import { distinctUntilChanged, filter, map, startWith } from "rxjs/operators"
 
 export enum ConnectionStatus {
@@ -23,7 +23,9 @@ const connectionMapper = (input: HConnectionStatus): ConnectionStatus =>
   mapper[input]
 
 export const [useConnectionStatus, connectionStatus$] = bind(
-  hConnectionStatus$().pipe(map(connectionMapper)),
+  import.meta.env.VITE_MOCKS
+    ? of(ConnectionStatus.CONNECTED)
+    : hConnectionStatus$().pipe(map(connectionMapper)),
   ConnectionStatus.CONNECTING,
 )
 

--- a/src/new-client/src/services/currencyPairs/currencyPairs.service-mock.ts
+++ b/src/new-client/src/services/currencyPairs/currencyPairs.service-mock.ts
@@ -1,0 +1,90 @@
+import { bind } from "@react-rxjs/core"
+import { of } from "rxjs"
+import { delay, distinctUntilChanged, map } from "rxjs/operators"
+import { CurrencyPair } from "./types"
+
+const fakeData: Record<string, CurrencyPair> = {
+  EURUSD: {
+    symbol: "EURUSD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "EUR",
+    terms: "USD",
+    defaultNotional: 1000000,
+  },
+  USDJPY: {
+    symbol: "USDJPY",
+    ratePrecision: 3,
+    pipsPosition: 2,
+    base: "USD",
+    terms: "JPY",
+    defaultNotional: 1000000,
+  },
+  GBPUSD: {
+    symbol: "GBPUSD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "GBP",
+    terms: "USD",
+    defaultNotional: 1000000,
+  },
+  GBPJPY: {
+    symbol: "GBPJPY",
+    ratePrecision: 3,
+    pipsPosition: 2,
+    base: "GBP",
+    terms: "JPY",
+    defaultNotional: 1000000,
+  },
+  EURJPY: {
+    symbol: "EURJPY",
+    ratePrecision: 3,
+    pipsPosition: 2,
+    base: "EUR",
+    terms: "JPY",
+    defaultNotional: 1000000,
+  },
+  AUDUSD: {
+    symbol: "AUDUSD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "AUD",
+    terms: "USD",
+    defaultNotional: 1000000,
+  },
+  NZDUSD: {
+    symbol: "NZDUSD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "NZD",
+    terms: "USD",
+    defaultNotional: 10000000,
+  },
+  EURCAD: {
+    symbol: "EURCAD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "EUR",
+    terms: "CAD",
+    defaultNotional: 1000000,
+  },
+  EURAUD: {
+    symbol: "EURAUD",
+    ratePrecision: 5,
+    pipsPosition: 4,
+    base: "EUR",
+    terms: "AUD",
+    defaultNotional: 1000000,
+  },
+}
+
+export const [useCurrencyPairs, currencyPairs$] = bind<
+  Record<string, CurrencyPair>
+>(of(fakeData).pipe(delay(1_000)))
+
+export const [useCurrencyPair, getCurrencyPair$] = bind((symbol: string) =>
+  currencyPairs$.pipe(
+    map((currencyPairs) => currencyPairs[symbol]),
+    distinctUntilChanged(),
+  ),
+)

--- a/src/new-client/src/services/executions/executions.service-mock.ts
+++ b/src/new-client/src/services/executions/executions.service-mock.ts
@@ -1,0 +1,47 @@
+import { Observable, race, Subject, timer } from "rxjs"
+import { mapTo, tap } from "rxjs/operators"
+import {
+  ExecutionRequest,
+  ExecutionTrade,
+  ExecutionStatus,
+  TimeoutExecution,
+} from "./types"
+
+const executionsSubject = new Subject<ExecutionTrade>()
+
+let id = 1
+
+export const execute$ = (
+  execution: ExecutionRequest,
+): Observable<ExecutionTrade | TimeoutExecution> => {
+  const time =
+    execution.currencyPair === "EURJPY" ? 4_000 : Math.random() * 2_000
+  const status: ExecutionStatus.Done | ExecutionStatus.Rejected =
+    execution.currencyPair === "GBPJPY"
+      ? ExecutionStatus.Rejected
+      : ExecutionStatus.Done
+
+  const execution$: Observable<ExecutionTrade> = timer(time).pipe(
+    mapTo({
+      ...execution,
+      tradeId: id++,
+      status,
+      valueDate: new Date(),
+      tradeDate: new Date(),
+    }),
+    tap((exec) => {
+      executionsSubject.next(exec)
+    }),
+  )
+
+  const timeout$ = timer(30_000).pipe(
+    mapTo({
+      ...execution,
+      status: ExecutionStatus.Timeout,
+    } as TimeoutExecution),
+  )
+
+  return race([execution$, timeout$])
+}
+
+export const executions$ = executionsSubject.asObservable()

--- a/src/new-client/src/services/executions/executions.ts
+++ b/src/new-client/src/services/executions/executions.ts
@@ -37,7 +37,8 @@ const mapResponseToTrade =
       spotRate: trade.spotRate,
       status: ExecutionStatus[trade.status],
       tradeId: Number(trade.tradeId), // TODO: talk with hydra team
-      valueDate: trade.valueDate,
+      tradeDate: new Date(),
+      valueDate: new Date(trade.valueDate),
       id,
     }
   }

--- a/src/new-client/src/services/executions/index.ts
+++ b/src/new-client/src/services/executions/index.ts
@@ -1,4 +1,4 @@
-export { execute$ } from "./executions"
+export * from "./executions"
 export { ExecutionStatus, RawExecutionStatus } from "./types"
 export type {
   ExecutionRequest,

--- a/src/new-client/src/services/executions/types.ts
+++ b/src/new-client/src/services/executions/types.ts
@@ -50,7 +50,8 @@ export enum ExecutionStatus {
 export interface ExecutionTrade extends ExecutionRequest {
   status: ExecutionStatus.Done | ExecutionStatus.Rejected
   tradeId: number
-  valueDate: string
+  valueDate: Date
+  tradeDate: Date
 }
 
 export interface TimeoutExecution extends ExecutionRequest {

--- a/src/new-client/src/services/prices/prices.service-mock.ts
+++ b/src/new-client/src/services/prices/prices.service-mock.ts
@@ -1,0 +1,80 @@
+import { bind } from "@react-rxjs/core"
+import { Observable, of } from "rxjs"
+import { scan, map } from "rxjs/operators"
+import { PriceMovementType, HistoryPrice, Price } from "./types"
+
+function* makePriceGenerator(
+  symbol: string,
+): Generator<HistoryPrice, HistoryPrice, HistoryPrice> {
+  let mid = Math.trunc(Math.random() * 1_000_000) / 100_000
+  while (true) {
+    const now = new Date()
+    const price: HistoryPrice = {
+      ask: mid + 0.0002,
+      mid,
+      bid: mid - 0.0002,
+      creationTimestamp: now.getTime(),
+      symbol,
+      valueDate: [now.getFullYear(), now.getMonth() + 1, now.getDate()]
+        .map((x) => x.toString().padStart(2, "0"))
+        .join("-"),
+    }
+    yield price
+    mid = mid * (1 + (Math.random() > 0.5 ? 0.0001 : -0.0001))
+  }
+}
+
+const [, getSymbolPrices$] = bind(
+  (symbol: string) =>
+    new Observable<HistoryPrice[]>((observer) => {
+      const priceGenerator = makePriceGenerator(symbol)
+      let prices: HistoryPrice[] = []
+      for (let i = 0; i < 50; i++) {
+        prices.push(priceGenerator.next().value)
+      }
+      observer.next(prices)
+
+      let token: any = 0
+
+      const scheduleNextPrice = () => {
+        token = setTimeout(() => {
+          prices = prices.slice(1).concat(priceGenerator.next().value)
+          observer.next(prices)
+          scheduleNextPrice()
+        }, Math.max(150, Math.random() * 1000))
+      }
+
+      scheduleNextPrice()
+
+      return () => {
+        clearTimeout(token)
+      }
+    }),
+)
+
+export const [, getIsSymbolDataStale$] = bind((_: string) => of(false))
+
+export const [usePrice, getPrice$] = bind((symbol: string) =>
+  getSymbolPrices$(symbol).pipe(
+    map((prices) => prices[prices.length - 1]),
+    scan(
+      (acc, price) => ({
+        ...price,
+        movementType:
+          acc === undefined
+            ? PriceMovementType.NONE
+            : price.mid > acc.mid
+            ? PriceMovementType.UP
+            : PriceMovementType.DOWN,
+      }),
+      undefined as any as Price,
+    ),
+  ),
+)
+
+export const [useHistoricalPrices, getHistoricalPrices$] = bind<
+  [string],
+  HistoryPrice[]
+>((symbol: string) =>
+  getSymbolPrices$(symbol).pipe(map((prices) => prices.slice(0, -1))),
+)

--- a/src/new-client/src/services/trades/trades.service-mock.ts
+++ b/src/new-client/src/services/trades/trades.service-mock.ts
@@ -1,0 +1,21 @@
+import { bind } from "@react-rxjs/core"
+import { map, scan, startWith } from "rxjs/operators"
+import { withIsStaleData } from "../connection"
+import { executions$ } from "../executions"
+import { Trade } from "./types"
+
+export const [useTrades, trades$] = bind<Trade[]>(
+  executions$.pipe(
+    scan(
+      (acc, trade) => ({
+        ...acc,
+        [trade.id]: trade,
+      }),
+      {} as Record<number, Trade>,
+    ),
+    map((trades) => Object.values(trades).reverse()),
+    startWith([]),
+  ),
+)
+
+export const isBlotterDataStale$ = withIsStaleData(trades$)


### PR DESCRIPTION
Habemus mocks!

How to use the mocks?

```bash
VITE_MOCKS=true npm start
```

One of the goals was that I wanted to make sure that the code of the mocks didn't end up being bundle into the production build. In order to accomplish that I've created (with the help of @voliva ) a vite plugin that  what it does is: whenever we are running with the `VITE_MOCKS` env variable, then when importing a file, if that file has a sibling that ends with `.service-mock`, then it would load that file instead of the original one... That's it.

Some parts of the mocks try to mimic a little bit the real UX, like when a trade is executed/rejecte it appears in the blotter, other parts (analytics) are completely disconnected from user actions... These things can be improved in the future. At least now we can work without a hydra BE up and running :slightly_smiling_face: .