### PR TITLE
fix(styleguide): add global style override to stylguide to enable scroll

### DIFF
--- a/src/client/src/styleguide/index.tsx
+++ b/src/client/src/styleguide/index.tsx
@@ -1,6 +1,6 @@
 import { createRef, FC } from "react"
 import Helmet from "react-helmet"
-import styled from "styled-components"
+import styled, { createGlobalStyle } from "styled-components"
 import FloatingTools from "./components/FloatingsTools"
 import OnePageNavBar from "./components/OnePageNavBar"
 import Introduction from "./sections/Introduction"
@@ -35,6 +35,7 @@ const Styleguide: FC = () => {
 
   return (
     <>
+      <StyleGuideGlobal />
       <Helmet title={"Style Guide for Reactive Trader®"}>
         <link
           rel="stylesheet"
@@ -57,6 +58,12 @@ const Styleguide: FC = () => {
     </>
   )
 }
+
+const StyleGuideGlobal = createGlobalStyle`
+  body, #root {
+    overflow: initial;
+  }
+`
 
 const ScrollableContainer = styled.div`
   scroll-margin: 76px;


### PR DESCRIPTION
Fixes a bug in the /styleguide caused by https://github.com/AdaptiveConsulting/ReactiveTraderCloud/pull/2070 where the body is not scrolling.