### PR TITLE
fix(new-client): Notional negative values handled

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -39,9 +39,10 @@ export const [useNotional, getNotional$] = symbolBind((symbol) =>
   ).pipe(
     map(({ rawVal }) => {
       const lastChar = rawVal.slice(-1).toLowerCase()
-      const value =
+      const value = Math.abs(
         Number(rawVal.replace(/,|k$|m$|K$|M$/g, "")) *
-        (multipliers[lastChar] || 1)
+          (multipliers[lastChar] || 1),
+      )
       return {
         value,
         inputValue: formatter.format(value) + (lastChar === "." ? "." : ""),


### PR DESCRIPTION
Notional negative values handled, we take the absolute value. 

The notional input already takes care of all characters that are not numeric but if we Ctrl+C Ctrl+V a negative value the latter is accepted when it shouldn't.