### PR TITLE
rename: concise name change for e2e workflow to link slack notification

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,4 +1,4 @@
-name: Runs e2e every day at 9am against RT Prod
+name: Scheduled E2E
 on:
   schedule:
     - cron: "55 8 * * *"


### PR DESCRIPTION
Simple update to E2E workflow name change. Required to link Github to slack for notification as it checks for the name of the workflow to differentiate between them  