### PR TITLE
feat(client): Reload application after 1 hour

### DIFF
--- a/src/new-client/src/index.tsx
+++ b/src/new-client/src/index.tsx
@@ -1,11 +1,20 @@
 import main from "./main"
 
 declare global {
-  const __TARGET__: "web" | "openfin" | "finsemble"
-
   interface Window {
     ga: any
   }
 }
 
 main()
+
+// Google Cloud Run kills all ws connections after 1 hour
+// Reload the application to establish a new connection and avoid staring at the DisconnectionOverlay indefinitely
+// This is a temporary measure while we have the GCR limitation
+const reloadAfter1Hour = () => {
+  setTimeout(() => {
+    window.location.reload()
+  }, 60 * 1000)
+}
+
+reloadAfter1Hour()


### PR DESCRIPTION
Google Cloud Run kills all websocket connections after 1 hour
Reload the application to establish a new connection and avoid staring at the `DisconnectionOverlay` indefinitely
This is a temporary measure while we have the GCR limitation