### PR TITLE
fix(positions): bubbles div size fix

### DIFF
--- a/src/client/src/App/Analytics/Positions/Positions.tsx
+++ b/src/client/src/App/Analytics/Positions/Positions.tsx
@@ -24,9 +24,11 @@ const d3Effect = (chartDiv: HTMLDivElement) => {
     .attr("data-testid", "tooltip")
 
   // const svg: Selection<SVGElement> = select(chartDiv).select("svg")
-  const { width, height } = chartDiv
-    ? chartDiv.getBoundingClientRect()
-    : { width: 0, height: 0 }
+  //TODO Refactor - Make sure getBoundingClientRect runs after the chartDiv has width
+  const { width, height } =
+    chartDiv.getBoundingClientRect().width !== 0
+      ? chartDiv.getBoundingClientRect()
+      : { width: 288, height: 288 }
   const svg = select(chartDiv)
     .append("svg")
     .attr("width", width)


### PR DESCRIPTION
d3Effect function where the svg for the positions bubbles are created, is running before the encompassing div gets correct width and height leading to an error in the detection of the size of this div(it is 0 when the function runs on load/reload of the page). 
For demo purposes it is conditioned to get a fixed width and height(288px) temporarily as the dimensions of this element do not change with resizing. 