### PR TITLE
fix(new-client): miscellaneous buy/sell numbers

### DIFF
--- a/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
+++ b/src/new-client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
@@ -3,6 +3,7 @@ import { Direction } from "@/services/trades"
 import {
   customNumberFormatter,
   significantDigitsNumberFormatter,
+  DECIMAL_SEPARATOR,
 } from "@/utils/formatNumber"
 import { map, switchMap } from "rxjs/operators"
 import { bind } from "@react-rxjs/core"
@@ -54,6 +55,8 @@ const [usePrice, getPriceDirection$] = bind(
 export const priceButton$ = (direction: Direction) => (symbol: string) =>
   getPriceDirection$(symbol, direction)
 
+const formatSimple = customNumberFormatter()
+const formatTo2Digits = significantDigitsNumberFormatter(2)
 const formatTo3Digits = significantDigitsNumberFormatter(3)
 const formatToMin2IntDigits = customNumberFormatter({
   minimumIntegerDigits: 2,
@@ -88,13 +91,19 @@ export const PriceButtonInner: React.FC<PriceButtonProps> = ({
   const pip = formatToMin2IntDigits(
     Number(fractions.substring(pipsPosition - 2, pipsPosition)),
   )
-  const tenth = Number(fractions.substring(pipsPosition, pipsPosition + 1))
+  const tenth = formatSimple(
+    Number(fractions.substring(pipsPosition, pipsPosition + 1)),
+  )
 
   const bigFigureNumber = Number(
     wholeNumber + "." + fractions.substring(0, pipsPosition - 2),
   )
-  let bigFigure = formatTo3Digits(bigFigureNumber)
-  if (bigFigureNumber === Math.floor(bigFigureNumber)) bigFigure += "."
+  let bigFigure =
+    bigFigureNumber < 1 && pipsPosition === 4
+      ? formatTo2Digits(bigFigureNumber)
+      : formatTo3Digits(bigFigureNumber)
+  if (bigFigureNumber === Math.floor(bigFigureNumber))
+    bigFigure += DECIMAL_SEPARATOR
 
   return (
     <TradeButton


### PR DESCRIPTION
## Trailing 0 for "bigNumber" portion of Buy/Sell number < 1
- Problem: For AUD/USD and NZD/USD conversions, `formatTo3Digits` was appending a trailing 0 on the first part of the buy/sell numbers, a rate of .82671 would render as .820 67 1, since .82 only has 2 significant digits.
- Fix: Added a check for `bigFigureNumber < 1 && pipsPosition === 4`, which accurately finds scenarios where the `bigFigureNumber` only has 2 significant digits and use `formatTo2Digits` in this scenario

### Before
![Screen Shot 2022-01-26 at 11 21 26 AM](https://user-images.githubusercontent.com/10551665/151203550-99863fdd-a8b8-46be-8995-53720f39b991.png)

### After
![Screen Shot 2022-01-26 at 11 18 41 AM](https://user-images.githubusercontent.com/10551665/151203396-fb7c9ba2-b1fd-40e3-8b5b-5308d92163d2.png)

## Internationalized decimal separator usage for buy/sell when decimal separator is manually added
- Problem: When the pips number is 2 (JPY currencies), the decimal separator is manually added between `bigFigureNumber` and the pips because the `bigFigureNumber` is a whole number and the separator is not added by the formatter.  It was hard coded to `.`
- Fix: Use calculated internationalized `DECIMAL_SEPARATOR`

### Before
![Screen Shot 2022-01-26 at 11 21 59 AM](https://user-images.githubusercontent.com/10551665/151203528-f30bc4bc-c425-47fa-aadc-297b455e3d48.png)

### After
![Screen Shot 2022-01-26 at 11 19 56 AM](https://user-images.githubusercontent.com/10551665/151203414-69be0779-ead1-4380-a2cd-3221105c5a00.png)

## Tenths (final) digit was never passed through a `Intl` formatter, causing an inconsistency (Arabic)
- Problem: The Tenths (final) digit was rendering as a raw number while the rest of the buy/sell number was getting formatted at some point
- Fix: Use `formatSimple` to pass the `tenth` value through an `Intl` formatter

### Before
![Screen Shot 2022-01-26 at 11 22 38 AM](https://user-images.githubusercontent.com/10551665/151203512-5d04a1da-a54b-49d4-a7c5-431186da809a.png)

### After
![Screen Shot 2022-01-26 at 11 20 37 AM](https://user-images.githubusercontent.com/10551665/151203461-76191adf-beee-4786-8e5b-bdf2cf6d9fd0.png)