### PR TITLE
feat(new-client): implementet horitzontal resizer

### DIFF
--- a/src/new-client/src/App/Analytics/Analytics.tsx
+++ b/src/new-client/src/App/Analytics/Analytics.tsx
@@ -9,7 +9,7 @@ const AnalyticsCore = lazy(() => AnalyticsCoreDeferred)
 
 const AnalyticsWrapper = styled.div<{ hideIfMatches?: string | null }>`
   height: 100%;
-  flex: 0 0 371px;
+  flex: 0 0 100%;
   padding: 0.5rem 1rem 0.5rem 0;
   user-select: none;
   overflow: hidden;

--- a/src/new-client/src/App/Analytics/AnalyticsCore.tsx
+++ b/src/new-client/src/App/Analytics/AnalyticsCore.tsx
@@ -14,15 +14,24 @@ import { isAnalyticsDataStale$ } from "@/services/analytics"
 import { supportsTearOut } from "@/App/TearOutSection/supportsTearOut"
 import { TearOutComponent } from "@/App/TearOutSection/TearOutComponent"
 
+import { useHoritzontalResizeValues } from "@/components/resizeState"
+import { TearOutContext } from "@/App/TearOutSection/tearOutContext"
+import { useContext } from "react"
+
 const analytics$ = merge(pnL$, profitAndLoss$, positions$)
 
 const SuspenseOnStaleData = createSuspenseOnStale(isAnalyticsDataStale$)
 
 const Analytics: React.FC = ({ children }) => {
+  const resizeHSize = useHoritzontalResizeValues()
+  const tearOutContext = useContext(TearOutContext)
+
   return (
     <Subscribe source$={analytics$} fallback={children}>
       <SuspenseOnStaleData />
-      <AnalyticsInnerWrapper>
+      <AnalyticsInnerWrapper
+        width={!tearOutContext.isTornOut ? resizeHSize : null}
+      >
         <AnalyticsHeader>
           Analytics
           <RightNav>

--- a/src/new-client/src/App/Analytics/Positions/Positions.tsx
+++ b/src/new-client/src/App/Analytics/Positions/Positions.tsx
@@ -9,7 +9,7 @@ import {
   select,
 } from "d3"
 import { BubbleChartNode, nodes$, useData, data$ } from "./data"
-import { BubbleChart, Title } from "../styled"
+import { BubbleChart, Title, BubbleContainer } from "../styled"
 
 // extra pixel amount that nodes in the chart repel each other within
 // for collision detection purposes, a nodes radius is r + COLLIDE_BORDER_WIDTH pixels
@@ -183,7 +183,9 @@ export const Positions: React.FC = () => {
   return (
     <div>
       <Title>Positions</Title>
-      <BubbleChart ref={wrapperRef} />
+      <BubbleContainer>
+        <BubbleChart ref={wrapperRef} />
+      </BubbleContainer>
     </div>
   )
 }

--- a/src/new-client/src/App/Analytics/styled.tsx
+++ b/src/new-client/src/App/Analytics/styled.tsx
@@ -1,6 +1,11 @@
 import styled from "styled-components"
 import { transparentColor } from "./globals/variables"
 
+export const BubbleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`
+
 export const AnalyticsInnerWrapper = styled.div<{
   inExternalWindow?: boolean
   width?: number | null
@@ -136,6 +141,7 @@ export const BubbleChart = styled.div`
   height: 18rem;
   overflow: hidden;
   position: relative;
+  width: 382px;
 `
 
 export const Controls = styled("div")`

--- a/src/new-client/src/App/Analytics/styled.tsx
+++ b/src/new-client/src/App/Analytics/styled.tsx
@@ -4,7 +4,6 @@ import { transparentColor } from "./globals/variables"
 export const AnalyticsInnerWrapper = styled.div<{ inExternalWindow?: boolean }>`
   width: 100%;
   height: 100%;
-  width: 320px;
   margin: auto;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/new-client/src/App/Analytics/styled.tsx
+++ b/src/new-client/src/App/Analytics/styled.tsx
@@ -1,8 +1,10 @@
 import styled from "styled-components"
 import { transparentColor } from "./globals/variables"
 
-export const AnalyticsInnerWrapper = styled.div<{ inExternalWindow?: boolean }>`
-  width: 100%;
+export const AnalyticsInnerWrapper = styled.div<{
+  inExternalWindow?: boolean
+  width?: number | null
+}>`
   height: 100%;
   margin: auto;
   overflow-y: auto;
@@ -11,6 +13,8 @@ export const AnalyticsInnerWrapper = styled.div<{ inExternalWindow?: boolean }>`
   display: grid;
   grid-template-rows: ${({ inExternalWindow }) =>
     inExternalWindow ? "0 auto" : "46px auto"};
+  width: ${({ width }) => (width ? width * 0.95 + "vw" : "372px")};
+  min-width: 372px;
 `
 
 export const AnalyticsHeader = styled.header`

--- a/src/new-client/src/Web/MainRoute.tsx
+++ b/src/new-client/src/Web/MainRoute.tsx
@@ -1,4 +1,5 @@
-import Resizer from "@/components/Resizer"
+import HResizer from "@/components/HResizer"
+import VResizer from "@/components/VResizer"
 import styled from "styled-components"
 import Header from "@/App/Header"
 import { Footer } from "@/App/Footer"
@@ -69,23 +70,25 @@ export const MainRoute: React.FC = () => {
       <AppLayoutRoot data-qa="app-layout__root">
         <Header />
         <MainWrapper>
-          <Resizer defaultHeight={30}>
-            {!tornOutSectionState.tiles && (
-              <DraggableSectionTearOut section="tiles">
-                <LiveRates />
+          <HResizer defaultWidth={20}>
+            <VResizer defaultHeight={30}>
+              {!tornOutSectionState.tiles && (
+                <DraggableSectionTearOut section="tiles">
+                  <LiveRates />
+                </DraggableSectionTearOut>
+              )}
+              {!tornOutSectionState.blotter && (
+                <DraggableSectionTearOut section="blotter">
+                  <Trades />
+                </DraggableSectionTearOut>
+              )}
+            </VResizer>
+            {!tornOutSectionState.analytics && (
+              <DraggableSectionTearOut section="analytics">
+                <Analytics />
               </DraggableSectionTearOut>
             )}
-            {!tornOutSectionState.blotter && (
-              <DraggableSectionTearOut section="blotter">
-                <Trades />
-              </DraggableSectionTearOut>
-            )}
-          </Resizer>
-          {!tornOutSectionState.analytics && (
-            <DraggableSectionTearOut section="analytics">
-              <Analytics />
-            </DraggableSectionTearOut>
-          )}
+          </HResizer>
         </MainWrapper>
         <Footer />
       </AppLayoutRoot>

--- a/src/new-client/src/Web/MainRoute.tsx
+++ b/src/new-client/src/Web/MainRoute.tsx
@@ -16,6 +16,8 @@ import {
 
 import { handleTearOutSection } from "@/App/TearOutSection/handleTearOutSection"
 
+import { defaultWidth } from "@/components/resizeState"
+
 const Wrapper = styled("div")`
   width: 100%;
   background-color: ${({ theme }) => theme.core.darkBackground};
@@ -70,7 +72,7 @@ export const MainRoute: React.FC = () => {
       <AppLayoutRoot data-qa="app-layout__root">
         <Header />
         <MainWrapper>
-          <HResizer defaultWidth={20}>
+          <HResizer defaultWidth={defaultWidth}>
             <VResizer defaultHeight={30}>
               {!tornOutSectionState.tiles && (
                 <DraggableSectionTearOut section="tiles">

--- a/src/new-client/src/components/DraggableTearOut/canDrag.ts
+++ b/src/new-client/src/components/DraggableTearOut/canDrag.ts
@@ -1,1 +1,1 @@
-export const canDrag = true
+export const canDrag = false

--- a/src/new-client/src/components/HResizer.tsx
+++ b/src/new-client/src/components/HResizer.tsx
@@ -1,0 +1,95 @@
+import { useState, useRef } from "react"
+import {
+  ResizableSection,
+  ResizerStyle,
+  ResizableContentHoritzontal,
+  ResizableContent,
+  Bar,
+} from "./Resizer.styles"
+
+interface Props {
+  children: [React.ReactNode, React.ReactNode]
+  minwidth?: number
+  defaultWidth: number
+}
+
+const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [width, setwidth] = useState(defaultWidth)
+
+  const startDragging = useRef<() => void>()
+  if (!startDragging.current) {
+    startDragging.current = () => {
+      const setClientwidth = (clientX: number) => {
+        const wrapperElement = wrapperRef.current
+        if (!wrapperElement) return
+
+        // Calculate the width of the bottom div based on cursor position
+        const wrapperwidth = wrapperElement.offsetWidth
+        const wrapperTop = wrapperElement.offsetTop
+        const wrapperOffset = clientX - wrapperTop
+        const rawwidth = wrapperwidth - wrapperOffset
+        // Calculate width as a percentage of parent
+        let width = Math.round((rawwidth / wrapperwidth) * 100)
+
+        // Block widths that would completely overlap left div
+        if (width > 65) width = 65
+
+        // Block widths that would hide left div
+        if (width < 20) width = 20
+
+        setwidth(width)
+      }
+
+      const handleMouseMove = (event: MouseEvent) =>
+        setClientwidth(event.clientX)
+      const handleTouchMove = (event: TouchEvent) =>
+        setClientwidth(event.touches[0].clientX)
+      const handleStop = () => {
+        document.removeEventListener("mousemove", handleMouseMove)
+        document.removeEventListener("touchmove", handleTouchMove)
+        document.removeEventListener("mouseup", handleStop)
+        document.removeEventListener("touchend", handleStop)
+      }
+
+      document.addEventListener("mousemove", handleMouseMove)
+      document.addEventListener("touchmove", handleTouchMove)
+      document.addEventListener("mouseup", handleStop, { once: true })
+      document.addEventListener("touchend", handleStop, { once: true })
+    }
+  }
+  return (
+    <ResizerStyle horitzontalResize={true} ref={wrapperRef}>
+      {children[0] && (
+        <ResizableSection
+          horitzontalResize={true}
+          width={children[1] ? 100 - width : 100}
+        >
+          <ResizableContent horitzontalResize={true}>
+            {children[0]}
+          </ResizableContent>
+          {children[1] && (
+            <Bar
+              onMouseDown={startDragging.current!}
+              onTouchStart={startDragging.current!}
+              show
+              horitzontalResize={true}
+            />
+          )}
+        </ResizableSection>
+      )}
+      {children[1] && (
+        <ResizableSection
+          horitzontalResize={true}
+          width={children[0] ? width : 100}
+        >
+          <ResizableContentHoritzontal>
+            {children[1]}
+          </ResizableContentHoritzontal>
+        </ResizableSection>
+      )}
+    </ResizerStyle>
+  )
+}
+
+export default HResizer

--- a/src/new-client/src/components/HResizer.tsx
+++ b/src/new-client/src/components/HResizer.tsx
@@ -7,6 +7,8 @@ import {
   Bar,
 } from "./Resizer.styles"
 
+import { HResizerEnabled } from "./ResizerEnabled"
+
 interface Props {
   children: [React.ReactNode, React.ReactNode]
   minwidth?: number
@@ -60,7 +62,7 @@ const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
   }
   return (
     <ResizerStyle horitzontalResize={true} ref={wrapperRef}>
-      {children[0] && (
+      {children[0] && HResizerEnabled && (
         <ResizableSection
           horitzontalResize={true}
           width={children[1] ? 100 - width : 100}
@@ -78,7 +80,7 @@ const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
           )}
         </ResizableSection>
       )}
-      {children[1] && (
+      {children[1] && HResizerEnabled && (
         <ResizableSection
           horitzontalResize={true}
           width={children[0] ? width : 100}
@@ -88,6 +90,8 @@ const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
           </ResizableContentHoritzontal>
         </ResizableSection>
       )}
+      <>{!HResizerEnabled && children[0]}</>
+      <>{!HResizerEnabled && children[1]}</>
     </ResizerStyle>
   )
 }

--- a/src/new-client/src/components/HResizer.tsx
+++ b/src/new-client/src/components/HResizer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import {
   ResizableSection,
   ResizerStyle,
@@ -8,6 +8,7 @@ import {
 } from "./Resizer.styles"
 
 import { HResizerEnabled } from "./ResizerEnabled"
+import { horitzontalResize } from "./resizeState"
 
 interface Props {
   children: [React.ReactNode, React.ReactNode]
@@ -18,6 +19,11 @@ interface Props {
 const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [width, setwidth] = useState(defaultWidth)
+
+  useEffect(() => {
+    //Whenever we tear out, we reset the width values
+    setwidth(defaultWidth)
+  }, [children])
 
   const startDragging = useRef<() => void>()
   if (!startDragging.current) {
@@ -41,6 +47,7 @@ const HResizer: React.FC<Props> = ({ defaultWidth, children }) => {
         if (width < 20) width = 20
 
         setwidth(width)
+        horitzontalResize(width)
       }
 
       const handleMouseMove = (event: MouseEvent) =>

--- a/src/new-client/src/components/Resizer.styles.ts
+++ b/src/new-client/src/components/Resizer.styles.ts
@@ -1,0 +1,63 @@
+import styled from "styled-components"
+
+export const ResizableContent = styled.div<{ horitzontalResize?: boolean }>`
+  width: ${({ horitzontalResize }) => (horitzontalResize ? "inherit" : "100%")};
+  height: ${({ horitzontalResize }) =>
+    horitzontalResize ? "inherit" : "100%"};
+  display: ${({ horitzontalResize }) => (horitzontalResize ? "contents" : "")};
+  position: ${({ horitzontalResize }) => (horitzontalResize ? "" : "absolute")};
+`
+
+export const ResizerStyle = styled.div<{ horitzontalResize?: boolean }>`
+  width: 100%;
+  height: 100%;
+  display: ${({ horitzontalResize }) => (horitzontalResize ? "flex" : "")};
+`
+
+export const ResizableSection = styled.div<{
+  height?: number
+  width?: number
+  horitzontalResize?: boolean
+}>`
+  height: ${({ height }) => (height ? height + "%" : "")};
+  width: ${({ width }) => (width ? width + "%" : "")};
+  overflow: hidden;
+  position: relative;
+
+  display: ${({ horitzontalResize }) => (horitzontalResize ? "flex" : "")};
+  justify-content: ${({ horitzontalResize }) =>
+    horitzontalResize ? "center" : ""};
+`
+
+export const Bar = styled.div<{ show?: boolean; horitzontalResize?: boolean }>`
+  display: ${({ show }) => (show ? "block" : "none")};
+  background-color: ${({ theme }) => theme.core.textColor};
+  box-shadow: 0 -0.125rem 0 0 ${({ theme }) => theme.core.textColor},
+    0 0.125rem 0 0 ${({ theme }) => theme.core.textColor};
+  cursor: ${({ horitzontalResize }) =>
+    horitzontalResize ? "col-resize" : "row-resize"};
+  height: ${({ horitzontalResize }) =>
+    horitzontalResize ? "100%" : "0.25rem"};
+  width: ${({ horitzontalResize }) => (horitzontalResize ? "0.4rem" : "100%")};
+  box-shadow: ${({ horitzontalResize, theme }) =>
+    horitzontalResize
+      ? ""
+      : `0 -0.125rem 0 0 ${theme.core.textColor},0 0.125rem 0 0 ${theme.core.textColor};`};
+  opacity: 0.1;
+  z-index: 1;
+
+  &:hover {
+    box-shadow: 0 -0.125rem 0 0 ${({ theme }) => theme.core.textColor},
+      0 0.125rem 0 0 ${({ theme }) => theme.core.textColor};
+    opacity: 0.3;
+    transition: all 200ms ease-in-out;
+  }
+
+  user-select: none;
+`
+
+export const ResizableContentHoritzontal = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/src/new-client/src/components/Resizer.styles.ts
+++ b/src/new-client/src/components/Resizer.styles.ts
@@ -27,6 +27,7 @@ export const ResizableSection = styled.div<{
   display: ${({ horitzontalResize }) => (horitzontalResize ? "flex" : "")};
   justify-content: ${({ horitzontalResize }) =>
     horitzontalResize ? "center" : ""};
+  min-width: 372px;
 `
 
 export const Bar = styled.div<{ show?: boolean; horitzontalResize?: boolean }>`

--- a/src/new-client/src/components/ResizerEnabled.ts
+++ b/src/new-client/src/components/ResizerEnabled.ts
@@ -1,0 +1,1 @@
+export const HResizerEnabled = true

--- a/src/new-client/src/components/Switch/SwitchContainer.ts
+++ b/src/new-client/src/components/Switch/SwitchContainer.ts
@@ -6,4 +6,5 @@ export const SwitchContainer = styled.div`
   min-width: 3.5rem;
   display: flex;
   justify-content: flex-end;
+  transition: all 2s ease-in-out;
 `

--- a/src/new-client/src/components/VResizer.tsx
+++ b/src/new-client/src/components/VResizer.tsx
@@ -1,43 +1,10 @@
 import { useState, useRef } from "react"
-import styled from "styled-components"
-
-const ResizerStyle = styled.div`
-  width: 100%;
-  height: 100%;
-`
-
-const ResizableSection = styled.div<{ height: number }>`
-  height: ${({ height }) => height + "%"};
-  overflow: hidden;
-  position: relative;
-`
-
-const ResizableContent = styled.div`
-  position: absolute;
-  height: 100%;
-  width: 100%;
-`
-
-const Bar = styled.div<{ show?: boolean }>`
-  display: ${({ show }) => (show ? "block" : "none")};
-  background-color: ${({ theme }) => theme.core.textColor};
-  box-shadow: 0 -0.125rem 0 0 ${({ theme }) => theme.core.textColor},
-    0 0.125rem 0 0 ${({ theme }) => theme.core.textColor};
-  cursor: row-resize;
-  opacity: 0.1;
-  z-index: 1;
-  height: 0.25rem;
-  width: 100%;
-
-  &:hover {
-    box-shadow: 0 -0.125rem 0 0 ${({ theme }) => theme.core.textColor},
-      0 0.125rem 0 0 ${({ theme }) => theme.core.textColor};
-    opacity: 0.3;
-    transition: all 200ms ease-in-out;
-  }
-
-  user-select: none;
-`
+import {
+  ResizableSection,
+  ResizerStyle,
+  ResizableContent,
+  Bar,
+} from "./Resizer.styles"
 
 interface Props {
   children: [React.ReactNode, React.ReactNode]
@@ -45,7 +12,7 @@ interface Props {
   defaultHeight: number
 }
 
-const Resizer: React.FC<Props> = ({ defaultHeight, children }) => {
+const VResizer: React.FC<Props> = ({ defaultHeight, children }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [height, setHeight] = useState(defaultHeight)
 
@@ -101,11 +68,13 @@ const Resizer: React.FC<Props> = ({ defaultHeight, children }) => {
       {children[1] && (
         <ResizableSection height={children[0] ? height : 100}>
           <ResizableContent>
-            <Bar
-              onMouseDown={startDragging.current!}
-              onTouchStart={startDragging.current!}
-              show
-            />
+            {children[0] && (
+              <Bar
+                onMouseDown={startDragging.current!}
+                onTouchStart={startDragging.current!}
+                show
+              />
+            )}
             {children[1]}
           </ResizableContent>
         </ResizableSection>
@@ -114,4 +83,4 @@ const Resizer: React.FC<Props> = ({ defaultHeight, children }) => {
   )
 }
 
-export default Resizer
+export default VResizer

--- a/src/new-client/src/components/resizeState.ts
+++ b/src/new-client/src/components/resizeState.ts
@@ -1,0 +1,15 @@
+import { bind } from "@react-rxjs/core"
+import { createSignal } from "@react-rxjs/utils"
+
+export const defaultWidth = 15
+
+type horitzontalValue = number
+
+export const [horitzontalResizeEntry$, horitzontalResize] = createSignal(
+  (width: number): horitzontalValue => width,
+)
+
+export const [useHoritzontalResizeValues] = bind<horitzontalValue>(
+  horitzontalResizeEntry$,
+  defaultWidth,
+)


### PR DESCRIPTION
# Description

Added horitzontal resizer to the web client, works similary to the previous Resize component, now we work with HResize and VResizer.

https://user-images.githubusercontent.com/11291319/144224224-154832d7-1f78-4c0b-8d83-e17159e73d19.mov


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Tasks:

- [X] Implement horitzontal resize bar
- [ ] Investigate how feasible is to increase width of charts as well and not just the parent wrapper
- [ ] Add canHoritzontalResize so it can be enabled/disabled
- [X] Fix horitzontal bar on top when tiles grid tears out (pre-commit, bar appears even though it doesn't resize since there's no sibling)



