### PR TITLE
Clean up warnings and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Reactive Trader® is a real-time FX trading platform designed to showcase reactive programming principles across the full application stack.
 
-Originally [written in WPF and .Net](https://github.com/AdaptiveConsulting/ReactiveTrader), and now in React, React-RxJS, Node.js and running on [Hyrda](https://weareadaptive.com/platform-solutions/), we continue to evolve the platform to use the latest technologies.
+Originally [written in WPF and .Net](https://github.com/AdaptiveConsulting/ReactiveTrader), and now in React, React-RxJS, Node.js and running on [Hydra](https://weareadaptive.com/platform-solutions/), we continue to evolve the platform to use the latest technologies.
 
 Please see [our Showcase page](https://weareadaptive.com/showcase/) for a full list of the latest features.
 

--- a/src/client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
+++ b/src/client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
@@ -83,7 +83,7 @@ export const PriceButtonInner: React.FC<PriceButtonProps> = ({
   isStatic,
   onClick,
 }) => {
-  const { pipsPosition, ratePrecision, symbol } = currencyPair
+  const { pipsPosition, ratePrecision } = currencyPair
   const rateString = price.toFixed(ratePrecision)
   const [wholeNumber, fractions_] = rateString.split(".")
   const fractions = fractions_ || "00000"

--- a/src/client/src/Web/MainRoute.tsx
+++ b/src/client/src/Web/MainRoute.tsx
@@ -60,7 +60,7 @@ export const MainRoute: React.FC = () => {
         handleTearOutSection(section)
       }
     }
-  }, [tearOutEntry])
+  }, [tearOutEntry, tornOutSectionState])
 
   return (
     <Wrapper>


### PR DESCRIPTION
- fix linting warnings
```
src/client/src/Web/MainRoute.tsx
  63:6  warning  React Hook useEffect has a missing dependency: 'tornOutSectionState'. Either include it or remove the dependency array. You can also do a functional update 'setTornOutSectionState(t => ...)' if you only need 'tornOutSectionState' in the 'setTornOutSectionState' call  react-hooks/exhaustive-deps

src/client/src/App/LiveRates/Tile/PriceButton/PriceButton.tsx
  86:40  warning  'symbol' is assigned a value but never used  @typescript-eslint/no-unused-vars
```
- fix typo in README