### PR TITLE
fix: rfq pricing colours (BUG-1189)

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.styles.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.styles.tsx
@@ -44,7 +44,10 @@ export const TradeButton = styled.button<{
 }>`
   background-color: ${({ theme }) => theme.core.lightBackground};
   border-radius: 3px;
-  color: ${({ theme }) => theme.core.textColor};
+  color: ${({ theme, priceAnnounced, direction }) =>
+    priceAnnounced
+      ? theme.colors.spectrum.uniqueCollections[direction].base
+      : theme.core.textColor};
   transition: background-color 0.2s ease;
   cursor: pointer;
   border: none;

--- a/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
@@ -23,7 +23,7 @@ import {
 } from "./PriceButton.styles"
 import { of } from "rxjs"
 import { useIsNotionalValid } from "../Notional/Notional"
-import { getRfqPayload$ } from "../Rfq/Rfq.state"
+import { getRfqPayload$, QuoteState } from "../Rfq/Rfq.state"
 
 const getPriceByDirection$ = (symbol: string, direction: Direction) =>
   getPrice$(symbol).pipe(
@@ -58,7 +58,8 @@ const formatToMin2IntDigits = customNumberFormatter({
 
 const PriceButtonInner: React.FC<{
   direction: Direction
-}> = ({ direction }) => {
+  rfqQuoteState: QuoteState
+}> = ({ direction, rfqQuoteState }) => {
   const { pipsPosition, ratePrecision, symbol } = useTileCurrencyPair()
   const { price, isExpired } = usePrice(symbol, direction)
   const isNotionalValid = useIsNotionalValid()
@@ -85,7 +86,7 @@ const PriceButtonInner: React.FC<{
       onClick={() => {
         sendExecution(symbol, direction)
       }}
-      priceAnnounced={false}
+      priceAnnounced={rfqQuoteState.stage === QuoteStateStage.Received}
       disabled={disabled}
     >
       <Price disabled={disabled}>
@@ -118,6 +119,6 @@ export const PriceButton: React.FC<{
       Awaiting Price
     </QuotePriceLoading>
   ) : (
-    <PriceButtonInner direction={direction} />
+    <PriceButtonInner direction={direction} rfqQuoteState={rfqState} />
   )
 }


### PR DESCRIPTION
Match the previous behaviour when quoting an RFQ

**Before:**
![RFQColoursAfter](https://user-images.githubusercontent.com/54838842/129024432-878b8aae-97e1-4989-afa9-4cc3be03c661.gif)

**After:**
![RFQColoursAfter2](https://user-images.githubusercontent.com/54838842/129024435-3fe43831-7ac7-43d1-b40b-547f4c514568.gif)

