### PR TITLE
chore(ci): remove npmrc decrypt from builds

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -45,15 +45,6 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-      - name: Decrypt NPM credentials
-        run: |
-          gcloud kms decrypt \
-            --ciphertext-file=npmrc.enc \
-            --plaintext-file=.npmrc \
-            --location=global \
-            --keyring=rt-keyring \
-            --key=npmrc-key
-
       - name: Install
         run: npm ci
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -36,15 +36,6 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-      - name: Decrypt NPM credentials
-        run: |
-          gcloud kms decrypt \
-            --ciphertext-file=npmrc.enc \
-            --plaintext-file=.npmrc \
-            --location=global \
-            --keyring=rt-keyring \
-            --key=npmrc-key
-
       - name: Install
         run: npm ci
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,15 +43,6 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_PRIVATE_KEY }}
 
-      - name: Decrypt NPM credentials
-        run: |
-          gcloud kms decrypt \
-            --ciphertext-file=npmrc.enc \
-            --plaintext-file=.npmrc \
-            --location=global \
-            --keyring=rt-keyring \
-            --key=npmrc-key
-
       - name: Install
         run: npm ci
 


### PR DESCRIPTION
We have not needed authentication to access Hydra libs in Artifactory for at least a year - removing this now as it is preventing external contributions (Ignacio) and we can clean up some GCP config and permissions into the bargain