### PR TITLE
fix(new-client): Notional amount internationalized (RT-1664)

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -33,6 +33,12 @@ const multipliers: Record<string, number> = {
 
 const formatter = customNumberFormatter()
 
+const filterRegExp = new RegExp(
+  `${THOUSANDS_SEPARATOR_REGEXP}|k$|m$|K$|M$`,
+  "g",
+)
+const decimalRegExp = new RegExp(DECIMAL_SEPARATOR_REGEXP, "g")
+
 export const [useNotional, getNotional$] = symbolBind((symbol) =>
   concat(
     currencyPairs$.pipe(
@@ -46,11 +52,6 @@ export const [useNotional, getNotional$] = symbolBind((symbol) =>
   ).pipe(
     map(({ rawVal }) => {
       const lastChar = rawVal.slice(-1).toLowerCase()
-      const filterRegExp = new RegExp(
-        `${THOUSANDS_SEPARATOR_REGEXP}|k$|m$|K$|M$`,
-        "g",
-      )
-      const decimalRegExp = new RegExp(DECIMAL_SEPARATOR_REGEXP, "g")
       const value = Math.abs(
         Number(rawVal.replace(filterRegExp, "").replace(decimalRegExp, ".")) *
           (multipliers[lastChar] || 1),

--- a/src/new-client/src/utils/__tests__/formatNumber.test.ts
+++ b/src/new-client/src/utils/__tests__/formatNumber.test.ts
@@ -5,6 +5,8 @@ import {
   precisionNumberFormatter,
   significantDigitsNumberFormatter,
   customNumberFormatter,
+  getThousandsSeparator,
+  getDecimalSeparator,
 } from "../formatNumber"
 
 describe("all number formatters", () => {
@@ -146,5 +148,24 @@ describe("formatWithScale", () => {
     const input = 123.456
     const expectedOutput = "123.5"
     expect(formatWithScale(input, formatToPrecision1)).toBe(expectedOutput)
+  })
+})
+
+// Note - these tests are dependent on the Intl values for the provided languages
+describe("thousands and decimal formatters", () => {
+  describe("getThousandsSeparator", () => {
+    it("should find ',' for English, '\u00A0' for Russian, and '.' for German", () => {
+      expect(getThousandsSeparator("EN")).toEqual(",")
+      expect(getThousandsSeparator("RU")).toEqual("\u00A0")
+      expect(getThousandsSeparator("DE")).toEqual(".")
+    })
+  })
+
+  describe("getDecimalSeparator", () => {
+    it("should find '.' for English, ',' for Russian, and ',' for German", () => {
+      expect(getDecimalSeparator("EN")).toEqual(".")
+      expect(getDecimalSeparator("RU")).toEqual(",")
+      expect(getDecimalSeparator("DE")).toEqual(",")
+    })
   })
 })

--- a/src/new-client/src/utils/formatNumber.ts
+++ b/src/new-client/src/utils/formatNumber.ts
@@ -13,7 +13,7 @@
  * See __tests__/formatNumber.test.ts for full usage and behavior.
  */
 
-import escapeRegExp from "lodash/fp/escapeRegexp"
+import escapeRegExp from "lodash/fp/escapeRegExp"
 
 enum Scale {
   K = "k",

--- a/src/new-client/src/utils/formatNumber.ts
+++ b/src/new-client/src/utils/formatNumber.ts
@@ -159,16 +159,6 @@ export const THOUSANDS_SEPARATOR = getThousandsSeparator(locale)
  */
 export const DECIMAL_SEPARATOR = getDecimalSeparator(locale)
 
-type EscapeRegExp = (n: string) => string
-
-/**
- * Function to escape special RegExp character that could appear in a formatted number
- */
-export const escapeRegExp: EscapeRegExp = (c) => {
-  const specialChars = "."
-  return specialChars.includes(c) ? `\\${c}` : c
-}
-
 /**
  * Thousands separator for numbers in current locale, for use in regular expressions
  */

--- a/src/new-client/src/utils/formatNumber.ts
+++ b/src/new-client/src/utils/formatNumber.ts
@@ -8,8 +8,12 @@
  *
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation
  *
+ * Also exports raw and RegExp friendly variables for a locale's thousands and decimal separator values
+ *
  * See __tests__/formatNumber.test.ts for full usage and behavior.
  */
+
+import escapeRegExp from "lodash/fp/escapeRegexp"
 
 enum Scale {
   K = "k",
@@ -27,6 +31,8 @@ const k = 1_000
 const m = k * k
 const b = m * k
 const t = b * k
+
+const locale = "default"
 
 export const scaleNumber: (v: number) => ScaledNumber = (val: number) => {
   const magnitude = Math.abs(val)
@@ -55,7 +61,7 @@ type NumberFormatter = (n: number) => string
 const numberFormatter = (
   options?: Intl.NumberFormatOptions,
 ): NumberFormatter => {
-  const nf = new Intl.NumberFormat("default", { ...options })
+  const nf = new Intl.NumberFormat(locale, { ...options })
 
   return (num: number) => {
     if (typeof num !== "number") {
@@ -126,3 +132,49 @@ export const formatWithScale = (num: number, format: NumberFormatter) => {
   const { value, scale } = scaleNumber(num)
   return format(value) + scale
 }
+
+// The following code deals with finding the thousands and decimal separators for the current locale
+// Functions were chosen in order to write unit tests that would not be depended on driver default locale
+// "Magic Number" 1000.5 was chosen to accessing the thousands/decimal values
+// Assumes that for this number, for all locales, the thousands and decimal separators will occur at the provided indices
+// Preference would have been given to a native Intl function for finding these values, but none appear to be exposed at this time
+
+type SeparatorGetter = (_locale: string) => string
+
+export const getThousandsSeparator: SeparatorGetter = (_locale) => {
+  return new Intl.NumberFormat(_locale).formatToParts(1000.5)[1].value
+}
+
+export const getDecimalSeparator: SeparatorGetter = (_locale) => {
+  return new Intl.NumberFormat(_locale).formatToParts(1000.5)[3].value
+}
+
+/**
+ * Thousands separator for numbers in current locale
+ */
+export const THOUSANDS_SEPARATOR = getThousandsSeparator(locale)
+
+/**
+ * Decimal separator for numbers in current locale
+ */
+export const DECIMAL_SEPARATOR = getDecimalSeparator(locale)
+
+type EscapeRegExp = (n: string) => string
+
+/**
+ * Function to escape special RegExp character that could appear in a formatted number
+ */
+export const escapeRegExp: EscapeRegExp = (c) => {
+  const specialChars = "."
+  return specialChars.includes(c) ? `\\${c}` : c
+}
+
+/**
+ * Thousands separator for numbers in current locale, for use in regular expressions
+ */
+export const THOUSANDS_SEPARATOR_REGEXP = escapeRegExp(THOUSANDS_SEPARATOR)
+
+/**
+ * Decimal separator for numbers in current locale, for use in regular expressions
+ */
+export const DECIMAL_SEPARATOR_REGEXP = escapeRegExp(DECIMAL_SEPARATOR)


### PR DESCRIPTION
# Details

## Cause
- Tester was unable to enter more than 4 characters, the issue was that the `Intl` utility was detecting Russian on their Android device and the Notional controlled input formatter was not supporting the `" "` characters used as the Russian thousands separator

## Fix
- Needed to generalized the thousands and decimal separators
- Modified `formatNumber.ts` to have the locale as a variable so that it can re-used and changed for testing (left as default but locally I can run RU and DE for example)
- Export values for the thousands/decimal separator, had to create a way to find them with functions because it appears `Intl` does not have any exposed functions for getting directly
- Exported the helper functions to unit test them (did not love this but I think its okay - open to ideas)
- Using lodash `convertRegExp` to create RegExp safe versions of the delimiters and also export those (really only required for the `.` character)
- In `Notional.tsx`:
    - Import formatter/values from `formatNumbers.ts `
    - Create the dynamic `filterRegExp` which removes non-number characters from the raw input so that it can be converted to a number
    - Create the `decimalRegExp` and apply it after applying `filterRegExp` so that the decimal separator is always `.` which I assume is needed for JavaScript to convert the string to a number, however if I was running in locale where `,` is actually used I'd be curious about the result... but my assumption is that JavaScript universally uses `.`
   
# Before and After
## Before
Before for Russian is available at this recording: https://www.screencast.com/t/wS1Ie5Z9bR

## After
Completed after testing for Russian, German, and US

### Russian
https://user-images.githubusercontent.com/10551665/150999709-fea80d03-ac9e-468f-b38e-224d73cb2b1c.mov

### German
https://user-images.githubusercontent.com/10551665/150999675-913c2898-df05-4e8a-ab2c-196a2cba1183.mov

### US
https://user-images.githubusercontent.com/10551665/150999738-1e14a5e4-7c8c-4d7d-a65c-a29a4ae0d4e3.mov
