### PR TITLE
fix: Flash of unstyled Text (FOUT)

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -33,10 +33,7 @@
         "react-window": "^1.8.8",
         "ress": "^3.0.0",
         "rxjs": "^7.5.4",
-        "styled-components": "^5.2.2",
-        "typeface-lato": "^1.1.13",
-        "typeface-montserrat": "^1.1.13",
-        "typeface-roboto": "^1.1.13"
+        "styled-components": "^5.2.2"
       },
       "devDependencies": {
         "@babel/core": "^7.13.16",
@@ -88,6 +85,7 @@
         "storybook": "^7.0.2",
         "text-encoding": "^0.7.0",
         "typescript": "^4.9.3",
+        "unplugin-fonts": "^1.0.0",
         "vite": "^4.2.1",
         "vite-plugin-html": "^3.2.0",
         "vite-plugin-static-copy": "^0.13.1",
@@ -17839,18 +17837,6 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
-    "node_modules/typeface-lato": {
-      "version": "1.1.13",
-      "license": "MIT"
-    },
-    "node_modules/typeface-montserrat": {
-      "version": "1.1.13",
-      "license": "MIT"
-    },
-    "node_modules/typeface-roboto": {
-      "version": "1.1.13",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "4.9.3",
       "dev": true,
@@ -18024,6 +18010,55 @@
         "webpack-sources": "^3.2.3",
         "webpack-virtual-modules": "^0.4.5"
       }
+    },
+    "node_modules/unplugin-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin-fonts/-/unplugin-fonts-1.0.0.tgz",
+      "integrity": "sha512-fguFV70CWOAd8tTeuQ0pjTze1dHTiGgWYjkSnyIn52k4kBVwtMveGVYNJS58tvmxSwMLL0TjXJU7zqWRPkbrQQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.12",
+        "unplugin": "^1.3.1"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": "^3.0.0",
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-fonts/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/unplugin-fonts/node_modules/unplugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.3.1.tgz",
+      "integrity": "sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
+    "node_modules/unplugin-fonts/node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true
     },
     "node_modules/unplugin/node_modules/acorn": {
       "version": "8.8.2",
@@ -31850,15 +31885,6 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
-    "typeface-lato": {
-      "version": "1.1.13"
-    },
-    "typeface-montserrat": {
-      "version": "1.1.13"
-    },
-    "typeface-roboto": {
-      "version": "1.1.13"
-    },
     "typescript": {
       "version": "4.9.3",
       "dev": true
@@ -31983,6 +32009,42 @@
           "version": "8.8.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
           "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+          "dev": true
+        }
+      }
+    },
+    "unplugin-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin-fonts/-/unplugin-fonts-1.0.0.tgz",
+      "integrity": "sha512-fguFV70CWOAd8tTeuQ0pjTze1dHTiGgWYjkSnyIn52k4kBVwtMveGVYNJS58tvmxSwMLL0TjXJU7zqWRPkbrQQ==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.12",
+        "unplugin": "^1.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+          "dev": true
+        },
+        "unplugin": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.3.1.tgz",
+          "integrity": "sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.8.2",
+            "chokidar": "^3.5.3",
+            "webpack-sources": "^3.2.3",
+            "webpack-virtual-modules": "^0.5.0"
+          }
+        },
+        "webpack-virtual-modules": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+          "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
           "dev": true
         }
       }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -81,10 +81,7 @@
     "react-window": "^1.8.8",
     "ress": "^3.0.0",
     "rxjs": "^7.5.4",
-    "styled-components": "^5.2.2",
-    "typeface-lato": "^1.1.13",
-    "typeface-montserrat": "^1.1.13",
-    "typeface-roboto": "^1.1.13"
+    "styled-components": "^5.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",
@@ -136,6 +133,7 @@
     "storybook": "^7.0.2",
     "text-encoding": "^0.7.0",
     "typescript": "^4.9.3",
+    "unplugin-fonts": "^1.0.0",
     "vite": "^4.2.1",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-static-copy": "^0.13.1",

--- a/src/client/src/App/Footer/common-styles.ts
+++ b/src/client/src/App/Footer/common-styles.ts
@@ -22,7 +22,7 @@ export const Button = styled.button<{ margin?: string; disabled?: boolean }>`
   padding: 0 0.7rem;
   height: 1.6rem;
   font-size: 0.65rem;
-  font-weight: 350;
+  font-weight: 300;
   margin: ${({ margin }) => (margin ? margin : "unset")};
 `
 

--- a/src/client/src/theme/globals.ts
+++ b/src/client/src/theme/globals.ts
@@ -14,6 +14,7 @@
  * Here we use "ress", a modern CSS reset based off normalize
  */
 import "ress"
+
 /**
  * Adding Typefaces
  *
@@ -25,10 +26,6 @@ import "ress"
  * benefit between maintainence, functional guarantees, and
  * trade offs in initial load times.
  */
-import "typeface-lato"
-import "typeface-montserrat"
-import "typeface-roboto"
-
 /**
  * Establishing a Baseline
  *


### PR DESCRIPTION
The issue where the PWA banner style is not applying immediately on load seem to be more widespread than initially thought & has been there for some time.

This PR removes the deprecated `typeface-lato, typeface-roboto & typeface-montserrat` and replaced it with Google's font CDN. The issue seems to be that when a page is first requested, the font is queued & downloaded at the tail end of the request. The default behaviour of `@font-face` is that the `font-display` is set to `swap`. This means that if the font is not available, the browser user agent will apply a font of its choice until ours is available, which explains why we see a Flash of Unstyled Text (FOUT). 

The fix is to add to preloading mechanism `<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>` or enable non-blocking renderer `<link rel="preload" href="xxx" as="style" onload="this.rel='stylesheet'">`. With this and setting the `font-display: block` the font will not show until it is available and because of the `preconnect` & `preload` the font download is queued much earlier in the render cycle.


https://user-images.githubusercontent.com/52295529/232049957-547f88bd-fab6-46d8-afe4-96dddec7711e.mov

