### PR TITLE
fix: OF launcher flash of white to a minimum (milliseconds)

### DIFF
--- a/src/client/public-openfin/launcher.json
+++ b/src/client/public-openfin/launcher.json
@@ -55,7 +55,7 @@
   "snapshot": {
     "windows": [
       {
-        "autoShow": true,
+        "autoShow": false,
         "frame": false,
         "_comment": "Openfin Excel API preloaded below + added in appAssets (not included in standard OpenFin package)",
         "preload": [
@@ -72,7 +72,6 @@
         "defaultHeight": 56,
         "defaultTop": 160,
         "defaultLeft": 30,
-        "backgroundColor": "#313131",
         "cornerRounding": {
           "width": 4,
           "height": 4

--- a/src/client/src/OpenFin/apps/Launcher/MainRoute.tsx
+++ b/src/client/src/OpenFin/apps/Launcher/MainRoute.tsx
@@ -93,6 +93,8 @@ function Launcher() {
   useEffect(() => {
     setOverlay(overlayRef.current)
     getCurrentWindowBounds().then(setInitialBounds).catch(console.error)
+    const window = fin.Window.getCurrentSync()
+    window.show()
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
OpenFIn Launcher has a white screen flash that occurs for approximately 2 seconds during the initial launch of the OpenFin application when there is no cached data available. The proposed fix enhances the user experience by setting the "autoShow" option in the launcher manifest JSON to false and utilizing the useEffect hook to display the page on first load instead.

This doesnt completely get rid of the flash as it seems to be something OpenFin tends to do, for example the `waitForPageLoad` desc is : "The user will experience a brief white flash until the content arrives and is rendered. This can be mitigated somewhat by setting the backgroundColor option to some other color compatible with the expected content.". 
The problem with this solution however is that it doesn't take into account theme switch