### PR TITLE
fix(client): grid number filter (RT-1657-1658)

### DIFF
--- a/src/new-client/src/App/Trades/TradesState/tableTrades.ts
+++ b/src/new-client/src/App/Trades/TradesState/tableTrades.ts
@@ -1,13 +1,6 @@
 import { startOfDay } from "date-fns"
 import { combineLatest, merge } from "rxjs"
-import {
-  delay,
-  filter,
-  map,
-  mergeMap,
-  scan,
-  startWith,
-} from "rxjs/operators"
+import { delay, filter, map, mergeMap, scan, startWith } from "rxjs/operators"
 import { bind } from "@react-rxjs/core"
 import { Trade, trades$ } from "@/services/trades"
 import type { ColField } from "./colConfig"
@@ -162,7 +155,9 @@ const numFiltersTrueOfTrade = (
       return true
     }
 
-    const tradeNumber = trade[field as NumColField]
+    const tradeValue = trade[field as NumColField]
+    const tradeNumber =
+      typeof tradeValue === "number" ? tradeValue : parseFloat(tradeValue)
     const filterNumber = filterContent.value1
 
     switch (filterContent.comparator) {


### PR DESCRIPTION
*Note - this is my first contributions - please let me know if anything is not following the conventions!*
*Also note - raised MR from main repo b/c PRs from a private fork don't work with the builds at the moment*

### Overview
- Convert string to number for tradeId comparisons
- Fixes === and !== operations

### Details
- For the tradeId column, the `numberFilterTrueOfTrade` is being called on filter change, and the value in the tradeId column is coming as a string and is typed as string|number.  Less than/greater than operator were evaluating the comparison between the number inputted and string value correctly but === and !== were always returning false
- The fix converts the string value found on the field to a number with parseFloat to allow the exact comparisons to compare correctly when the field value is not a number type
- parseFloat was used because it can also work in scenarios where a number column has floats formatted as strings

### Before and After

#### Before (taken from [reactivetrader.com]())

##### Equals
![image](https://user-images.githubusercontent.com/10551665/148829701-77bda06b-2a94-4893-9389-26c174ab1bc1.png) ![image](https://user-images.githubusercontent.com/10551665/148829929-181ebfd0-e349-4ede-8995-4185b109fc5a.png)

##### Not equal
![image](https://user-images.githubusercontent.com/10551665/148830051-0bd817ba-c0e8-43ee-9d71-141653c91081.png)
Note that 2659 is present in the search results.

#### After

##### Equals
![image](https://user-images.githubusercontent.com/10551665/148829044-60aa5f45-fd8b-4378-ba93-a4885c55ded5.png) ![image](https://user-images.githubusercontent.com/10551665/148829137-7eb66a22-9436-456f-87e8-85e55a870dea.png)

##### Not equal 
![image](https://user-images.githubusercontent.com/10551665/148829374-52781d8c-8be8-4033-97ae-42c2b52a5278.png)
Note that 2403 is omitted from the search results.
