### PR TITLE
fix(serviceworker): service worker base url as origin for most cases

### DIFF
--- a/src/client/src/Web/serviceWorkerRegistration.ts
+++ b/src/client/src/Web/serviceWorkerRegistration.ts
@@ -1,6 +1,8 @@
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
+import { ENVIRONMENT } from "@/constants"
+
 // This lets the app load faster on subsequent visits in production, and gives
 // it offline capabilities. However, it also means that developers (and users)
 // will only see deployed updates on subsequent visits to a page, after all the
@@ -29,8 +31,10 @@ const doubleSlashesInURLRegex = /([^:])(\/{2,})/g
 export function register(config?: Config) {
   if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-      // This url can be changed back to using window.locationi.origin once we have fixed the env gateway url pathing
-      const swUrl = `${window.location.href}/sw.js`.replace(
+      // This url can be changed back to using window.location.origin once we have fixed the env gateway url pathing
+      const baseAddress =
+        ENVIRONMENT !== "env" ? window.location.origin : window.location.href
+      const swUrl = `${baseAddress}/sw.js`.replace(
         doubleSlashesInURLRegex,
         "$1/",
       )


### PR DESCRIPTION
.. this still leaves the "env" deployments broken
I am not too concerned about that for now as we can test fully in Dev (non-"env" deployment) - the app was working fine in Dev up till now, apart from the SW registration failure if you refreshed when address was on /credit