### PR TITLE
fix(new-client): Android day/light mode (RT-1663)

### DIFF
--- a/src/new-client/src/App/Header/theme-switcher/ThemeSwitcher.tsx
+++ b/src/new-client/src/App/Header/theme-switcher/ThemeSwitcher.tsx
@@ -38,11 +38,15 @@ const ThemeStorageSwitch: React.FC<ThemeStorageSwitchProps & { theme: Theme }> =
       ...(isTouchDevice && { onTouchStart: handleTouchThemeSwitch }),
     }
 
+    const handleChange = () => {
+      !isTouchDevice && toggleTheme()
+    }
+
     return (
       <SwitchContainer {...eventHandlers}>
         {hover ? (
           <Switch
-            onChange={toggleTheme}
+            onChange={handleChange}
             checked={isDarkTheme}
             checkedIcon={
               <IconContainer hover={hover}>


### PR DESCRIPTION
# Details

## Problem
- `ThemeSwitcher` is configured to call `toggleTheme` when the `onChange` event is fired from `react-switch`
- `ThemeSwitcher` is also configured to call `themeToggle` for `onTouchStart` on devices that support touch
- This was working to support different devices:
     - Mac/PC fire `toggleTheme` event from `react-switch`, only
     - iPhone fires from the `onTouchStart` event, only
     - Android touch was firing the `onChange` event AND `onTouchStart` event, causing the theme to switch and unswitch shortly after

## Fix
- Created `handleChange` handler function for `onChange` to only call `toggleTheme` for non-touch devices so that it would not get misfired by Android

# Screen Capture

## Before
https://user-images.githubusercontent.com/10551665/150604860-525447f0-412b-489a-ae7f-633a94f37a7b.mov

## After
https://user-images.githubusercontent.com/10551665/150604840-dc279e34-e5b5-4baf-8f91-9eaa985158ba.mov


