### PR TITLE
fix: fx notification button to highlight blotter

### DIFF
--- a/src/client/src/App/Credit/CreditRfqs/CreditRfqCards/CardFooter.tsx
+++ b/src/client/src/App/Credit/CreditRfqs/CreditRfqCards/CardFooter.tsx
@@ -62,7 +62,7 @@ export const AcceptedFooterContent = ({
       </AcceptedCardState>
       <ViewTrade
         onClick={() => {
-          handleViewTrade(rfqId.toString())
+          handleViewTrade(rfqId)
         }}
         data-testid="view-trade"
       >

--- a/src/client/src/App/Credit/CreditRfqs/CreditRfqCards/handleViewTrade.ts
+++ b/src/client/src/App/Credit/CreditRfqs/CreditRfqCards/handleViewTrade.ts
@@ -3,6 +3,6 @@
 
 import { setCreditTradeRowHighlight } from "@/App/Trades/TradesState"
 
-export function handleViewTrade(rfqId: string) {
+export function handleViewTrade(rfqId: number) {
   setCreditTradeRowHighlight(rfqId)
 }

--- a/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
+++ b/src/client/src/App/Trades/TradesGrid/TradesGrid.tsx
@@ -274,7 +274,7 @@ export const TradesGridInner = <Row extends Trade>({
 }
 
 export interface TradesGridInnerProps<Row extends Trade> {
-  highlightedRow?: string | null
+  highlightedRow?: number | null
   onRowClick?: (row: Row) => void
   isRowCrossed?: (row: Row) => boolean
   caption: string

--- a/src/client/src/App/Trades/TradesState/tableTrades.ts
+++ b/src/client/src/App/Trades/TradesState/tableTrades.ts
@@ -347,13 +347,13 @@ export const [useFilterFields] = bind(
  * Signal to capture a tradeId of row to highlight in FX blotter
  */
 export const [fxTradeRowHighlight$, setFxTradeRowHighlight] =
-  createSignal<string>()
+  createSignal<number>()
 
 /**
  * Signal to capture a tradeId of row to highlight in Credit blotter
  */
 export const [creditTradeRowHighlight$, setCreditTradeRowHighlight] =
-  createSignal<string>()
+  createSignal<number>()
 
 /**
  * Emit tradeId of new trades after the initial load

--- a/src/client/src/notifications.openfin.ts
+++ b/src/client/src/notifications.openfin.ts
@@ -74,8 +74,7 @@ export async function registerFxNotifications() {
   fin.InterApplicationBus.subscribe(
     { uuid: "*" },
     TOPIC_HIGHLIGHT_FX_BLOTTER,
-    (message: { tradeId: number }) =>
-      setFxTradeRowHighlight(message.tradeId.toString()),
+    (message: { tradeId: number }) => setFxTradeRowHighlight(message.tradeId),
   )
 
   addEventListener("notification-action", handleNotificationAction)
@@ -122,7 +121,7 @@ export function registerCreditBlotterUpdates() {
     { uuid: "*" },
     TOPIC_HIGHLIGHT_CREDIT_BLOTTER,
     (message: { tradeId: number }) => {
-      setCreditTradeRowHighlight(message.tradeId.toString())
+      setCreditTradeRowHighlight(message.tradeId)
     },
   )
 }

--- a/src/client/src/services/trades/__mocks__/creditTrades.ts
+++ b/src/client/src/services/trades/__mocks__/creditTrades.ts
@@ -4,7 +4,7 @@ import { CreditTrade } from "../types"
 
 export const mockCreditTrades: CreditTrade[] = [
   {
-    tradeId: "1111111111",
+    tradeId: 1111111111,
     direction: Direction.Buy,
     tradeDate: new Date("2021-01-13T17:32:12.6003777+00:00"),
     status: QuoteState.Accepted,
@@ -16,7 +16,7 @@ export const mockCreditTrades: CreditTrade[] = [
     unitPrice: 100.65,
   },
   {
-    tradeId: "2222222222",
+    tradeId: 2222222222,
     direction: Direction.Buy,
     tradeDate: new Date("2021-01-13T17:32:26.7011799+00:00"),
     status: QuoteState.Accepted,
@@ -28,7 +28,7 @@ export const mockCreditTrades: CreditTrade[] = [
     unitPrice: 100.65,
   },
   {
-    tradeId: "3333333333",
+    tradeId: 3333333333,
     direction: Direction.Buy,
     tradeDate: new Date("2021-01-13T20:02:39.4410315+00:00"),
     status: QuoteState.Accepted,

--- a/src/client/src/services/trades/__mocks__/trades.mock.ts
+++ b/src/client/src/services/trades/__mocks__/trades.mock.ts
@@ -45,7 +45,7 @@ export const mockRawTrades = {
 
 export const mockTrades: FxTrade[] = [
   {
-    tradeId: "1111111111",
+    tradeId: 1111111111,
     traderName: "LMO",
     symbol: "GBPUSD",
     notional: 1_000_000,
@@ -57,7 +57,7 @@ export const mockTrades: FxTrade[] = [
     status: TradeStatus.Done,
   },
   {
-    tradeId: "2222222222",
+    tradeId: 2222222222,
     traderName: "LMO",
     symbol: "USDJPY",
     notional: 1_000_000,
@@ -69,7 +69,7 @@ export const mockTrades: FxTrade[] = [
     status: TradeStatus.Pending,
   },
   {
-    tradeId: "3333333333",
+    tradeId: 3333333333,
     traderName: "EDO",
     symbol: "USDJPY",
     notional: 10_000_000,
@@ -83,7 +83,7 @@ export const mockTrades: FxTrade[] = [
 ]
 
 export const nextTrade = {
-  tradeId: "4444444444",
+  tradeId: 4444444444,
   traderName: "EDO",
   symbol: "USDJPY",
   notional: 1_000_000,

--- a/src/client/src/services/trades/__tests__/trades.test.ts
+++ b/src/client/src/services/trades/__tests__/trades.test.ts
@@ -132,7 +132,7 @@ describe("trades", () => {
         tradesService.creditTrades$.subscribe((value) => {
           expect(value).toEqual([
             {
-              tradeId: "3",
+              tradeId: 3,
               status: "Accepted",
               tradeDate: expect.any(Date),
               direction: "Buy",
@@ -144,7 +144,7 @@ describe("trades", () => {
               unitPrice: 88,
             },
             {
-              tradeId: "2",
+              tradeId: 2,
               status: "Accepted",
               tradeDate: expect.any(Date),
               direction: "Buy",

--- a/src/client/src/services/trades/trades.ts
+++ b/src/client/src/services/trades/trades.ts
@@ -60,7 +60,7 @@ export const [useCreditTrades, creditTrades$] = bind(
             (quote) => quote.state === QuoteState.Accepted,
           )
           return {
-            tradeId: rfq.id.toString(),
+            tradeId: rfq.id,
             status: QuoteState.Accepted,
             tradeDate: new Date(Date.now()),
             direction: rfq.direction,

--- a/src/client/src/services/trades/types.ts
+++ b/src/client/src/services/trades/types.ts
@@ -49,6 +49,6 @@ export interface CreditTrade extends Trade {
 }
 
 export interface Trade {
-  tradeId: string
+  tradeId: number
   [prop: string]: unknown
 }


### PR DESCRIPTION
The highlight row signal was emitting the tradeId as a string which failed against a strict equality check. Comparison was between emitted tradeId (string) and backend tradeId (number). 