### PR TITLE
Fix credit snapshots

### DIFF
--- a/src/client/public-openfin/rt-credit.json
+++ b/src/client/public-openfin/rt-credit.json
@@ -14,7 +14,8 @@
     }
   },
   "runtime": {
-    "version": "17.85.53.10"
+    "version": "17.85.53.10",
+    "arguments": "--security-realm=rtcredit"
   },
   "splashScreenImage": "<BASE_URL>/static/media/splash.png",
   "shortcut": {

--- a/src/client/public-openfin/rt-fx.json
+++ b/src/client/public-openfin/rt-fx.json
@@ -13,7 +13,8 @@
     }
   },
   "runtime": {
-    "version": "17.85.53.10"
+    "version": "17.85.53.10",
+    "arguments": "--security-realm=rtfx"
   },
   "services": [
     {


### PR DESCRIPTION
This ensures that the OpenFin snapshots are segregated across Credit and FX. Without this configuration, `localStorage` is shared by both apps, thus they see each others snapshots which lead to undesirable layout state changes.