### PR TITLE
Fix/2373 tile scroll

### DIFF
--- a/src/client/src/App/LiveRates/Tile/TearOut/TornOutTile.tsx
+++ b/src/client/src/App/LiveRates/Tile/TearOut/TornOutTile.tsx
@@ -10,7 +10,9 @@ import styled from "styled-components"
 import { useTearOutEntry } from "./state"
 
 const Wrapper = styled("div")`
-  margin: 8px;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 8px;
 `
 
 export const TornOutTile = withSubscriber<{
@@ -29,7 +31,7 @@ export const TornOutTile = withSubscriber<{
       }
     }
   }, [tearOutEntry])
-  
+
   return (
     <Wrapper>
       <Tile

--- a/src/client/src/App/LiveRates/Tile/TearOut/handleTearOut.web.ts
+++ b/src/client/src/App/LiveRates/Tile/TearOut/handleTearOut.web.ts
@@ -9,7 +9,7 @@ export function handleTearOut(symbol: string) {
       url: constructUrl(ROUTES_CONFIG.tile.replace(":symbol", symbol)),
       name: symbol,
       width: 380,
-      height: 170,
+      height: 172,
     },
     () => tearOut(symbol, false),
   )

--- a/src/client/src/theme/GlobalScrollbarStyle.tsx
+++ b/src/client/src/theme/GlobalScrollbarStyle.tsx
@@ -7,7 +7,7 @@ const getColor = (props: { theme: Theme }) =>
 
 export const GlobalScrollbarStyle = withTheme(createGlobalStyle`
 body, #root {
-  // overflow: hidden; // TODO
+  overflow: hidden;
 }
 
 body ::-webkit-scrollbar {


### PR DESCRIPTION
- Removed unstyled default "browser" scrollbar from tear-out tiles in openfin and finsemble apps
- increased default window size for tear-out tile to hide scrollbar on open

### OF / Finsemble before:
![OF_before_scroll](https://user-images.githubusercontent.com/106198976/172878056-2a97e9c7-2e9c-405b-9cdb-1c6304b5fa2e.PNG)

### OF / Finsemble after fix:
![finsemble_fix_scroll](https://user-images.githubusercontent.com/106198976/172878263-35d76063-358b-4de3-bcb1-5d8f91a36b82.PNG)

### Webapp before:
![webapp_fix_scroll](https://user-images.githubusercontent.com/106198976/172878391-a949fba6-63dd-44c9-88d4-31269269f03f.PNG)

### Webapp after:
![webapp_after_scroll](https://user-images.githubusercontent.com/106198976/172879517-62f3bc65-b665-4477-b38f-debbeec2bdb8.PNG)

 