### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ steps.vars.outputs.URL_SUFFIX }}
 
       - name: Set up GCloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -15,7 +15,7 @@ env:
   BUCKET_OPENFIN: reactive-trader-openfin-builds
   BUCKET_FINSEMBLE: reactive-trader-finsemble-builds
   BUCKET_LAUNCHER: reactive-trader-launcher-builds
-  
+
 jobs:
   build:
     name: Build & deploy
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up GCloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "::set-output name=tag::$(git describe --tag --abbrev=0)"
 
       - name: Set up GCloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in
a future release. Even though GitHub will establish redirects, this
will break any GitHub Actions workflows that pin to master. This PR
updates your GitHub Actions workflows to pin to v0, which is the
recommended best practice.