### PR TITLE
feat(new-client): Show modal when service worker has pre-cached

### DIFF
--- a/src/new-client/src/Web/MainRoute.tsx
+++ b/src/new-client/src/Web/MainRoute.tsx
@@ -2,6 +2,7 @@ import Resizer from "@/components/Resizer"
 import styled from "styled-components"
 import Header from "@/App/Header"
 import { Footer } from "@/App/Footer"
+import { Trades } from "@/App/Trades"
 import { Analytics } from "@/App/Analytics"
 import { DisconnectionOverlay } from "@/App/DisconnectionOverlay"
 import { LiveRates } from "@/App/LiveRates"
@@ -43,7 +44,7 @@ export const MainRoute: React.FC = () => (
       <MainWrapper>
         <Resizer defaultHeight={30}>
           <LiveRates />
-          <div>Hello world</div>
+          <Trades />
         </Resizer>
         <Analytics />
       </MainWrapper>

--- a/src/new-client/src/Web/MainRoute.tsx
+++ b/src/new-client/src/Web/MainRoute.tsx
@@ -2,7 +2,6 @@ import Resizer from "@/components/Resizer"
 import styled from "styled-components"
 import Header from "@/App/Header"
 import { Footer } from "@/App/Footer"
-import { Trades } from "@/App/Trades"
 import { Analytics } from "@/App/Analytics"
 import { DisconnectionOverlay } from "@/App/DisconnectionOverlay"
 import { LiveRates } from "@/App/LiveRates"
@@ -44,7 +43,7 @@ export const MainRoute: React.FC = () => (
       <MainWrapper>
         <Resizer defaultHeight={30}>
           <LiveRates />
-          <Trades />
+          <div>Hello world</div>
         </Resizer>
         <Analytics />
       </MainWrapper>

--- a/src/new-client/src/Web/cacheUpdateModal.tsx
+++ b/src/new-client/src/Web/cacheUpdateModal.tsx
@@ -1,0 +1,51 @@
+import { Modal } from "@/components/Modal"
+import { ThemeProvider, TouchableIntentName } from "@/theme"
+import ReactDOM from "react-dom"
+import styled from "styled-components"
+
+const Buttons = styled.button`
+  display: flex;
+  margin-top: 20px;
+`
+
+// TODO - Use component from styleguide when
+const Button = styled.button<{ intent: TouchableIntentName }>`
+  background-color: ${({ theme, intent }) =>
+    theme.button[intent].backgroundColor};
+  color: #ffffff;
+  padding: 5px 9px;
+  margin-right: 10px;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.accents.primary.darker};
+  }
+`
+
+export const showCacheUpdateModal = () => {
+  const updateRoot = document.createElement("div")
+  document.body.appendChild(updateRoot)
+
+  ReactDOM.render(
+    <ThemeProvider>
+      <Modal title="New updates are available" shouldShow>
+        <p>Reload the page to see them.</p>
+        <Buttons>
+          <Button onClick={() => window.location.reload()} intent="primary">
+            Reload
+          </Button>
+          <Button
+            onClick={() => {
+              document.body.removeChild(updateRoot)
+            }}
+            intent="secondary"
+          >
+            Cancel
+          </Button>
+        </Buttons>
+      </Modal>
+    </ThemeProvider>,
+    updateRoot,
+  )
+}

--- a/src/new-client/src/Web/index.tsx
+++ b/src/new-client/src/Web/index.tsx
@@ -14,6 +14,7 @@ import { TradesCoreDeferred } from "@/App/Trades"
 import { connectToGateway } from "@adaptive/hydra-platform"
 import { noop } from "rxjs"
 import { PlatformContext } from "@/platform"
+import { showCacheUpdateModal } from "./cacheUpdateModal"
 
 export default function main() {
   if (!import.meta.env.VITE_MOCKS) {
@@ -30,19 +31,16 @@ export default function main() {
       onUpdate: (registration) => {
         // If the SW got updated, then we have to be careful. We can't immediately
         // skip the waiting phase, because if there are requests on the fly that
-        // could be a disaster. In an ideal world we should display a message to
-        // the user letting them know that a new version is available and whenever
-        // the user confirms that they want to update then we can skip the waiting
-        // phase and we reload the App. However, before we implement that feature
-        // what we can do is to skip the waiting phase after all the async chunks
-        // have been loaded. This is only an option because all our async chunks
-        // get always preloaded from the main chunk.
+        // could be a disaster.
+        // Wait for our async chunks to be loaded, then skip waiting phase and show
+        // the user a modal informing them that there are new updates available
         Promise.all([
           AnalyticsCoreDeferred,
           LiveRatesCoreDeferred,
           TradesCoreDeferred,
         ]).then(() => {
           registration.waiting?.postMessage({ type: "SKIP_WAITING" })
+          showCacheUpdateModal()
         })
       },
     })

--- a/src/new-client/src/Web/index.tsx
+++ b/src/new-client/src/Web/index.tsx
@@ -31,7 +31,7 @@ export default function main() {
       onUpdate: (registration) => {
         // If the SW got updated, then we have to be careful. We can't immediately
         // skip the waiting phase, because if there are requests on the fly that
-        // could be a disaster.
+        // could be a disaster
         // Wait for our async chunks to be loaded, then skip waiting phase and show
         // the user a modal informing them that there are new updates available
         Promise.all([
@@ -40,7 +40,6 @@ export default function main() {
           TradesCoreDeferred,
         ]).then(() => {
           registration.waiting?.postMessage({ type: "SKIP_WAITING" })
-
           showCacheUpdateModal()
         })
       },

--- a/src/new-client/src/Web/index.tsx
+++ b/src/new-client/src/Web/index.tsx
@@ -40,6 +40,7 @@ export default function main() {
           TradesCoreDeferred,
         ]).then(() => {
           registration.waiting?.postMessage({ type: "SKIP_WAITING" })
+
           showCacheUpdateModal()
         })
       },

--- a/src/new-client/src/Web/serviceWorkerRegistration.ts
+++ b/src/new-client/src/Web/serviceWorkerRegistration.ts
@@ -35,7 +35,7 @@ export function register(config?: Config) {
         "$1/",
       )
 
-      if (!isLocalhost) {
+      if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
         checkValidServiceWorker(swUrl, config)
 

--- a/src/new-client/src/Web/serviceWorkerRegistration.ts
+++ b/src/new-client/src/Web/serviceWorkerRegistration.ts
@@ -35,7 +35,7 @@ export function register(config?: Config) {
         "$1/",
       )
 
-      if (isLocalhost) {
+      if (!isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
         checkValidServiceWorker(swUrl, config)
 
@@ -70,12 +70,11 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              /*
+
               console.log(
                 "New content is available and will be used when all " +
                   "tabs for this page are closed. See https://cra.link/PWA.",
               )
-              */
 
               // Execute callback
               if (config && config.onUpdate) {
@@ -85,7 +84,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              // console.log("Content is cached for offline use.")
+              console.log("Content is cached for offline use.")
 
               // Execute callback
               if (config && config.onSuccess) {

--- a/src/new-client/src/components/Modal/Modal.tsx
+++ b/src/new-client/src/components/Modal/Modal.tsx
@@ -14,7 +14,6 @@ interface Props {
 }
 
 // TODO disable tabbing outside of the modal
-// tslint:disable-next-line:variable-name
 export const Modal: FC<Props> = ({
   shouldShow,
   title,

--- a/src/new-client/vite.config.ts
+++ b/src/new-client/vite.config.ts
@@ -13,7 +13,7 @@ const PORT = Number(process.env.PORT) || 1917
 function getBaseUrl(dev: boolean) {
   return dev
     ? `http://localhost:${PORT}`
-    : `${process.env.DOMAIN}${process.env.URL_PATH || ""}` || ""
+    : `${process.env.DOMAIN || ""}${process.env.URL_PATH || ""}` || ""
 }
 
 function apiMockReplacerPlugin(): Plugin {


### PR DESCRIPTION
Show a modal to the user when service worker has pre-cached new updates. The user can then reload the page so they're not looking at an old version.

![image](https://user-images.githubusercontent.com/50445182/140718772-4ae6ba5e-4190-4d4d-bb49-557abdf4e333.png)
