### PR TITLE
fix(client): Mobile > Trade confirmation cuts off

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/ExecutionResponse/Pending.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/ExecutionResponse/Pending.tsx
@@ -4,7 +4,9 @@ import { OverlayDiv } from "@/components/OverlayDiv"
 import { CenteringContainer } from "@/components/CenteringContainer"
 
 const PendingContainer = styled(OverlayDiv)`
-  margin-left: -100%;
+  // Solution to stack flex child ontop of another, height is not respected in safari
+  // margin-left: -100%;
+  position: absolute;
 `
 
 const PendingPill = styled("div")`

--- a/src/new-client/src/App/LiveRates/Tile/ExecutionResponse/Response.styles.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/ExecutionResponse/Response.styles.tsx
@@ -25,7 +25,9 @@ export const ExecutionStatusAlertContainer = styled(OverlayDiv)<{
   font-weight: bolder;
   justify-content: space-evenly;
   color: ${({ theme }) => theme.white};
-  margin-left: -100%;
+  // Solution to stack flex child ontop of another, height is not respected in safari
+  // margin-left: -100%;
+  position: absolute;
 `
 
 export const TradeIdDiv = styled.div`

--- a/src/new-client/src/services/trades/index.ts
+++ b/src/new-client/src/services/trades/index.ts
@@ -1,4 +1,5 @@
+import * as tradesTestData from "./__mocks__/mockTrades"
 export * from "./trades"
-export * as tradesTestData from "./__mocks__/mockTrades"
 export { Direction, TradeStatus } from "./types"
 export type { Trade } from "./types"
+export { tradesTestData }


### PR DESCRIPTION
Position `ExecutionMessage` & `Pending` absolutely to fix trade confirmation UI on safari (mobile and desktop

**Before**
<img width="366" alt="Screenshot 2021-09-29 at 13 20 52" src="https://user-images.githubusercontent.com/50445182/135267901-24fea65e-54aa-4a83-b053-d011cc51c3e4.png">

**After**
<img width="373" alt="Screenshot 2021-09-29 at 13 21 15" src="https://user-images.githubusercontent.com/50445182/135267915-3f27af21-6865-4d5f-b35c-58548b6db733.png">

