### PR TITLE
fix(credit): correct precision on quantity and price inputs

### DIFF
--- a/src/client/README.md
+++ b/src/client/README.md
@@ -63,7 +63,21 @@ Run the client using mocks:
 VITE_MOCKS=true npm start
 ```
 
-Run the client with a back end on the cloud:
+Run the client against the Dev back end in the cloud
+
+(uses `wss://trading-web-gateway-rt-dev.demo.hydra.weareadaptive.com`)
+
+```sh
+npm start
+```
+
+NOTE: you may test against UAT endpoint by temporarily substituting
+
+```sh
+VITE_HYDRA_URL=wss://trading-web-gateway-rt-uat.demo.hydra.weareadaptive.com npm start
+```
+
+or PROD (**_be careful!! this might interfere with demos_**)
 
 ```sh
 VITE_HYDRA_URL=wss://trading-web-gateway-rt-prod.demo.hydra.weareadaptive.com npm start

--- a/src/client/src/App/Credit/CreditRfqForm/RfqParameters.tsx
+++ b/src/client/src/App/Credit/CreditRfqForm/RfqParameters.tsx
@@ -1,8 +1,8 @@
 import {
-  customNumberFormatter,
   DECIMAL_SEPARATOR,
   DECIMAL_SEPARATOR_REGEXP,
   THOUSANDS_SEPARATOR_REGEXP,
+  truncatedDecimalNumberFormatter,
 } from "@/utils/formatNumber"
 import { bind } from "@react-rxjs/core"
 import { createSignal } from "@react-rxjs/utils"
@@ -52,7 +52,8 @@ const ParameterValue = styled.div`
   height: 24px;
 `
 
-const formatter = customNumberFormatter()
+const formatter = truncatedDecimalNumberFormatter(0)
+
 const filterRegExp = new RegExp(THOUSANDS_SEPARATOR_REGEXP, "g")
 const decimalRegExp = new RegExp(DECIMAL_SEPARATOR_REGEXP, "g")
 
@@ -61,15 +62,26 @@ const [useQuantity, quantity$] = bind(
   rawQuantity$.pipe(
     map((rawVal) => {
       const lastChar = rawVal.slice(-1).toLowerCase()
-      const value = Math.abs(
-        Number(rawVal.replace(filterRegExp, "").replace(decimalRegExp, ".")),
+      const cleanedInput = rawVal
+        .replace(filterRegExp, "")
+        .replace(decimalRegExp, ".")
+
+      const inputQuantityAsNumber = Math.abs(Number(cleanedInput))
+
+      // numeric value could be NaN at this stage
+
+      const truncated = formatter(inputQuantityAsNumber)
+
+      const value = Number(
+        truncated.replace(filterRegExp, "").replace(decimalRegExp, "."),
       )
+
       return {
         value,
         inputValue:
           value === 0
             ? ""
-            : formatter(value) +
+            : truncated +
               (lastChar === DECIMAL_SEPARATOR ? DECIMAL_SEPARATOR : ""),
       }
     }),

--- a/src/client/src/App/Credit/CreditSellSideTicket/CreditSellSideParameters.tsx
+++ b/src/client/src/App/Credit/CreditSellSideTicket/CreditSellSideParameters.tsx
@@ -1,10 +1,10 @@
 import { QuoteBody, RfqState } from "@/generated/TradingGateway"
 import { ThemeName } from "@/theme"
 import {
-  customNumberFormatter,
   DECIMAL_SEPARATOR,
   DECIMAL_SEPARATOR_REGEXP,
   THOUSANDS_SEPARATOR_REGEXP,
+  truncatedDecimalNumberFormatter,
 } from "@/utils"
 import { bind } from "@react-rxjs/core"
 import { createSignal } from "@react-rxjs/utils"
@@ -60,7 +60,8 @@ export const ParameterInput = styled.input`
   }
 `
 
-const formatter = customNumberFormatter()
+const formatter = truncatedDecimalNumberFormatter(4)
+
 const filterRegExp = new RegExp(THOUSANDS_SEPARATOR_REGEXP, "g")
 const decimalRegExp = new RegExp(DECIMAL_SEPARATOR_REGEXP, "g")
 
@@ -69,9 +70,20 @@ export const [usePrice, price$] = bind(
   rawPrice$.pipe(
     map((rawVal) => {
       const lastChar = rawVal.slice(-1).toLowerCase()
-      const value = Math.abs(
-        Number(rawVal.replace(filterRegExp, "").replace(decimalRegExp, ".")),
+      const cleanedInput = rawVal
+        .replace(filterRegExp, "")
+        .replace(decimalRegExp, ".")
+
+      const inputQuantityAsNumber = Math.abs(Number(cleanedInput))
+
+      // numeric value could be NaN at this stage
+
+      const truncated = formatter(inputQuantityAsNumber)
+
+      const value = Number(
+        truncated.replace(filterRegExp, "").replace(decimalRegExp, "."),
       )
+
       return {
         value,
         inputValue:

--- a/src/client/src/utils/formatNumber.ts
+++ b/src/client/src/utils/formatNumber.ts
@@ -99,6 +99,20 @@ export const precisionNumberFormatter = (precision: number): NumberFormatter =>
   })
 
 /**
+ * Returns a function that will format numbers truncating to the maximum precision given
+ *
+ * See __tests__/formatNumber.test.ts for full usage and behavior.
+ */
+export const truncatedDecimalNumberFormatter = (
+  precision: number,
+): NumberFormatter =>
+  numberFormatter({
+    maximumFractionDigits: precision,
+    // @ts-ignore // has not made it into types yet - or support grid in MDN seemingly! - but works
+    roundingMode: "trunc",
+  })
+
+/**
  * Takes any Intl.NumberFormatOptions as input to construct and
  * return a function that formats numbers as configured by options.
  *


### PR DESCRIPTION
early view of precision rework for Credit - aside from the dodgy rounding that was going on, we clarified that the quantity should be limited to whole numbers of 000s of bonds.

*refactoring unit test setup/dependencies and related tests is deferred to ticket 3001*