### PR TITLE
Chore/openfin manifest handling vite rollup

### DIFF
--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -2451,11 +2451,30 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "8.1.2",
+      "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+      "integrity": "sha1-cSXMLkvdm9L8gwBf/bHQugDMph8=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/geojson": {
       "version": "7946.0.7",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
       "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
       "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.4",
+      "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/@types/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha1-6lniHS7lxReRTLS8jkFTuZ5WZnI=",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -2535,6 +2554,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A=",
       "dev": true
     },
     "@types/minimist": {
@@ -9888,6 +9913,49 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
+      }
+    },
+    "rollup-plugin-copy": {
+      "version": "3.4.0",
+      "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
+      "integrity": "sha1-8SKKP/tm/62GBuLz+3/yMUHtMoY=",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "10.0.1",
+          "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/globby/-/globby-10.0.1.tgz",
+          "integrity": "sha1-R4LDTLdd1oM1EzXFgpzDQg5gayI=",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc=",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "3.0.1",
+          "resolved": "https://cglcloud.jfrog.io/artifactory/api/npm/npm-remote/is-plain-object/-/is-plain-object-3.0.1.tgz",
+          "integrity": "sha1-Zi2S0kwKpDAkB7DUXSHyJRyF+Fs=",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-modulepreload": {

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -28,8 +28,8 @@
     "serve": "TARGET=web vite preview",
     "openfin:dev": "TARGET=openfin vite",
     "openfin:build": "TARGET=openfin vite build",
-    "openfin:start": "concurrently \"./scripts/build_openfin_manifest -s\" \"npm:openfin:dev\" \"npm:openfin:run\"",
-    "openfin:run": "wait-on -l http://localhost:1917/config/app.json && openfin -c http://localhost:1917/config/app.json -l",
+    "openfin:start": "concurrently \"npm:openfin:dev\" \"npm:openfin:run\"",
+    "openfin:run": "wait-on -l http://localhost:1917/dist/config/app.json && openfin -c http://localhost:1917/dist/config/app.json -l",
     "format": "prettier --write README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "generateCod": "hydra-web-codegen -i trading-gateway.hyer -o src/generated"
   },
@@ -99,6 +99,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-test-renderer": "^17.0.2",
+    "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-modulepreload": "^1.2.3",
     "rollup-plugin-typescript2": "^0.30.0",
     "rollup-plugin-workbox": "^6.1.1",


### PR DESCRIPTION
I was curious, so I tried to get the static file transform going (as previous efforts in webpack-land) - this seems to work well, in development (dev server + es modules) and prod (rollup bundling -> dist) modes
The rollup copy plugin always copies to dist, hence a small change in the local openfin manifest URL