### PR TITLE
chore(client): upgrade OpenFin to v25

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -37497,11 +37497,6 @@
         }
       }
     },
-    "@finos/fdc3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-1.2.0.tgz",
-      "integrity": "sha512-im/vqpS96qsCKMPkwR/Fg2t2FQtwh+/LOvTekIY0eYyuz/CZQoqhwcxwk/Re0pqJiA3inisV7DSfQ1JYLi+bxw=="
-    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -55663,9 +55658,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "dev": true,
       "optional": true
     },

--- a/src/client/public-openfin/app.json
+++ b/src/client/public-openfin/app.json
@@ -2,18 +2,18 @@
   "platform": {
     "uuid": "reactive-trader-<ENV_NAME>",
     "name": "Reactive Trader®<ENV_SUFFIX>",
-    "applicationIcon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
+    "icon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
     "url": "<BASE_URL>",
-    "fdc3Api": true,
+    "autoShow": false,
     "defaultWindowOptions": {
       "contextMenu": true,
       "frame": false,
-      "applicationIcon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
+      "icon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
       "url": "<BASE_URL>/openfin-sub-window-frame"
     }
   },
   "runtime": {
-    "version": "17.85.53.10"
+    "version": "25.100.69.8"
   },
   "services": [
     {
@@ -39,7 +39,7 @@
   "snapshot": {
     "windows": [
       {
-        "applicationIcon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
+        "icon": "<BASE_URL>/static/media/reactive-trader-icon-256x256.png",
         "autoShow": true,
         "defaultWidth": 1280,
         "defaultHeight": 900,

--- a/src/client/public-openfin/launcher.json
+++ b/src/client/public-openfin/launcher.json
@@ -2,7 +2,7 @@
   "platform": {
     "uuid": "reactive-launcher-<ENV_NAME>",
     "name": "Reactive Launcher<ENV_SUFFIX>",
-    "applicationIcon": "<BASE_URL>/static/media/adaptive-icon-256x256.png",
+    "icon": "<BASE_URL>/static/media/adaptive-icon-256x256.png",
     "defaultWindowOptions": {
       "contextMenu": true,
       "frame": false,
@@ -13,7 +13,6 @@
         }
       }
     },
-    "fdc3Api": true,
     "permissions": {
       "System": {
         "launchExternalProcess": true
@@ -21,7 +20,7 @@
     }
   },
   "runtime": {
-    "version": "17.85.53.10",
+    "version": "25.100.69.8",
     "arguments": "--remote-debugging-port=9091"
   },
   "services": [

--- a/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
+++ b/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
@@ -1,4 +1,3 @@
-import { broadcast } from "@finos/fdc3"
 import styled, { css } from "styled-components"
 import { Trade, TradeStatus } from "@/services/trades"
 import {
@@ -8,6 +7,7 @@ import {
   useTableTrades,
 } from "../TradesState"
 import { TableHeadCellContainer } from "./TableHeadCell"
+import useInterApplicationBus from "./useInterApplicationBus"
 
 const TableWrapper = styled.div`
   height: calc(100% - 4.75rem);
@@ -144,26 +144,13 @@ export const TradesGridInner: React.FC<{
 export const TradesGrid: React.FC = () => {
   const trades = useTableTrades()
   const highlightedRow = useTradeRowHighlight()
-
-  const tryBroadcastContext = (symbol: string) => {
-    const context = {
-      type: "fdc3.instrument",
-      id: { ticker: symbol },
-    }
-
-    if (window.fdc3) {
-      broadcast(context)
-    } else if (window.fin) {
-      // @ts-ignore
-      fin.me.interop.setContext(context)
-    }
-  }
+  const dispatchSelectedSymbol = useInterApplicationBus()
 
   return (
     <TradesGridInner
       trades={trades}
       highlightedRow={highlightedRow}
-      onRowClick={tryBroadcastContext}
+      onRowClick={dispatchSelectedSymbol}
     />
   )
 }

--- a/src/client/src/App/Trades/TradesGrid/useInterApplicationBus.ts
+++ b/src/client/src/App/Trades/TradesGrid/useInterApplicationBus.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from "react"
+import { ChannelClient } from "openfin/_v2/main"
+
+function useInterApplicationBus(): (symbol: string) => void {
+  const channelClientRef = useRef<null | ChannelClient>(null)
+  const connectRetriesRef = useRef(1)
+  const disconnectedIntentionallyRef = useRef(false)
+
+  useEffect(() => {
+    if (!window.fin) {
+      return
+    }
+    function handleDisconnection() {
+      console.log("Disconnected from InterApplicationBus")
+      // suppress sending messages until connection established
+      channelClientRef.current = null
+
+      // prevent infinite recursion on recurring disconnections
+      connectRetriesRef.current += 1
+      const CONNECTION_RETRY_LIMIT = 50
+      if (connectRetriesRef.current > CONNECTION_RETRY_LIMIT) {
+        console.log(
+          `Exceeded connection retry limit of ${CONNECTION_RETRY_LIMIT}, ` +
+            `will not reconnect to InterApplicationBus`,
+        )
+        return
+      }
+      if (disconnectedIntentionallyRef.current) {
+        console.log(
+          "Connection to InterApplicationBus has been terminated " +
+            "intentionally, will not reconnect",
+        )
+        return
+      }
+      connectToInterApplicationBus()
+    }
+    async function connectToInterApplicationBus() {
+      console.log(
+        `About to connect to InterApplicationBus, attempt ${connectRetriesRef.current}`,
+      )
+      try {
+        channelClientRef.current =
+          await fin.InterApplicationBus.Channel.connect("reactive-ecosystem")
+        console.log("Successfully connected to InterApplicationBus")
+        channelClientRef.current.onDisconnection(handleDisconnection)
+      } catch (e) {
+        console.log("Unable to connect to InterApplicationBus", e)
+      }
+    }
+
+    connectToInterApplicationBus()
+
+    return () => {
+      disconnectedIntentionallyRef.current = true // suppress reconnection
+      channelClientRef.current?.disconnect()
+    }
+  }, [])
+
+  return function dispatchSelectedSymbol(symbol: string) {
+    if (!window.fin) {
+      return
+    }
+    if (channelClientRef.current === null) {
+      console.log(
+        "Unable to dispatch symbol selection message; channel connection not established",
+      )
+      return
+    }
+    const payload = { symbol }
+    console.log("About to dispatch symbol selection message", payload)
+    channelClientRef.current
+      .dispatch("symbol-selection", payload)
+      .catch((e) =>
+        console.error("Failed to dispatch symbol selection message", e),
+      )
+  }
+}
+
+export default useInterApplicationBus


### PR DESCRIPTION
The latest FDC3 API does not support sending messages across different platforms.
We want to send messages to ReactiveTraderCloud. Since these two applications
have distinct UUIDs in their OpenFin manifest (app.json), they cannot communicate
via FDC3 Interop API. We don't want to change to a shared UUID because the
Launcher app currently references ReactiveAnalytics and ReactiveTrader by their
UUIDs, so they need to be distinct.

In order to upgrade OpenFin runtime to latest version without breaking interop
between ReactiveTrader and ReactiveAnalytics, we are moving from using the
FDC3 Interop API to instead use the OpenFin InterApplicationBus
https://developer.openfin.co/docs/javascript/25.100.69.8/InterApplicationBus.Channel.html
which supports communicating across OpenFin platforms.

## Test Plan

1. pull upgrade-openfin branches for RT and RA repos
2. ensure no OpenFin processes running
3. clear OpenFin cache
4. run Launcher, RT, and RA
    1. `ReactiveTraderCloud\src\client> npm run openfin:dev`
    1. `ReactiveTraderCloud\src\client> npm run launcher:start`
    1. `ReactiveAnalytics> yarn start`
    1. launch RA and RT from launcher
5. in OpenFin
    1. execute a trade in RT
        1. verify it appears in blotter
        1. verify trade notifications appear
    1. select a trade in the RT blotter
        1. verify that selected currency pair appears in RA
        1. to test reconnecting to InterApplicationBus, close and relaunch RA
        1. verify that selecting trade in RT blotter still populates selected currency pair in RA
    1. save a snapshot, modify view, save another snapshot
    1. restore initial snapshot, verify it appears as expected
6. Chrome
    1. `ReactiveTraderCloud\src\client> npm run openfin:dev`
    1. execute a trade in RT, verify it appears in blotter
    1. select a trade in blotter, verify no messages in console
