### PR TITLE
fix(new-client): Reconnection loop whit screen of death

### DIFF
--- a/src/new-client/src/App/Trades/TradesState/tableTrades.ts
+++ b/src/new-client/src/App/Trades/TradesState/tableTrades.ts
@@ -355,7 +355,7 @@ const newTradeId$ = trades$.pipe(
       trades: Trade[]
     },
   ),
-  skipWhile(({ stateOfWorld }) => stateOfWorld),
+  skipWhile(({ stateOfWorld, trades }) => stateOfWorld || trades.length === 0),
   map(({ trades }) => trades[0].tradeId),
 )
 


### PR DESCRIPTION
Added defensive code around `newTradeId$` to fix white screen of death when reconnecting to Hydra after a service restart