### PR TITLE
fix(new-client): Export to Excel notional column

### DIFF
--- a/src/new-client/src/App/Trades/TradesHeader/ExcelButton.tsx
+++ b/src/new-client/src/App/Trades/TradesHeader/ExcelButton.tsx
@@ -51,7 +51,9 @@ export const exportTable$ = tableTrades$.pipe(
     trades.map((trade) =>
       colFields.map((field) => {
         let res =
-          colConfigs[field].valueFormatter?.(trade[field]) ?? trade[field]
+          colConfigs[field].excelValueFormatter?.(trade[field]) ??
+          colConfigs[field].valueFormatter?.(trade[field]) ??
+          trade[field]
         if (typeof res === "string" && res?.includes(",")) {
           res = '"' + res + '"'
         }

--- a/src/new-client/src/App/Trades/TradesState/colConfig.ts
+++ b/src/new-client/src/App/Trades/TradesState/colConfig.ts
@@ -4,11 +4,14 @@ import {
   significantDigitsNumberFormatter,
   formatAsWholeNumber,
   capitalize,
+  THOUSANDS_SEPARATOR,
 } from "@/utils"
 
 export type ColField = keyof Trade
 
 export type FilterType = "set" | "date" | "number"
+
+type ValueFormatter = (val: unknown) => string
 
 /**
  * All of these values are configured centrally because
@@ -19,18 +22,23 @@ export type FilterType = "set" | "date" | "number"
  * headerName - display name for the column field / trade key
  * filterType - type of filter predicate that applies to the column
  * valueFormatter - how to display the field values in the column
+ * excelValueFormatter - if defined, overwrites valueFormatter when exporting to Excel/CSV
  * width - needed to keep header/body cells same width
  */
 export interface ColConfig {
   headerName: string
   filterType: FilterType
-  valueFormatter?: (val: unknown) => string
+  valueFormatter?: ValueFormatter
+  excelValueFormatter?: ValueFormatter
   width: number
 }
 
 export const DATE_FORMAT = "dd-MMM-yyyy"
 
 const formatTo6Digits = significantDigitsNumberFormatter(6)
+
+const notionalExcelValueFormatter: ValueFormatter = (v) =>
+  formatAsWholeNumber(v as number).replaceAll(THOUSANDS_SEPARATOR, "")
 
 export const colConfigs: Record<ColField, ColConfig> = {
   tradeId: {
@@ -69,6 +77,7 @@ export const colConfigs: Record<ColField, ColConfig> = {
     headerName: "Notional",
     filterType: "number",
     valueFormatter: (v) => formatAsWholeNumber(v as number),
+    excelValueFormatter: notionalExcelValueFormatter,
     width: 120,
   },
   spotRate: {


### PR DESCRIPTION
# Details

## Cause
- The suspected cause is that the version and language/region configurations on the Excel being used to read the CSV could not interpret the thousands separator in the exported CSV
    - I suspect the thousand separator was the "thin whitespace" character used in Russian
 
## Fix
- It was decided that the thousands separator would be removed from the notional column in the Excel export altogether
- This introduced the requirement that the formatting for Excel could be different from the formatting for the table
    - I decided to make an `excelValueFormatter` function field on the `ColConfig` interface
    - In `ExcelButton.tsx`, if `excelValueFormatter` is defined, it is used to format the value, otherwise the existing format functionality is followed (`valueFormatter` is used, otherwise the raw value is used)
    - `excelValueFormatter` is only used for the notional column, but this solution is extensible in case a decision is made to modify how any other fields are exported and it is cleaner than doing an `if` check for notional in `ExcelButton.tsx` itself
- For the notional column, I created a function for the `excelValueFormatter` field that follows the existing process (`formatAsWholeNumber`) and then removes the thousands separators
    - I thought of just directly returning the value without formatting then essentially removing the formatting,  but `formatAsWholeNumber` is rounding the notional column to a whole number and I don't want to take that away from the Excel export unless there is an ask to do so

# Before and After
Note - data values are not the same in the before/after, purpose is to show notional column formatting

## Before

### US
![image](https://user-images.githubusercontent.com/10551665/151230725-42297c5f-ee4a-4112-959c-3ffdad4bebf4.png)

### Russian
![image](https://user-images.githubusercontent.com/10551665/151230448-dde80528-69d2-4b3a-9704-6d6570b38468.png)


## After

### US
![image](https://user-images.githubusercontent.com/10551665/151231288-625df323-02fa-4cf0-8de5-75d7a35e990c.png)

### Russian
![image](https://user-images.githubusercontent.com/10551665/151230550-7da43e62-1eb7-4fde-80c4-9c0a48e868e0.png)

