### PR TITLE
fix: limit check stream is skipped over if limit checker is closed

### DIFF
--- a/src/client/src/OpenFin/Window/WindowFrameBase.tsx
+++ b/src/client/src/OpenFin/Window/WindowFrameBase.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useEffect } from "react"
+import { PropsWithChildren, useEffect } from "react"
 
 import { WindowBody } from "./WindowBody"
 import { WindowFooter } from "./WindowFooter"

--- a/src/client/src/OpenFin/Window/WindowViewport.tsx
+++ b/src/client/src/OpenFin/Window/WindowViewport.tsx
@@ -1,3 +1,4 @@
+import { joinChannel } from "@finos/fdc3"
 import { ApplicationEvents } from "@openfin/core/src/api/events/application.js"
 import { WindowEvent } from "@openfin/core/src/api/events/base.js"
 import { Subscribe } from "@react-rxjs/core"
@@ -33,6 +34,8 @@ const getEmptyContent = (key: LayoutKey, useIcon = true) => {
 const WindowViewportComponent = ({ children }: WithChildren) => {
   //TODO: Remove this HACK once OpenFin exposes content of "empty" layout containers...
   useEffect(() => {
+    joinChannel("green")
+
     if (!fin.me.isView) {
       const listenerViewAttached = (
         _: WindowEvent<"window", "view-attached">,
@@ -121,15 +124,16 @@ const WindowViewportComponent = ({ children }: WithChildren) => {
       }: WindowEvent<"application", "window-closing">) => {
         //const label: string = (e || {}).name || "unknown"
         // ReactGA.event({ category: "RT - Window", action: "closing", label })
+
+        if (name === "Limit-Checker") {
+          fin.me.interop.setContext({
+            type: "limit-checker-status",
+            id: { isAlive: "false" },
+          })
+        }
+
         fin.Window.wrap({ uuid, name }).then((closingWindow) => {
           closingWindow.removeAllListeners()
-
-          if (name === "Limit-Checker") {
-            fin.me.interop.setContext({
-              type: "limit-checker-status",
-              id: { isAlive: "false" },
-            })
-          }
         })
       }
 

--- a/src/client/src/OpenFin/Window/WindowViewport.tsx
+++ b/src/client/src/OpenFin/Window/WindowViewport.tsx
@@ -1,4 +1,4 @@
-import { joinChannel } from "@finos/fdc3"
+import { broadcast, joinChannel } from "@finos/fdc3"
 import { ApplicationEvents } from "@openfin/core/src/api/events/application.js"
 import { WindowEvent } from "@openfin/core/src/api/events/base.js"
 import { Subscribe } from "@react-rxjs/core"
@@ -126,7 +126,7 @@ const WindowViewportComponent = ({ children }: WithChildren) => {
         // ReactGA.event({ category: "RT - Window", action: "closing", label })
 
         if (name === "Limit-Checker") {
-          fin.me.interop.setContext({
+          broadcast({
             type: "limit-checker-status",
             id: { isAlive: "false" },
           })

--- a/src/client/src/services/limitChecker/limitChecker.openfin.ts
+++ b/src/client/src/services/limitChecker/limitChecker.openfin.ts
@@ -1,6 +1,6 @@
 import { bind } from "@react-rxjs/core"
-import { BehaviorSubject, race, Subject, timer } from "rxjs"
-import { map, take, tap } from "rxjs/operators"
+import { BehaviorSubject, of, race, Subject, timer } from "rxjs"
+import { map, switchMap, take, tap } from "rxjs/operators"
 
 import { CheckLimitStreamGenerator } from "./types"
 
@@ -10,7 +10,7 @@ window.fdc3.addContextListener("limit-checker-status", (context) => {
 
 const limitCheckSubscription$ = new BehaviorSubject<string>("false")
 
-export const [useIsLimitCheckerRunning] = bind<boolean>(
+export const [useIsLimitCheckerRunning, isLimitCheckerRunning$] = bind<boolean>(
   limitCheckSubscription$.pipe(map((isAlive) => isAlive === "true")),
 )
 
@@ -22,37 +22,48 @@ export const checkLimit$: CheckLimitStreamGenerator = (message: {
   tradedCurrencyPair: string
   notional: number
   rate: number
-}) => {
-  const payload = {
-    notional: message.notional.toString(),
-    rate: message.rate.toString(),
-    tradedCurrencyPair: message.tradedCurrencyPair,
-    id: (limitCheckId++).toString(),
-  }
-
-  const result$ = new Subject<string>()
-
-  const listener = window.fdc3.addContextListener(
-    `result-${payload.id}`,
-    (context) => {
-      if (context.id) {
-        result$.next(context.id.result)
+}) =>
+  isLimitCheckerRunning$.pipe(
+    take(1),
+    switchMap((isAlive) => {
+      if (!isAlive) {
+        return of(true)
       }
-    },
+
+      const payload = {
+        notional: message.notional.toString(),
+        rate: message.rate.toString(),
+        tradedCurrencyPair: message.tradedCurrencyPair,
+        id: (limitCheckId++).toString(),
+      }
+
+      const result$ = new Subject<string>()
+
+      const listener = window.fdc3.addContextListener(
+        `result-${payload.id}`,
+        (context) => {
+          if (context.id) {
+            result$.next(context.id.result)
+          }
+        },
+      )
+
+      window.fdc3.broadcast({ type: "check-limit", id: payload })
+
+      return race([
+        result$.pipe(
+          take(1),
+          map((result) => result === "true"),
+        ),
+        timer(3000).pipe(
+          map(() => {
+            console.info(
+              LOG_NAME,
+              "limit check timed out, removing subscription",
+            )
+            return true
+          }),
+        ),
+      ]).pipe(tap(listener.unsubscribe))
+    }),
   )
-
-  window.fdc3.broadcast({ type: "check-limit", id: payload })
-
-  return race([
-    result$.pipe(
-      take(1),
-      map((result) => result === "true"),
-    ),
-    timer(3000).pipe(
-      map(() => {
-        console.info(LOG_NAME, "limit check timed out, removing subscription")
-        return true
-      }),
-    ),
-  ]).pipe(tap(listener.unsubscribe))
-}


### PR DESCRIPTION
The Limit Checker PR introduced a bug where each trade would wait for the limit check stream to timeout before executing, this is quick pr to fix that.