### PR TITLE
fix(new-client): Platform bundle rewrite

### DIFF
--- a/src/new-client/src/App/LiveRates/Tiles.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles.tsx
@@ -57,6 +57,7 @@ export const Tiles = () => {
     if (tearOutEntry) {
       const [symbol, tornOut, tileRef] = tearOutEntry
       if (tornOut) {
+        console.log("Should handleTearOut", handleTearOut)
         handleTearOut(symbol, tileRef!)
       }
     }

--- a/src/new-client/src/App/LiveRates/Tiles.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles.tsx
@@ -57,7 +57,6 @@ export const Tiles = () => {
     if (tearOutEntry) {
       const [symbol, tornOut, tileRef] = tearOutEntry
       if (tornOut) {
-        console.log("Should handleTearOut", handleTearOut)
         handleTearOut(symbol, tileRef!)
       }
     }

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -61,6 +61,7 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
 
       return {
         id: candidate,
+        moduleSideEffects: "no-treeshake",
       }
     },
   }

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -61,6 +61,7 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
 
       return {
         id: candidate,
+        external: false,
         moduleSideEffects: "no-treeshake",
       }
     },

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -48,10 +48,21 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
 
       // Set the id of this file to the one importing it marked with our suffix
       // so we can load it in the load hook below
-      const mockPath = `${file.dir}/${file.name}.${target}.ts`
-      return this.resolve(mockPath, importer)
+      // const mockPath = `${file.dir}/${file.name}.${target}.ts`
+      // return this.resolve(mockPath, importer)
+
+      const importerFile = path.parse(importer)
+
+      const candidate = path.join(
+        importerFile.dir,
+        file.dir,
+        `${file.name}.${target.toLowerCase()}.ts`,
+      )
+
+      return {
+        id: candidate,
+      }
     },
-    hook: dev ? "buildStart" : "writeBundle",
   }
 }
 

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -33,6 +33,9 @@ function apiMockReplacerPlugin(): Plugin {
   }
 }
 
+// Replace files with .<target> if they exist
+// Note - resolveId source and importer args are different between dev and build
+// Some more investigation and work should be done to improve this when possible
 function targetBuildPlugin(dev: boolean, target: string): Plugin {
   return {
     name: "targetBuildPlugin",
@@ -69,13 +72,6 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
           `${importedFile.name}.${target.toLowerCase()}.ts`,
         )
 
-        // if (source.includes("openWindow") || source.includes("handleTear")) {
-        //   console.log(source)
-        //   console.log("importedFile", importedFile)
-        //   console.log("importerFile", importerFile)
-        //   console.log("candidate", candidate)
-        // }
-
         try {
           statSync(candidate)
           // console.log("candidate good", candidate)
@@ -109,10 +105,8 @@ function indexSwitchPlugin(target: string): Plugin {
 
       try {
         statSync(candidate)
-        // console.log("main candidate good", candidate)
         return candidate
       } catch (e) {
-        // console.log("Error with main candidate", candidate, e)
         return null
       }
     },

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -47,37 +47,38 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
         // Only continue if we can find a .<target>.ts file
         if (!files.includes(`${file.name}.${target}.ts`)) return null
 
-        // Set the id of this file to the one importing it marked with our suffix
-        // so we can load it in the load hook below
         const mockPath = `${file.dir}/${file.name}.${target}.ts`
         return this.resolve(mockPath, importer)
       } else {
+        const rootPrefix = "new-client/src/"
         const thisImporter = (importer || "").replace(/\\/g, "/")
-        if (!importer || !thisImporter.includes("/new-client/src/")) {
+        if (!importer || !thisImporter.includes(rootPrefix)) {
           return null
         }
 
         const importedFile = path.parse(source)
         const importerFile = path.parse(thisImporter)
         const candidate = path.join(
+          // If imported file starts with /src we can not append it to importer dir
+          // so we need to strip the path by the rootPrefix first
           importedFile.dir.startsWith("/src") &&
-            importerFile.dir.includes("new-client/src/")
-            ? `${importerFile.dir.split("new-client/src/")[0]}/new-client`
+            importerFile.dir.includes(rootPrefix)
+            ? `${importerFile.dir.split(rootPrefix)[0]}/new-client`
             : importerFile.dir,
           importedFile.dir,
           `${importedFile.name}.${target.toLowerCase()}.ts`,
         )
 
-        if (source.includes("openWindow") || source.includes("handleTear")) {
-          console.log(source)
-          console.log("importedFile", importedFile)
-          console.log("importerFile", importerFile)
-          console.log("candidate", candidate)
-        }
+        // if (source.includes("openWindow") || source.includes("handleTear")) {
+        //   console.log(source)
+        //   console.log("importedFile", importedFile)
+        //   console.log("importerFile", importerFile)
+        //   console.log("candidate", candidate)
+        // }
 
         try {
           statSync(candidate)
-          console.log("candidate good", candidate)
+          // console.log("candidate good", candidate)
           return candidate
         } catch (e) {
           // console.log("Error with candidate", candidate, e)
@@ -108,7 +109,7 @@ function indexSwitchPlugin(target: string): Plugin {
 
       try {
         statSync(candidate)
-        console.log("main candidate good", candidate)
+        // console.log("main candidate good", candidate)
         return candidate
       } catch (e) {
         // console.log("Error with main candidate", candidate, e)

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -37,7 +37,7 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
   return {
     name: "targetBuildPlugin",
     enforce: "pre",
-    resolveId: function (source, importer) {
+    resolveId: function (source, importer, options) {
       if (!source.endsWith(".ts")) return null
 
       const file = path.parse(source)
@@ -48,22 +48,24 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
 
       // Set the id of this file to the one importing it marked with our suffix
       // so we can load it in the load hook below
-      // const mockPath = `${file.dir}/${file.name}.${target}.ts`
-      // return this.resolve(mockPath, importer)
+      const mockPath = `${file.dir}/${file.name}.${target}.ts`
+      return this.resolve(mockPath, importer, {
+        ...options,
+      })
 
-      const importerFile = path.parse(importer)
+      // const importerFile = path.parse(importer)
 
-      const candidate = path.join(
-        importerFile.dir,
-        file.dir,
-        `${file.name}.${target.toLowerCase()}.ts`,
-      )
+      // const candidate = path.join(
+      //   importerFile.dir,
+      //   file.dir,
+      //   `${file.name}.${target.toLowerCase()}.ts`,
+      // )
 
-      return {
-        id: candidate,
-        external: false,
-        moduleSideEffects: "no-treeshake",
-      }
+      // return {
+      //   id: candidate,
+      //   external: false,
+      //   moduleSideEffects: "no-treeshake",
+      // }
     },
   }
 }

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -48,24 +48,24 @@ function targetBuildPlugin(dev: boolean, target: string): Plugin {
 
       // Set the id of this file to the one importing it marked with our suffix
       // so we can load it in the load hook below
-      const mockPath = `${file.dir}/${file.name}.${target}.ts`
-      return this.resolve(mockPath, importer, {
-        ...options,
-      })
+      // const mockPath = `${file.dir}/${file.name}.${target}.ts`
+      // return this.resolve(mockPath, importer, {
+      //   ...options,
+      // })
 
-      // const importerFile = path.parse(importer)
+      const importerFile = path.parse(importer)
 
-      // const candidate = path.join(
-      //   importerFile.dir,
-      //   file.dir,
-      //   `${file.name}.${target.toLowerCase()}.ts`,
-      // )
+      const candidate = path.join(
+        importerFile.dir,
+        file.dir,
+        `${file.name}.${target.toLowerCase()}.ts`,
+      )
 
-      // return {
-      //   id: candidate,
-      //   external: false,
-      //   moduleSideEffects: "no-treeshake",
-      // }
+      return {
+        id: candidate,
+        external: false,
+        moduleSideEffects: "no-treeshake",
+      }
     },
   }
 }


### PR DESCRIPTION
Adds vite plugin to replace imported files with platform specific files if they exist.

`import { openWindow } from '@utils/window/openWindow'` will import from `@utils/window/openWindow.openfin.ts` when building for the OpenFin target.

Note - The behavior between dev and build in the `resolveId` plugin function is different. This PR gets our solution working, but more work towards  stable'er solution is needed.