### PR TITLE
fix(new-client): Changed OpenFin version to getsnapshots working

### DIFF
--- a/src/new-client/public-openfin/app.json
+++ b/src/new-client/public-openfin/app.json
@@ -13,7 +13,7 @@
     }
   },
   "runtime": {
-    "version": "19.89.60.5"
+    "version": "17.85.53.10"
   },
   "services": [
     {

--- a/src/new-client/src/OpenFin/Window/WindowControls.tsx
+++ b/src/new-client/src/OpenFin/Window/WindowControls.tsx
@@ -4,6 +4,7 @@ import { MinimizeIcon } from "../icons/MinimizeIcon"
 import { PopInIcon } from "@/components/icons/PopInIcon"
 import { closeOtherWindows, inMainOpenFinWindow } from "../utils/window"
 import { Control, ControlsWrapper } from "./WindowHeader.styles"
+import { useEffect } from "react"
 
 export interface Props {
   close?: () => void
@@ -18,6 +19,25 @@ export const WindowControls: React.FC<Props> = ({
   maximize,
   popIn,
 }) => {
+  // Close other windows when page is refreshed to avoid recreating popups
+  useEffect(() => {
+    const inMainWindow = inMainOpenFinWindow()
+
+    const cb = async () => {
+      await closeOtherWindows()
+    }
+
+    if (inMainWindow) {
+      window.addEventListener("beforeunload", cb)
+    }
+
+    return () => {
+      if (inMainWindow) {
+        window.removeEventListener("beforeunload", cb)
+      }
+    }
+  }, [])
+
   async function wrappedClose() {
     if (inMainOpenFinWindow()) {
       await closeOtherWindows()

--- a/src/new-client/src/OpenFin/utils/window.ts
+++ b/src/new-client/src/OpenFin/utils/window.ts
@@ -92,13 +92,8 @@ export async function createOpenFinPopup(
     await popupWindow.addListener("blurred", () =>
       popupWindow.hide().then(callback),
     )
-  } catch (e) {
-    if (
-      e.message &&
-      e.message.startsWith(
-        "Trying to create a Window with name-uuid combination already in use",
-      )
-    ) {
+  } catch (e: any) {
+    if (e.message && e.message.includes("with name already in use")) {
       console.log(`Attempted to recreate hidden window: ${popupNameFor(name)}`)
     } else {
       console.error(e)


### PR DESCRIPTION
Snapshot functionality was not working in new-client. The only obvious difference I could see between classic and new-client was the openfin runtime version.
Changing the version to `17.85.53.10` resolved the issue.
We will need to look into updating openfin rtv in the future and pay attention to the snapshot functionality and update accordingly.