### PR TITLE
fix(blotter): add CSS containment directive for blotter performance

### DIFF
--- a/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
+++ b/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
@@ -9,6 +9,7 @@ const TableWrapper = styled.div`
   height: calc(100% - 4.75rem);
   overflow-x: scroll;
   overflow-y: scroll;
+  contain: content;
 `
 const Table = styled.table`
   background-color: ${({ theme }) => theme.core.lightBackground};


### PR DESCRIPTION
minimal fix for ticket 3800 (iOS poor blotter performance with more than a few hundred rows)
* seems ok in testing, some concerns from @ivanfalanga-adaptive regarding cross-browser compatibility, which I share .. this is a HINT rather than a command, so is not a permanent fix.
* considering applying to other sections - this was the minimal change required to bring iOS browsers under control when blotter rows started exceeding the 500 mark (although we start to perceive degradation after only a few 100)
* this has been debugged a fair bit in Safari with attached device, and the layout phase is almost totally dominant when performance is bad .. hence the optimisations in the CSS .. this particular attribute chosen for cross-browser compatibility