### PR TITLE
1185 finsemble target, basic app with router to support rtc-finsemble

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,7 +3,7 @@ name: Branch build
 on:
   push:
     paths:
-    - 'src/new-client/**'
+      - 'src/new-client/**'
 
 defaults:
   run:
@@ -12,6 +12,7 @@ defaults:
 env:
   BUCKET_WEB: reactive-trader-web-builds
   BUCKET_OPENFIN: reactive-trader-openfin-builds
+  BUCKET_FINSEMBLE: reactive-trader-finsemble-builds
   VITE_HYDRA_URL: wss://trading-web-gateway-rt.demo.hydra.weareadaptive.com
 
 jobs:
@@ -21,61 +22,73 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Set variables
-      id: vars
-      run: echo "::set-output name=branch::$(git branch --show-current | sed 's/\//_/g')"
+      - name: Set variables
+        id: vars
+        run: echo "::set-output name=branch::$(git branch --show-current | sed 's/\//_/g')"
 
-    - name: Set up GCloud
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-        service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+      - name: Set up GCloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-    - name: Decrypt NPM credentials
-      run: |
-        gcloud kms decrypt \
-          --ciphertext-file=npmrc.enc \
-          --plaintext-file=.npmrc \
-          --location=global \
-          --keyring=rt-keyring \
-          --key=npmrc-key
+      - name: Decrypt NPM credentials
+        run: |
+          gcloud kms decrypt \
+            --ciphertext-file=npmrc.enc \
+            --plaintext-file=.npmrc \
+            --location=global \
+            --keyring=rt-keyring \
+            --key=npmrc-key
 
-    - name: Install
-      run: npm ci
+      - name: Install
+        run: npm ci
 
-    - name: Build (web)
-      env:
-        BASE_URL: /branch/${{ steps.vars.outputs.branch }}
-      run: npm run build
+      - name: Build (web)
+        env:
+          BASE_URL: /branch/${{ steps.vars.outputs.branch }}
+        run: npm run build
 
-    - name: Deploy (web)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_WEB/branch/${{ steps.vars.outputs.branch }}
+      - name: Deploy (web)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_WEB/branch/${{ steps.vars.outputs.branch }}
 
-    - name: Build (OpenFin)
-      env:
-        BASE_URL: /branch/${{ steps.vars.outputs.branch }}
-      run: npm run openfin:build
+      - name: Build (OpenFin)
+        env:
+          BASE_URL: /branch/${{ steps.vars.outputs.branch }}
+        run: npm run openfin:build
 
-    - name: Generate manifest (OpenFin)
-      env:
-        OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
-      run: |
-        ./scripts/build_openfin_manifest \
-          -b ${{ env.OPENFIN_DOMAIN }}/branch/${{ steps.vars.outputs.branch }} \
-          -e ""
+      - name: Generate manifest (OpenFin)
+        env:
+          OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
+        run: |
+          ./scripts/build_openfin_manifest \
+            -b ${{ env.OPENFIN_DOMAIN }}/branch/${{ steps.vars.outputs.branch }} \
+            -e ""
 
-    - name: Deploy (OpenFin)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_OPENFIN/branch/${{ steps.vars.outputs.branch }}
+      - name: Deploy (OpenFin)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_OPENFIN/branch/${{ steps.vars.outputs.branch }}
+
+      - name: Build (Finsemble)
+        env:
+          BASE_URL: /branch/${{ steps.vars.outputs.branch }}
+        run: npm run finsemble:build
+
+      - name: Deploy (Finsemble)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_FINSEMBLE/branch/${{ steps.vars.outputs.branch }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -3,7 +3,7 @@ name: Commit build
 on:
   push:
     paths:
-    - 'src/new-client/**'
+      - 'src/new-client/**'
 
 defaults:
   run:
@@ -12,6 +12,7 @@ defaults:
 env:
   BUCKET_WEB: reactive-trader-web-builds
   BUCKET_OPENFIN: reactive-trader-openfin-builds
+  BUCKET_FINSEMBLE: reactive-trader-finsemble-builds
   VITE_HYDRA_URL: wss://trading-web-gateway-rt.demo.hydra.weareadaptive.com
 
 jobs:
@@ -21,61 +22,73 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Set variables
-      id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD | cut -c1-8)"
+      - name: Set variables
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD | cut -c1-8)"
 
-    - name: Set up GCloud
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-        service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+      - name: Set up GCloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-    - name: Decrypt NPM credentials
-      run: |
-        gcloud kms decrypt \
-          --ciphertext-file=npmrc.enc \
-          --plaintext-file=.npmrc \
-          --location=global \
-          --keyring=rt-keyring \
-          --key=npmrc-key
+      - name: Decrypt NPM credentials
+        run: |
+          gcloud kms decrypt \
+            --ciphertext-file=npmrc.enc \
+            --plaintext-file=.npmrc \
+            --location=global \
+            --keyring=rt-keyring \
+            --key=npmrc-key
 
-    - name: Install
-      run: npm ci
+      - name: Install
+        run: npm ci
 
-    - name: Build (web)
-      env:
-        BASE_URL: /commit/${{ steps.vars.outputs.sha_short }}
-      run: npm run build
+      - name: Build (web)
+        env:
+          BASE_URL: /commit/${{ steps.vars.outputs.sha_short }}
+        run: npm run build
 
-    - name: Deploy (web)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_WEB/commit/${{ steps.vars.outputs.sha_short }}
+      - name: Deploy (web)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_WEB/commit/${{ steps.vars.outputs.sha_short }}
 
-    - name: Build (OpenFin)
-      env:
-        BASE_URL: /commit/${{ steps.vars.outputs.sha_short }}
-      run: npm run openfin:build
+      - name: Build (OpenFin)
+        env:
+          BASE_URL: /commit/${{ steps.vars.outputs.sha_short }}
+        run: npm run openfin:build
 
-    - name: Generate manifest (OpenFin)
-      env:
-        OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
-      run: |
-        ./scripts/build_openfin_manifest \
-          -b ${{ env.OPENFIN_DOMAIN }}/commit/${{ steps.vars.outputs.sha_short }} \
-          -e ""
+      - name: Generate manifest (OpenFin)
+        env:
+          OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
+        run: |
+          ./scripts/build_openfin_manifest \
+            -b ${{ env.OPENFIN_DOMAIN }}/commit/${{ steps.vars.outputs.sha_short }} \
+            -e ""
 
-    - name: Deploy (OpenFin)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_OPENFIN/commit/${{ steps.vars.outputs.sha_short }}
+      - name: Deploy (OpenFin)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_OPENFIN/commit/${{ steps.vars.outputs.sha_short }}
+
+      - name: Build (Finsemble)
+        env:
+          BASE_URL: /commit/${{ steps.vars.outputs.sha_short }}
+        run: npm run finsemble:build
+
+      - name: Deploy (Finsemble)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_FINSEMBLE/commit/${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -3,10 +3,10 @@ name: Pull request build
 on:
   pull_request:
     types:
-    - opened
-    - synchronize
+      - opened
+      - synchronize
     paths:
-    - 'src/new-client/**'
+      - 'src/new-client/**'
 
 defaults:
   run:
@@ -15,6 +15,7 @@ defaults:
 env:
   BUCKET_WEB: reactive-trader-web-builds
   BUCKET_OPENFIN: reactive-trader-openfin-builds
+  BUCKET_FINSEMBLE: reactive-trader-finsemble-builds
   VITE_HYDRA_URL: wss://trading-web-gateway-rt.demo.hydra.weareadaptive.com
 
 jobs:
@@ -23,91 +24,104 @@ jobs:
 
     runs-on: ubuntu-20.04
 
-    if: "!github.event.pull_request.header.repo.fork"
+    if: '!github.event.pull_request.header.repo.fork'
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Set up GCloud
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-        service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+      - name: Set up GCloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-    - name: Decrypt NPM credentials
-      run: |
-        gcloud kms decrypt \
-          --ciphertext-file=npmrc.enc \
-          --plaintext-file=.npmrc \
-          --location=global \
-          --keyring=rt-keyring \
-          --key=npmrc-key
+      - name: Decrypt NPM credentials
+        run: |
+          gcloud kms decrypt \
+            --ciphertext-file=npmrc.enc \
+            --plaintext-file=.npmrc \
+            --location=global \
+            --keyring=rt-keyring \
+            --key=npmrc-key
 
-    - name: Install
-      run: npm ci
+      - name: Install
+        run: npm ci
 
-    - name: Build (web)
-      env:
-        BASE_URL: /pull/${{ github.event.number }}
-      run: npm run build
+      - name: Build (web)
+        env:
+          BASE_URL: /pull/${{ github.event.number }}
+        run: npm run build
 
-    - name: Deploy (web)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_WEB/pull/${{ github.event.number }}
+      - name: Deploy (web)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_WEB/pull/${{ github.event.number }}
 
-    - name: Build (OpenFin)
-      env:
-        BASE_URL: /pull/${{ github.event.number }}
-      run: npm run openfin:build
+      - name: Build (OpenFin)
+        env:
+          BASE_URL: /pull/${{ github.event.number }}
+        run: npm run openfin:build
 
-    - name: Generate manifest (OpenFin)
-      env:
-        OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
-      run: |
-        ./scripts/build_openfin_manifest \
-          -b ${{ env.OPENFIN_DOMAIN }}/pull/${{ github.event.number }} \
-          -e ""
+      - name: Generate manifest (OpenFin)
+        env:
+          OPENFIN_DOMAIN: https://openfin.env.reactivetrader.com
+        run: |
+          ./scripts/build_openfin_manifest \
+            -b ${{ env.OPENFIN_DOMAIN }}/pull/${{ github.event.number }} \
+            -e ""
 
-    - name: Deploy (OpenFin)
-      run: |
-        gsutil -m \
-          -h "Cache-Control: no-cache" \
-          rsync -d -r dist \
-          gs://$BUCKET_OPENFIN/pull/${{ github.event.number }}
+      - name: Deploy (OpenFin)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_OPENFIN/pull/${{ github.event.number }}
 
-    - name: Find comment
-      uses: peter-evans/find-comment@v1
-      id: comment
-      with:
-        issue-number: ${{ github.event.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: '(auto-deploy)'
+      - name: Build (Finsemble)
+        env:
+          BASE_URL: /pull/${{ github.event.number }}
+        run: npm run finsemble:build
 
-    - name: Create comment (if not exists)
-      if: ${{ steps.comment.outputs.comment-id == 0 }}
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        issue-number: ${{ github.event.number }}
-        body: |
-          (auto-deploy) A deployment has been created for this Pull Request
+      - name: Deploy (Finsemble)
+        run: |
+          gsutil -m \
+            -h "Cache-Control: no-cache" \
+            rsync -d -r dist \
+            gs://$BUCKET_FINSEMBLE/pull/${{ github.event.number }}
 
-          ### Preview links
+      - name: Find comment
+        uses: peter-evans/find-comment@v1
+        id: comment
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '(auto-deploy)'
 
-          As part of the code review process, please ensure that you test against the following
+      - name: Create comment (if not exists)
+        if: ${{ steps.comment.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            (auto-deploy) A deployment has been created for this Pull Request
 
-          | Version | URL                                                                                     |
-          | :--     | :--                                                                                     |
-          | Web     | https://env.reactivetrader.com/pull/${{ github.event.number }}                          |
-          | OpenFin | https://openfin.env.reactivetrader.com/pull/${{ github.event.number }}/config/app.json |
+            ### Preview links
 
-          ### Performance
+            As part of the code review process, please ensure that you test against the following
 
-          Please ensure that this PR does not degrade the performance of the UI. We should maintain a performance score of 95+.
+            | Version   | URL                                                                                     |
+            | :--       | :--                                                                                     |
+            | Web       | https://env.reactivetrader.com/pull/${{ github.event.number }}                          |
+            | OpenFin   | https://openfin.env.reactivetrader.com/pull/${{ github.event.number }}/config/app.json |
+            | Finsemble | https://finsemble.env.reactivetrader.com/pull/${{ github.event.number }}                |
 
-          https://developers.google.com/speed/pagespeed/insights/?url=https://env.reactivetrader.com/pull/${{ github.event.number }}
+            ### Performance
+
+            Please ensure that this PR does not degrade the performance of the UI. We should maintain a performance score of 95+.
+
+            https://developers.google.com/speed/pagespeed/insights/?url=https://env.reactivetrader.com/pull/${{ github.event.number }}

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -30,6 +30,8 @@
     "openfin:build": "TARGET=openfin vite build",
     "openfin:start": "concurrently \"./scripts/build_openfin_manifest -s\" \"npm:openfin:dev\" \"npm:openfin:run\"",
     "openfin:run": "wait-on -l http://localhost:1917/config/app.json && openfin -c http://localhost:1917/config/app.json -l",
+    "finsemble:dev": "TARGET=finsemble vite",
+    "finsemble:build": "TARGET=finsemble vite build",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "generateCod": "hydra-web-codegen -i trading-gateway.hyer -o src/generated"
   },

--- a/src/new-client/src/Finsemble/FinsembleApp.tsx
+++ b/src/new-client/src/Finsemble/FinsembleApp.tsx
@@ -1,0 +1,68 @@
+import { Subscribe } from "@react-rxjs/core"
+import { BrowserRouter, Route, Switch } from "react-router-dom"
+
+import { Analytics } from "@/App/Analytics"
+import { LiveRates } from "@/App/LiveRates"
+import { TileView } from "@/App/LiveRates/selectedView"
+import { Trades } from "@/App/Trades"
+import { Loader } from "@/components/Loader"
+import { DocTitle } from "@/components/DocTitle"
+import { TileContent } from "./TileContent"
+
+export const FinsembleApp: React.FC = () => (
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <Switch>
+      <Route
+        path="/analytics"
+        render={() => (
+          <DocTitle title="Analytics">
+            <Analytics hideIfMatches={null} />
+          </DocTitle>
+        )}
+      />
+      <Route
+        path="/blotter"
+        render={() => (
+          <DocTitle title="Trades">
+            <Trades />
+          </DocTitle>
+        )}
+      />
+      <Route
+        path="/tiles"
+        render={() => (
+          <DocTitle title="Live Rates">
+            <LiveRates />
+          </DocTitle>
+        )}
+      />
+      <Route
+        path="/spot/:symbol"
+        render={({
+          location: { search },
+          match: {
+            params: { symbol },
+          },
+        }) => {
+          const query = new URLSearchParams(search)
+          const view = query.has("tileView")
+            ? (query.get("tileView") as TileView)
+            : TileView.Analytics
+
+          const loader = (
+            <Loader
+              ariaLabel="Loading live FX exchange rates"
+              minWidth="22rem"
+              minHeight="22rem"
+            />
+          )
+          return (
+            <Subscribe fallback={loader}>
+              <TileContent symbol={symbol} view={view} />
+            </Subscribe>
+          )
+        }}
+      />
+    </Switch>
+  </BrowserRouter>
+)

--- a/src/new-client/src/Finsemble/TileContent.tsx
+++ b/src/new-client/src/Finsemble/TileContent.tsx
@@ -1,0 +1,19 @@
+import { TileView } from "@/App/LiveRates/selectedView"
+import { Tile } from "@/App/LiveRates/Tile"
+import { useCurrencyPair } from "@/services/currencyPairs"
+
+interface TileContentProps {
+  symbol: string
+  view: TileView
+}
+
+export const TileContent: React.FC<TileContentProps> = ({ symbol, view }) => {
+  const currencyPair = useCurrencyPair(symbol)
+  return (
+    <Tile
+      key={symbol}
+      currencyPair={currencyPair}
+      isAnalytics={view === TileView.Analytics}
+    />
+  )
+}

--- a/src/new-client/src/Finsemble/index.tsx
+++ b/src/new-client/src/Finsemble/index.tsx
@@ -1,0 +1,44 @@
+import { StrictMode } from "react"
+import ReactDOM from "react-dom"
+import { GA_TRACKING_ID } from "@/constants"
+import GlobalStyle from "@/theme/globals"
+import { GlobalScrollbarStyle, ThemeProvider } from "@/theme"
+import { FinsembleApp } from "./FinsembleApp"
+
+import { connectToGateway } from "@adaptive/hydra-platform"
+import { noop } from "rxjs"
+
+if (!import.meta.env.VITE_MOCKS) {
+  connectToGateway({
+    url: import.meta.env.VITE_HYDRA_URL as string,
+    interceptor: noop,
+    useJson: true,
+  })
+}
+
+ReactDOM.render(
+  <StrictMode>
+    <GlobalStyle />
+    <ThemeProvider>
+      <GlobalScrollbarStyle />
+      <FinsembleApp />
+    </ThemeProvider>
+  </StrictMode>,
+  document.getElementById("root"),
+)
+
+const { ga } = window
+
+ga("create", {
+  trackingId: GA_TRACKING_ID,
+  transport: "beacon",
+})
+
+ga("set", {
+  dimension1: "finsemble",
+  dimension2: "finsemble",
+  dimension3: import.meta.env,
+  page: window.location.pathname,
+})
+
+ga("send", "pageview")

--- a/src/new-client/src/index.tsx
+++ b/src/new-client/src/index.tsx
@@ -5,13 +5,15 @@ async function main() {
     await import("@/Web")
   } else if (__TARGET__ === "openfin") {
     await import("@/OpenFin")
+  } else if (__TARGET__ === "finsemble") {
+    await import("@/Finsemble")
   }
 }
 
 main()
 
 declare global {
-  const __TARGET__: "web" | "openfin"
+  const __TARGET__: "web" | "openfin" | "finsemble"
 
   interface Window {
     ga: any


### PR DESCRIPTION
Simplest entry point app for Finsemble, and script entries.
Tested out with `VITE_MOCKS=true`  running with https://github.com/AdaptiveConsulting/ReactiveTraderCloud-Finsemble configured to address `http://localhost:1917` as root.

Update: now tested against the deployed target: 
`		"componentRoot": "https://finsemble.env.reactivetrader.com/pull/1923",`
