### PR TITLE
fix(new-client): Add autoReconnect option to connectToGateway in all locations

### DIFF
--- a/src/new-client/src/Finsemble/index.tsx
+++ b/src/new-client/src/Finsemble/index.tsx
@@ -14,6 +14,7 @@ export default function main() {
       url: `${window.location.origin}/ws`,
       interceptor: noop,
       useJson: true,
+      autoReconnect: true,
     })
   }
 

--- a/src/new-client/src/OpenFin/index.tsx
+++ b/src/new-client/src/OpenFin/index.tsx
@@ -14,6 +14,7 @@ export default function main() {
       url: `${window.location.origin}/ws`,
       interceptor: noop,
       useJson: true,
+      autoReconnect: true,
     })
   }
 

--- a/src/new-client/src/Web/index.tsx
+++ b/src/new-client/src/Web/index.tsx
@@ -19,7 +19,8 @@ export default function main() {
     connectToGateway({
       url: `${window.location.origin}/ws`,
       interceptor: noop,
-      // useJson: true,
+      useJson: true,
+      autoReconnect: true,
     })
   }
 


### PR DESCRIPTION
Enabled auto reconnect feature provided by hydra. Adds 2 second delay before reconnecting.

As shown in screenshots below, the subscription will re connect after a 2 second delay each hour. 


![Screen Shot 2021-10-04 at 3 56 08 PM](https://user-images.githubusercontent.com/19377709/135919410-ddd1d383-9d87-4498-a3c5-ec314e0e1191.png)

![Screen Shot 2021-10-04 at 3 50 37 PM](https://user-images.githubusercontent.com/19377709/135919454-2a7cf641-cde0-4e54-9027-f56d9ca526b2.png)


