### PR TITLE
fix (new-client): Re-Docking Live Rates tiles view fix

### DIFF
--- a/src/new-client/src/App/LiveRates/MainHeader/ToggleView/ToggleView.tsx
+++ b/src/new-client/src/App/LiveRates/MainHeader/ToggleView/ToggleView.tsx
@@ -3,6 +3,7 @@ import {
   TileView,
   onToggleSelectedView,
   useSelectedTileView,
+  getInitView,
 } from "../../selectedView"
 import { NavItem } from "../../styled"
 import { ChartIcon } from "./ChartIcon"
@@ -32,7 +33,7 @@ const ToggleItem = styled(NavItem)<{ active: boolean }>`
 `
 
 export const ToggleView: React.FC = () => {
-  const tileView = useSelectedTileView()
+  const tileView = useSelectedTileView(getInitView())
   return (
     <ToggleItem
       data-testid="toggleButton"

--- a/src/new-client/src/App/LiveRates/Tiles.tsx
+++ b/src/new-client/src/App/LiveRates/Tiles.tsx
@@ -1,7 +1,7 @@
 import { combineLatest, merge } from "rxjs"
 import styled from "styled-components"
 import { currencyPairs$ } from "@/services/currencyPairs"
-import { TileView, useSelectedTileView } from "./selectedView"
+import { getInitView, TileView, useSelectedTileView } from "./selectedView"
 import { Tile, tile$ } from "./Tile"
 import { map } from "rxjs/operators"
 import { selectedCurrency$, ALL_CURRENCIES } from "./selectedCurrency"
@@ -50,7 +50,7 @@ export const tiles$ = merge(
 
 export const Tiles = () => {
   const currencyPairs = useFilteredCurrencyPairs()
-  const selectedView = useSelectedTileView()
+  const selectedView = useSelectedTileView(getInitView())
   const tearOutEntry = useTearOutEntry()
 
   useEffect(() => {

--- a/src/new-client/src/App/LiveRates/selectedView.ts
+++ b/src/new-client/src/App/LiveRates/selectedView.ts
@@ -12,19 +12,21 @@ export { onToggleSelectedView }
 
 export const SELECTED_VIEW_KEY = "selectedView"
 
-const initView =
+export const getInitView = () =>
   (window.localStorage.getItem(SELECTED_VIEW_KEY) as TileView) ||
   TileView.Analytics
 
 export const [useSelectedTileView] = bind(
-  toggleSelectedView$.pipe(
-    scan(
-      (acc) => (acc === TileView.Normal ? TileView.Analytics : TileView.Normal),
-      initView,
+  (initView: TileView) =>
+    toggleSelectedView$.pipe(
+      scan(
+        (acc) =>
+          acc === TileView.Normal ? TileView.Analytics : TileView.Normal,
+        initView,
+      ),
+      tap((newView) => {
+        window.localStorage.setItem(SELECTED_VIEW_KEY, newView)
+      }),
     ),
-    tap((newView) => {
-      window.localStorage.setItem(SELECTED_VIEW_KEY, newView)
-    }),
-  ),
-  initView,
+  (initView: TileView) => initView,
 )


### PR DESCRIPTION
# Overview

- Updated `useSelectedTileView` to use bind factory constructor
- Pass in current view from window object as initial value to the hook

# Details

## Problem
- Upon re-docking, Live Rates tiles were getting the initView/defautValue for the tile view because the existing subscription to the source observable was closed when the tiles were un-docked
    - New window initializes new observable
- `initView` value default for the bind was set when the user first opened the app, so it was always re-docking to have that very initial value from when the user first loaded the page (either from window object or default Analytics)

## Fix
- The defaultValue/initView for the bind needed to be dynamic, based off the current selected tile view value
- I found that the only way to do this was using the factory bind initializer, where the hook takes an input, and in this case the input is the current selected view (found from the window object, or default, using a helper function)
- Added to `Tiles.tsx` and `ToggleView.tsx` a call to get the initial view (or maybe better worded current view?) that needed to be provided as the default value for the bind

## Alternative Approaches
- I considered other ways to force an initial value out of the observable like a merge map but inevitably found that the solution I used seemed clean and worked well
- One consideration I had was to make a wrapper function within `selectedView.ts` itself so that other components would not have to keep initializing the same way... e.g. `export const useSelectedTileView = () => useSelectedTileViewFactory(getInitView())` but ultimately thought this abstraction could be confusing compared to explicitly calling the factory bind hook in the components

# Screen Capture

## Before

https://user-images.githubusercontent.com/10551665/150415731-6d081ab0-366a-430b-8da2-a507ebcb0732.mov

## After
https://user-images.githubusercontent.com/10551665/150415931-37bbc66e-10d5-4817-9123-f1ab7ae831a9.mov


