### PR TITLE
fix: vite config for Windows (BUG-1193)

### DIFF
--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -126,9 +126,13 @@ const setConfig = ({ mode }) => {
       port: 1917,
     },
     resolve: {
-      alias: {
-        "@/": resolve(__dirname, "src"),
-      },
+      alias: [
+        {
+          // see https://github.com/vitejs/vite/issues/279#issuecomment-773454743
+          find: "@",
+          replacement: "/src",
+        },
+      ],
     },
     plugins,
   })

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -25,10 +25,8 @@ function apiMockReplacerPlugin(): Plugin {
 
       // Set the id of this file to the one importing it marked with our suffix
       // so we can load it in the load hook below
-      return this.resolve(
-        path.join(file.dir, `${file.name}.service-mock.ts`),
-        importer,
-      )
+      const mockPath = `${file.dir}/${file.name}.service-mock.ts`
+      return this.resolve(mockPath, importer)
     },
   }
 }
@@ -129,7 +127,7 @@ const setConfig = ({ mode }) => {
     },
     resolve: {
       alias: {
-        "@": resolve(__dirname, "src"),
+        "@/": resolve(__dirname, "src"),
       },
     },
     plugins,


### PR DESCRIPTION
couple of small fixes for Windows dev env
- @ -> src alias in vite config updated to find/replacement form fixes import failures and now works across the o/s platforms
- path mod in mocks resolution (always POSIX paths)