### PR TITLE
fix: replace BASE_URL with location.origin 

### DIFF
--- a/src/new-client/src/App/Footer/ContactUsButton/ContactUs.tsx
+++ b/src/new-client/src/App/Footer/ContactUsButton/ContactUs.tsx
@@ -1,4 +1,4 @@
-import { ContactUsContentResolver, Link, Input } from "./styled"
+import { ContactUsContentResolver, Link } from "./styled"
 
 const WEBSITE = "https://weareadaptive.com"
 const EMAIL = "sales@weareadaptive.com"

--- a/src/new-client/src/Launcher/applicationConfigurations.ts
+++ b/src/new-client/src/Launcher/applicationConfigurations.ts
@@ -1,4 +1,4 @@
-import { BASE_URL, ENVIRONMENT } from "@/constants"
+import { ENVIRONMENT } from "@/constants"
 import {
   limitCheckerIcon,
   reactiveAnalyticsIcon,
@@ -19,7 +19,7 @@ const defaultWindowOptions: fin.WindowOption = {
   defaultCentered: true,
   frame: false,
   shadow: true,
-  icon: `${BASE_URL}/static/media/adaptive.ico`,
+  icon: `${window.location.origin}/static/media/adaptive.ico`,
   accelerator:
     process.env.NODE_ENV !== "development"
       ? {}
@@ -111,7 +111,7 @@ const baseAppConfigs: ApplicationConfig[] = [
       applicationType: "download",
       windowOptions: {
         ...defaultWindowOptions,
-        icon: `${BASE_URL}/static/media/limit-checker-icon.ico`,
+        icon: `${window.location.origin}/static/media/limit-checker-icon.ico`,
       },
     },
   },

--- a/src/new-client/src/Launcher/applicationConfigurations.ts
+++ b/src/new-client/src/Launcher/applicationConfigurations.ts
@@ -1,4 +1,5 @@
 import { ENVIRONMENT } from "@/constants"
+import { constructUrl } from "@/utils/url"
 import {
   limitCheckerIcon,
   reactiveAnalyticsIcon,
@@ -19,7 +20,7 @@ const defaultWindowOptions: fin.WindowOption = {
   defaultCentered: true,
   frame: false,
   shadow: true,
-  icon: `${window.location.origin}/static/media/adaptive.ico`,
+  icon: constructUrl(`/static/media/adaptive.ico`),
   accelerator:
     process.env.NODE_ENV !== "development"
       ? {}
@@ -111,7 +112,7 @@ const baseAppConfigs: ApplicationConfig[] = [
       applicationType: "download",
       windowOptions: {
         ...defaultWindowOptions,
-        icon: `${window.location.origin}/static/media/limit-checker-icon.ico`,
+        icon: constructUrl(`/static/media/limit-checker-icon.ico`),
       },
     },
   },

--- a/src/new-client/src/Launcher/utils/url.ts
+++ b/src/new-client/src/Launcher/utils/url.ts
@@ -6,5 +6,5 @@ export const getReactiveTraderUrl = (path: string) =>
     path,
     ENVIRONMENT !== "local"
       ? window.location.origin.replace("launcher", "openfin")
-      : "http://localhost:1917",
+      : window.location.origin,
   )

--- a/src/new-client/src/Launcher/utils/url.ts
+++ b/src/new-client/src/Launcher/utils/url.ts
@@ -1,10 +1,10 @@
-import { BASE_URL, ENVIRONMENT } from "@/constants"
+import { ENVIRONMENT } from "@/constants"
 import { constructUrl } from "@/utils/url"
 
 export const getReactiveTraderUrl = (path: string) =>
   constructUrl(
     path,
     ENVIRONMENT !== "local"
-      ? BASE_URL.replace("launcher", "openfin")
+      ? window.location.origin.replace("launcher", "openfin")
       : "http://localhost:1917",
   )

--- a/src/new-client/src/constants.ts
+++ b/src/new-client/src/constants.ts
@@ -1,7 +1,9 @@
 type Environment = "local" | "env" | "dev" | "uat" | "prod"
 
 export const GA_TRACKING_ID = "UA-46320965-5"
-export const BASE_URL = import.meta.env.BASE_URL
+// Comes from vite.config - base
+// Will be / for localhost or platform.env.reactivetrader.com
+const BASE_URL = import.meta.env.BASE_URL
 export const BASE_PATH =
   BASE_URL && BASE_URL.startsWith("http") ? new URL(BASE_URL).pathname : ""
 export const ENVIRONMENT: Environment =
@@ -13,5 +15,5 @@ export const ROUTES_CONFIG = {
   tile: "/spot/:symbol",
   tiles: "/tiles",
   blotter: "/blotter",
-  analytics: "/analytics"
+  analytics: "/analytics",
 }

--- a/src/new-client/src/notifications.openfin.ts
+++ b/src/new-client/src/notifications.openfin.ts
@@ -9,7 +9,7 @@ import { ExecutionStatus, ExecutionTrade } from "@/services/executions"
 import { executions$ } from "@/services/executions/executions"
 import { formatNumber } from "@/utils"
 import { onTradeRowHighlight } from "@/App/Trades/TradesState"
-import { ENVIRONMENT } from "./constants"
+import { constructUrl } from "./utils/url"
 
 const sendNotification = (executionTrade: ExecutionTrade) => {
   const notification = {
@@ -21,9 +21,7 @@ const sendNotification = (executionTrade: ExecutionTrade) => {
   const status =
     notification.status === ExecutionStatus.Done ? "Accepted" : "Rejected"
 
-  const host =
-    ENVIRONMENT === "local" ? "http://localhost:1917" : window.location.origin
-  const iconUrl = `${host}/static/media/reactive-trader-icon-dark.ico`
+  const iconUrl = constructUrl(`/static/media/reactive-trader-icon-dark.ico`)
 
   create({
     title: `Trade ${status}: ID ${notification.tradeId}`,

--- a/src/new-client/src/notifications.openfin.ts
+++ b/src/new-client/src/notifications.openfin.ts
@@ -9,7 +9,7 @@ import { ExecutionStatus, ExecutionTrade } from "@/services/executions"
 import { executions$ } from "@/services/executions/executions"
 import { formatNumber } from "@/utils"
 import { onTradeRowHighlight } from "@/App/Trades/TradesState"
-import { BASE_URL } from "./constants"
+import { ENVIRONMENT } from "./constants"
 
 const sendNotification = (executionTrade: ExecutionTrade) => {
   const notification = {
@@ -21,7 +21,8 @@ const sendNotification = (executionTrade: ExecutionTrade) => {
   const status =
     notification.status === ExecutionStatus.Done ? "Accepted" : "Rejected"
 
-  const host = BASE_URL === "/" ? "http://localhost:1917" : BASE_URL
+  const host =
+    ENVIRONMENT === "local" ? "http://localhost:1917" : window.location.origin
   const iconUrl = `${host}/static/media/reactive-trader-icon-dark.ico`
 
   create({

--- a/src/new-client/src/services/currentUser.ts
+++ b/src/new-client/src/services/currentUser.ts
@@ -1,3 +1,4 @@
+import { constructUrl } from "@/utils/url"
 import { bind } from "@react-rxjs/core"
 import { Observable } from "rxjs"
 import { shareReplay } from "rxjs/operators"
@@ -14,31 +15,31 @@ export const fakeUsers: User[] = [
     code: "LMO",
     firstName: "Lorretta",
     lastName: "Moe",
-    avatar: `${window.location.origin}/static/media/mockedAvatars/one.png`,
+    avatar: constructUrl(`/static/media/mockedAvatars/one.png`),
   },
   {
     code: "WMO",
     firstName: "Wenona",
     lastName: "Moshier",
-    avatar: `${window.location.origin}/static/media/mockedAvatars/two.png`,
+    avatar: constructUrl(`/static/media/mockedAvatars/two.png`),
   },
   {
     code: "NGA",
     firstName: "Nita",
     lastName: "Garica",
-    avatar: `${window.location.origin}/static/media/mockedAvatars/three.png`,
+    avatar: constructUrl(`/static/media/mockedAvatars/three.png`),
   },
   {
     code: "HHA",
     firstName: "Hyun",
     lastName: "Havlik",
-    avatar: `${window.location.origin}/static/media/mockedAvatars/four.png`,
+    avatar: constructUrl(`/static/media/mockedAvatars/four.png`),
   },
   {
     code: "EDO",
     firstName: "Elizebeth",
     lastName: "Doverspike",
-    avatar: `${window.location.origin}/static/media/mockedAvatars/five.png`,
+    avatar: constructUrl(`/static/media/mockedAvatars/five.png`),
   },
 ]
 

--- a/src/new-client/src/utils/url.ts
+++ b/src/new-client/src/utils/url.ts
@@ -1,9 +1,12 @@
+import { BASE_PATH } from "@/constants"
+
 export const constructUrl = (
   path: string,
   base = window.location.origin,
 ): string => {
-  if (base.endsWith("/") && path.startsWith("/")) {
-    return `${base}${path.slice(1)}`
+  const baseUrl = `${base}${BASE_PATH}`
+  if (baseUrl.endsWith("/") && path.startsWith("/")) {
+    return `${baseUrl}${path.slice(1)}`
   }
-  return `${base}${path}`
+  return `${baseUrl}${path}`
 }

--- a/src/new-client/src/utils/url.ts
+++ b/src/new-client/src/utils/url.ts
@@ -1,9 +1,7 @@
-import { BASE_URL } from "@/constants"
-
-export const constructUrl = (path: string, base = BASE_URL): string => {
-  if (base === "/") {
-    return path
-  }
+export const constructUrl = (
+  path: string,
+  base = window.location.origin,
+): string => {
   if (base.endsWith("/") && path.startsWith("/")) {
     return `${base}${path.slice(1)}`
   }


### PR DESCRIPTION
Replaces `BASE_URL` with `location.origin` throughout the app so we construct urls based on the current origin (allows us to have multiple domains for the same build - web.prod.|www.|reactivetrader.com)