### PR TITLE
Es locale fix

### DIFF
--- a/src/client/src/utils/__tests__/formatNumber.test.ts
+++ b/src/client/src/utils/__tests__/formatNumber.test.ts
@@ -154,18 +154,22 @@ describe("formatWithScale", () => {
 // Note - these tests are dependent on the Intl values for the provided languages
 describe("thousands and decimal formatters", () => {
   describe("getThousandsSeparator", () => {
-    it("should find ',' for English, '\u00A0' for Russian, and '.' for German", () => {
+    it("should find ',' for English, '\u00A0' for Russian, and '.' for German and Spanish, ' ' for Finnish", () => {
       expect(getThousandsSeparator("EN")).toEqual(",")
       expect(getThousandsSeparator("RU")).toEqual("\u00A0")
       expect(getThousandsSeparator("DE")).toEqual(".")
+      expect(getThousandsSeparator("es-ES")).toEqual(".")
+      expect(getThousandsSeparator("fi-FI")).toEqual("\u00A0")
     })
   })
 
   describe("getDecimalSeparator", () => {
-    it("should find '.' for English, ',' for Russian, and ',' for German", () => {
+    it("should find '.' for English and Finnish, ',' for Russian, and ',' for German and Spanish, ", () => {
       expect(getDecimalSeparator("EN")).toEqual(".")
       expect(getDecimalSeparator("RU")).toEqual(",")
       expect(getDecimalSeparator("DE")).toEqual(",")
+      expect(getDecimalSeparator("es-ES")).toEqual(",")
+      expect(getDecimalSeparator("fi-FI")).toEqual(",")
     })
   })
 })

--- a/src/client/src/utils/formatNumber.ts
+++ b/src/client/src/utils/formatNumber.ts
@@ -142,11 +142,15 @@ export const formatWithScale = (num: number, format: NumberFormatter) => {
 type SeparatorGetter = (_locale: string) => string
 
 export const getThousandsSeparator: SeparatorGetter = (_locale) => {
-  return new Intl.NumberFormat(_locale).formatToParts(1000.5)[1].value
+  return new Intl.NumberFormat(_locale)
+    .formatToParts(10000.5)
+    .find((part) => part.type === "group")?.value!
 }
 
 export const getDecimalSeparator: SeparatorGetter = (_locale) => {
-  return new Intl.NumberFormat(_locale).formatToParts(1000.5)[3].value
+  return new Intl.NumberFormat(_locale)
+    .formatToParts(10000.5)
+    .find((part) => part.type === "decimal")?.value!
 }
 
 /**


### PR DESCRIPTION
When getDecimalSeparator and getThousandsSeparator functions were implemented to correctly export the numbers from blotter to CSV(Excel), a magic number had to be used to detect each locale's separators. This magic number (1000.5) was flawed in es-ES locale, because 4-digit numbers do not have thousands separator in Spain.
Unfortunately, there is no way to do this detection without a magic number yet, therefore I changed the magic number to include thousands separator after checking in over 20 locales, and implemented a few more tests.