### PR TITLE
fix: segregate OpenFin snapshots for credit vs FX...

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -21,6 +21,7 @@
         "openfin-adapter": "^27.71.21",
         "openfin-notifications": "^1.10.1",
         "polished": "^4.1.1",
+        "query-string": "^7.1.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.1",
@@ -11866,9 +11867,9 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -14187,6 +14188,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -22665,6 +22674,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystring": {
       "version": "0.2.0",
       "dev": true,
@@ -24411,6 +24437,14 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "dev": true,
@@ -24597,6 +24631,14 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -35851,8 +35893,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "dedent": {
       "version": "0.7.0",
@@ -37436,6 +37479,11 @@
     "filter-console": {
       "version": "0.1.1",
       "dev": true
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -43012,6 +43060,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "requires": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "dev": true
@@ -44224,6 +44283,11 @@
       "version": "3.0.9",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "dev": true,
@@ -44374,6 +44438,11 @@
     "stream-shift": {
       "version": "1.0.1",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -64,6 +64,7 @@
     "openfin-adapter": "^27.71.21",
     "openfin-notifications": "^1.10.1",
     "polished": "^4.1.1",
+    "query-string": "^7.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.1",

--- a/src/client/public-openfin/rt-credit.json
+++ b/src/client/public-openfin/rt-credit.json
@@ -43,7 +43,7 @@
           "reloadIgnoringCache": true,
           "zoom": true
         },
-        "url": "<BASE_URL>/openfin-window-frame",
+        "url": "<BASE_URL>/openfin-window-frame?app=CREDIT",
         "name": "Reactive-Trader-MAIN",
         "layout": {
           "settings": {

--- a/src/client/public-openfin/rt-fx.json
+++ b/src/client/public-openfin/rt-fx.json
@@ -67,7 +67,7 @@
           "reloadIgnoringCache": true,
           "zoom": true
         },
-        "url": "<BASE_URL>/openfin-window-frame",
+        "url": "<BASE_URL>/openfin-window-frame?app=FX",
         "name": "Reactive-Trader-MAIN",
         "layout": {
           "settings": {

--- a/src/client/src/OpenFin/Snapshots/SnapshotButton.tsx
+++ b/src/client/src/OpenFin/Snapshots/SnapshotButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/App/Footer/common-styles"
 import { PlatformLockedStatusIcon } from "../icons/PlatformLockedStatusIcon"
 import { createOpenFinPopup, Offset, showOpenFinPopup } from "../utils/window"
 import { constructUrl } from "@/utils/url"
+import { useLocation } from "react-router"
 
 const IconContainer = styled.div`
   display: flex;
@@ -24,12 +25,13 @@ const OFFSET: Offset = [119, 40]
 
 export const SnapshotButton = () => {
   const [showing, setShowing] = useState(false)
+  const queryString = useLocation().search
 
   useEffect(() => {
-    createOpenFinPopup(WINDOW, constructUrl("/snapshots"), () =>
+    createOpenFinPopup(WINDOW, constructUrl(`/snapshots${queryString}`), () =>
       setShowing(false),
     )
-  }, [])
+  }, [queryString])
 
   const handleShowPopup = () => {
     if (!showing) {

--- a/src/client/src/OpenFin/Snapshots/Snapshots.tsx
+++ b/src/client/src/OpenFin/Snapshots/Snapshots.tsx
@@ -2,7 +2,9 @@ import { useState } from "react"
 import {
   applySnapshotFromStorage,
   getSnapshots,
+  AppName,
   saveSnapshotToStorage,
+  useAppNameForSnapshots,
 } from "../utils/layout"
 
 import {
@@ -17,16 +19,16 @@ import {
   Title,
 } from "./Snapshots.styles"
 
-const useSnapshots = () => {
-  const [snapshots, setSnapshots] = useState(() => getSnapshots())
+const useSnapshots = (app: AppName) => {
+  const [snapshots, setSnapshots] = useState(() => getSnapshots(app))
 
   const saveSnapshot = async (name: string) => {
-    await saveSnapshotToStorage(name)
-    setSnapshots(getSnapshots())
+    await saveSnapshotToStorage(app, name)
+    setSnapshots(getSnapshots(app))
   }
 
   const applySnapshot = async (name: string) => {
-    await applySnapshotFromStorage(name)
+    await applySnapshotFromStorage(app, name)
   }
 
   return {
@@ -104,9 +106,8 @@ const SnapshotForm = ({ onSubmit }: FormProps) => {
 }
 
 export const Snapshots = () => {
-  const { snapshots, saveSnapshot, applySnapshot } = useSnapshots()
-
-  console.log(snapshots)
+  const app = useAppNameForSnapshots()
+  const { snapshots, saveSnapshot, applySnapshot } = useSnapshots(app)
 
   return (
     <Container>

--- a/src/client/src/OpenFin/apps/Launcher/utils/openfin.ts
+++ b/src/client/src/OpenFin/apps/Launcher/utils/openfin.ts
@@ -1,5 +1,3 @@
-// TODO - Revisit if/when launcher is cross platform
-import { Bounds } from "openfin/_v2/shapes/shapes"
 import { useEffect } from "react"
 
 export async function getExistingOpenFinApplication(
@@ -61,7 +59,10 @@ export const getCurrentWindowBounds = async () => {
   return window.getBounds()
 }
 
-export async function animateCurrentWindowSize(bounds: Bounds, duration = 200) {
+export async function animateCurrentWindowSize(
+  bounds: OpenFin.Bounds,
+  duration = 200,
+) {
   const window = await fin.Window.getCurrent()
 
   return window.animate(
@@ -79,7 +80,7 @@ export async function animateCurrentWindowSize(bounds: Bounds, duration = 200) {
   )
 }
 
-export function useAppBoundReset(bounds: Bounds | undefined) {
+export function useAppBoundReset(bounds: OpenFin.Bounds | undefined) {
   useEffect(() => {
     if (!bounds) {
       return

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -6,7 +6,7 @@
     },
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["vite/client", "node", "openfin", "jest"],
+    "types": ["vite/client", "node", "jest"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,


### PR DESCRIPTION
Local storage is shared by both apps, thus without this change, they see each other's snapshots, which lead to undesirable layout state changes. This commit appends the app name to the local storage keys to  ensure that the OpenFin snapshots are segregated across Credit and FX.

Interestingly, on Mac, local storage is segregated for the 2 apps, so this fix would seem to be unnecessary. On Windows, however, local storage is shared across apps that are served from the same origin, even if they have different UUIDs. Creating separate security realms for each app would create segregated local storage, but has the side effect of breaking interop with ReactiveAnalytics, so we did not pursue that approach.
