### PR TITLE
fix(client): fixed draggable inputs in trades (blotter)

### DIFF
--- a/src/client/src/App/Trades/TradesGrid/NumFilter.tsx
+++ b/src/client/src/App/Trades/TradesGrid/NumFilter.tsx
@@ -7,6 +7,7 @@ import {
 } from "../TradesState"
 import { FilterPopup } from "./components/FilterPopup"
 import { ComparatorSelect } from "./components/ComparatorSelect"
+import { nonDraggableChildProps } from "@/components/DraggableTearOut/nonDraggableChildProps"
 
 const FilterValueInputInner = styled.input`
   grid-area: Input;
@@ -31,6 +32,7 @@ const FilterValueInput: React.FC<{
   fieldValueName: "value1" | "value2"
 }> = ({ field, selected, fieldValueName }) => (
   <FilterValueInputInner
+    {...nonDraggableChildProps}
     placeholder="Filter..."
     role="textbox"
     defaultValue={selected[fieldValueName] ?? undefined}

--- a/src/client/src/App/Trades/TradesGrid/SetFilter.tsx
+++ b/src/client/src/App/Trades/TradesGrid/SetFilter.tsx
@@ -12,6 +12,7 @@ import {
 import { FilterPopup } from "./components/FilterPopup"
 import { onSearchInput, searchInputs$ } from "../TradesState/filterState"
 import { filter, map, startWith } from "rxjs/operators"
+import { nonDraggableChildProps } from "@/components/DraggableTearOut/nonDraggableChildProps"
 
 const MultiSelectOption = styled.div<{
   selected: boolean
@@ -70,6 +71,7 @@ const SetFilterInner: React.FC<{
   return (
     <FilterPopup parentRef={parentRef}>
       <SearchInput
+        {...nonDraggableChildProps}
         type="text"
         placeholder="Search"
         value={inputValue}

--- a/src/client/src/App/Trades/TradesHeader/QuickFilter.tsx
+++ b/src/client/src/App/Trades/TradesHeader/QuickFilter.tsx
@@ -1,3 +1,4 @@
+import { nonDraggableChildProps } from "@/components/DraggableTearOut/nonDraggableChildProps"
 import { useEffect, useRef, useState } from "react"
 import { FaFilter, FaTimes } from "react-icons/fa"
 import styled from "styled-components"
@@ -76,6 +77,7 @@ export const QuickFilter: React.FC = () => {
         <FaFilter aria-hidden="true" />
       </QuickFilterIcon>
       <QuickFilterInput
+        {...nonDraggableChildProps}
         ref={quickFilterInput}
         type="search"
         placeholder="Filter"


### PR DESCRIPTION
### Overview

- Used nonDraggableChildProps for child elements that should not be draggable within Trades (Blotter) section.
- Spread props on QuickFilter, NumFilter, and SetFilter inputs to prevent dragging from within input.

### Details

- Drag movements on the input elements were firing the ondragstart event on the Trades filter input fields, which was undesirable as the user could not easily highlight/copy parts of the input

- nonDraggableChildProps was created in [this](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/2027) fix, and now it is extended to input elements within Trades.

### Before

https://user-images.githubusercontent.com/42718557/158416878-8e873e53-30e8-4650-a43f-7a45e4b66a20.mov

### After

https://user-images.githubusercontent.com/42718557/158416772-2c1cdb5f-d510-436a-a876-19b269ebe568.mov




