### PR TITLE
fix(new-client): setfilters default to all when all selected

### DIFF
--- a/src/new-client/src/App/Trades/TradesState/filterState/setFilterState.ts
+++ b/src/new-client/src/App/Trades/TradesState/filterState/setFilterState.ts
@@ -7,7 +7,7 @@ import { trades$ } from "@/services/trades"
 import { colConfigs, colFields } from "../colConfig"
 import type { FilterEvent } from "./filterCommon"
 import { filterResets$ } from "./filterCommon"
-
+import _ from "lodash"
 /**
  * Subset of column fields (as type) that take set/multi-select filter-value
  * options.
@@ -174,6 +174,9 @@ const appliedSetFilters$ = mergeWithKey({
       } else {
         newValues.add(value)
       }
+      if (_.isEqual(newValues, distinctSetFieldValues)) {
+        newValues = new Set()
+      }
     }
     return {
       ...appliedFilters,
@@ -201,9 +204,7 @@ export const appliedSetFilterEntries$ = appliedSetFilters$.pipe(
  * State hook and parametric stream of applied filter-value options
  *  used by SetFilter component to render options.
  */
-export const [
-  useAppliedSetFieldFilters,
-  appliedSetFieldFilters$,
-] = bind((field: SetColField) =>
-  appliedSetFilters$.pipe(map((appliedFilters) => appliedFilters[field])),
+export const [useAppliedSetFieldFilters, appliedSetFieldFilters$] = bind(
+  (field: SetColField) =>
+    appliedSetFilters$.pipe(map((appliedFilters) => appliedFilters[field])),
 )


### PR DESCRIPTION
### What is the feature?

In the combination filters, default the selection to all once we have selected all posible values

### What is the solution?

We must reset the filter when the newValues equal all the possible choices (we get those from `distinctSetFieldValues`)

### What areas of the site does it impact?

Option filters within the Trades section

### How to test?

1)Go to the Trades section and try to select one choice from the Status/Direction/CCY/TRADER filters
2)Then select the rest of the options

In this case, it works fine, but the equivalent of choosing all possible choices is the default SELECT ALL 

![Screenshot 2021-11-22 at 15 01 55](https://user-images.githubusercontent.com/11291319/142874943-5931324e-b572-413f-abd6-9349bff4a94e.png)

I don't know if this was the desired behaviour ( I can see it's utility in cases where we have selected all choices and then we want to choose to stop seeing one of them). The current solution compares if both sets - the one with the selected choices and the other with all the possible ones- are the same, if they are, we default back to viewing all the options.

## Other Notes

Another issue with this solution would be the behaviour when we only have one possible choice (If we only have one status, such as Done, in all our trades), we wouldn't be able to select Done since it already encompasses all possible choices and it would default to SELECT ALL, which is not wrong _per se_ but in terms of user experience it would be weird to "ignore" that click