### PR TITLE
fix(new-client): Draggable component depends on tearout

### DIFF
--- a/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
+++ b/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components"
 import { RefObject, useState } from "react"
 import { tearOutSection, Section } from "@/App/TearOutSection/state"
-import { canDrag } from "@/components/DraggableTearOut/canDrag"
+import { supportsDragToTearOut } from "@/components/DraggableTearOut/supportsDragToTearOut"
 import { tearOut } from "@/App/LiveRates/Tile/TearOut/state"
 
 export const DragWrapper = styled.div`
@@ -26,7 +26,7 @@ type DraggableTearOutGenericProps = React.PropsWithChildren<{
 export const DraggableSectionTearOut: React.FC<DraggableSectionTearOutProps> = (
   props,
 ) => {
-  const draggable = canDrag && !props.disabled
+  const draggable = supportsDragToTearOut && !props.disabled
   const dragHandler = () => {
     tearOutSection(true, props.section)
   }
@@ -42,7 +42,7 @@ export const DraggableSectionTearOut: React.FC<DraggableSectionTearOutProps> = (
 export const DraggableTileTearOut: React.FC<DraggableTileTearOutProps> = (
   props,
 ) => {
-  const draggable = canDrag && !props.disabled
+  const draggable = supportsDragToTearOut && !props.disabled
   const dragHandler = () => {
     tearOut(props.symbol, true, props.tileRef.current!)
   }

--- a/src/new-client/src/components/DraggableTearOut/canDrag.openfin.ts
+++ b/src/new-client/src/components/DraggableTearOut/canDrag.openfin.ts
@@ -1,1 +1,0 @@
-export const canDrag = false

--- a/src/new-client/src/components/DraggableTearOut/canDrag.ts
+++ b/src/new-client/src/components/DraggableTearOut/canDrag.ts
@@ -1,2 +1,2 @@
 import { supportsTearOut } from "@/App/TearOutSection/supportsTearOut"
-export const canDrag = false && supportsTearOut
+export const canDrag = true && supportsTearOut

--- a/src/new-client/src/components/DraggableTearOut/canDrag.ts
+++ b/src/new-client/src/components/DraggableTearOut/canDrag.ts
@@ -1,2 +1,0 @@
-import { supportsTearOut } from "@/App/TearOutSection/supportsTearOut"
-export const canDrag = true && supportsTearOut

--- a/src/new-client/src/components/DraggableTearOut/canDrag.ts
+++ b/src/new-client/src/components/DraggableTearOut/canDrag.ts
@@ -1,1 +1,2 @@
-export const canDrag = true
+import { supportsTearOut } from "@/App/TearOutSection/supportsTearOut"
+export const canDrag = false && supportsTearOut

--- a/src/new-client/src/components/DraggableTearOut/supportsDragToTearOut.openfin.ts
+++ b/src/new-client/src/components/DraggableTearOut/supportsDragToTearOut.openfin.ts
@@ -1,0 +1,1 @@
+export const supportsDragToTearOut = false

--- a/src/new-client/src/components/DraggableTearOut/supportsDragToTearOut.ts
+++ b/src/new-client/src/components/DraggableTearOut/supportsDragToTearOut.ts
@@ -1,0 +1,3 @@
+import { supportsTearOut } from "@/App/TearOutSection/supportsTearOut"
+//If tear out is supported, allow drag.
+export const supportsDragToTearOut = true && supportsTearOut


### PR DESCRIPTION
While I was working with the virtualized table, I disabled the tearout to test something but saw that I could still drag, since the draggable components are just an extension of the already implemented tearout, I don't know if its an expected behaviour to be able to drag a component but not tear it out 

Besides, there's also the issue that if we drag and a new window appears, we wouldn't be able to revert it unless we close it, since the tearIn would also be disabled.

I just added to the canDrag constant the need for supportsTearOut to be enabled, I don't know which would be the preferred behaviour for openfin so I left that as it is.