### PR TITLE
fix: match blotter name in template layouts to manifest

### DIFF
--- a/src/client/src/OpenFin/utils/templates/fxTemplateLayouts.ts
+++ b/src/client/src/OpenFin/utils/templates/fxTemplateLayouts.ts
@@ -10,7 +10,7 @@ import {
 
 export enum FxView {
   Tiles = "Tiles",
-  FxBlotter = "FX-Blotter",
+  FxBlotter = "FX Blotter",
   Analytics = "Analytics",
 }
 


### PR DESCRIPTION
mismatched names in manifest and template layouts