### PR TITLE
fix(client): Filter Text (RT-1651)

### DIFF
--- a/src/new-client/src/App/Trades/TradesGrid/components/ComparatorSelect.tsx
+++ b/src/new-client/src/App/Trades/TradesGrid/components/ComparatorSelect.tsx
@@ -38,6 +38,10 @@ const ComparatorSelectInner = styled.select`
     linear-gradient(135deg, ${textColor} 50%, transparent 50%);
   background-position: calc(100% - 5px) center, calc(100%) center;
   background-size: 5px 5px, 5px 5px;
+
+  option {
+    background-color: ${({ theme }) => theme.core.lightBackground};
+  }
 `
 
 export const ComparatorSelect: React.FC<{


### PR DESCRIPTION
# Overview
- On Windows, select options were rending with white background and text was white on white
- Fix - apply theme background color directly to option child element on styled.select
- *Note - did not consult with a UI/PO, assumed theme light background would be acceptable*
- *Note - I would like to fix the padding around the text in the option tags but a quick check on adding margin/padding was not working and from what I found on the internet margin/padding on option tags are generally not supported across browsers*
- *Concern - this was working with Windows 11 but I'd wonder if older Windows/browser versions might not receive the options background color, is there a way for me to test this (e.g. browserstack)?*

# Screenshots
## Windows
### Dark - Before and After
![image](https://user-images.githubusercontent.com/10551665/149572317-f2f50aae-d0ca-452d-aed5-d9d21f7476bc.png) ![image](https://user-images.githubusercontent.com/10551665/149572470-8b45e01a-cb50-4436-9757-2fe091dcb853.png)

### Light - Before and After (no change)
![image](https://user-images.githubusercontent.com/10551665/149572608-2b593b2a-472d-489b-8e82-bd3b23d365db.png)

## Mac
- No impacts to MacOS select for light or dark mode
![image](https://user-images.githubusercontent.com/10551665/149574907-3f7ed563-c1bd-4231-98a9-205886b65824.png)

