### PR TITLE
fix(launcher): limit launcher NPL suggestion height to 800 with overflow

### DIFF
--- a/src/client/src/OpenFin/apps/Launcher/NlpSuggestions/styles.ts
+++ b/src/client/src/OpenFin/apps/Launcher/NlpSuggestions/styles.ts
@@ -98,6 +98,8 @@ export const Suggestion = styled.div`
   flex-direction: row;
   padding: 5px 2px;
   line-height: 1rem;
+  max-height: 800px;
+  overflow: auto;
 `
 
 export const LoadingWrapper = styled.div`


### PR DESCRIPTION
.. another quick fix for Launcher
This time, discovered that typing `/last` in Launcher gets all the trades back .. which can overwhelm the Suggestion box .. so limited this to 800px (guess)