### PR TITLE
fix(new-client): Tiles undock on notional input select (RT-1653)

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -9,10 +9,10 @@ import {
   ErrorMessage,
 } from "./Notional.styles"
 import { concat, merge, pipe } from "rxjs"
+import { nonDraggableChildProps } from "@/components/DraggableTearOut/nonDraggableChildProps"
 import { currencyPairs$ } from "@/services/currencyPairs"
 import { filter, map, pluck, take } from "rxjs/operators"
 import { createKeyedSignal } from "@react-rxjs/utils"
-import { nonDraggableChildProps } from "@/components/DraggableTearOut"
 
 const [rawNotional$, onChangeNotionalValue] = createKeyedSignal(
   (x) => x.symbol,

--- a/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -12,6 +12,7 @@ import { concat, merge, pipe } from "rxjs"
 import { currencyPairs$ } from "@/services/currencyPairs"
 import { filter, map, pluck, take } from "rxjs/operators"
 import { createKeyedSignal } from "@react-rxjs/utils"
+import { nonDraggableChildProps } from "@/components/DraggableTearOut"
 
 const [rawNotional$, onChangeNotionalValue] = createKeyedSignal(
   (x) => x.symbol,
@@ -96,6 +97,7 @@ export const NotionalInputInner: React.FC<Props> = ({
   <InputWrapper>
     <CurrencyPairSymbol htmlFor={id}>{base}</CurrencyPairSymbol>
     <Input
+      {...nonDraggableChildProps}
       type="text"
       id={id}
       className={!valid ? `is-invalid` : undefined}

--- a/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
+++ b/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
@@ -110,3 +110,11 @@ const createDragImage = (
     })
   }
 }
+
+export const nonDraggableChildProps = {
+  draggable: true,
+  onDragStart: (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+  },
+}

--- a/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
+++ b/src/new-client/src/components/DraggableTearOut/DraggableTearOut.tsx
@@ -110,11 +110,3 @@ const createDragImage = (
     })
   }
 }
-
-export const nonDraggableChildProps = {
-  draggable: true,
-  onDragStart: (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    event.stopPropagation()
-  },
-}

--- a/src/new-client/src/components/DraggableTearOut/nonDraggableChildProps.ts
+++ b/src/new-client/src/components/DraggableTearOut/nonDraggableChildProps.ts
@@ -1,0 +1,7 @@
+export const nonDraggableChildProps = {
+  draggable: true,
+  onDragStart: (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+  },
+}


### PR DESCRIPTION
# Overview
- Created nonDraggableChildProps for child elements that should not be draggable
- Spread props on notional input

# Details
- Drag movements on the input element were firing the ondragstart event on the notional tile, which was undesirable as the user could not easily highlight/copy parts of the input
- Followed this Stack Overflow article for an approach on the fix - https://stackoverflow.com/questions/6848140/how-do-i-prevent-drag-on-a-child-but-allow-drag-on-the-parent
- draggable must be set to true on the element that should not be dragged and `event.preventDefault()` and `event.stopPropagation()` called in the drag start handler (Drag event is triggered on the input element, then it is cancelled and not propagated to the parent)
- Chose to use a  `nonDraggableChildProps` and spread it so that the logic for dragging (or not dragging) is taken away from the Notional Input and can be used for other components if ever needed

# Before and After

## Before
https://user-images.githubusercontent.com/10551665/150206673-f72aa738-2a28-4b99-a2b9-7e888e251810.mov

## After
https://user-images.githubusercontent.com/10551665/150206704-75988fb5-b77a-40d1-9646-907d64a6f779.mov
