### PR TITLE
fix: removed standalone limit checker from workspace

### DIFF
--- a/src/workspace/src/apps.ts
+++ b/src/workspace/src/apps.ts
@@ -6,7 +6,6 @@ export async function getApps(): Promise<App[]> {
     reactiveTraderFx,
     reactiveTraderCredit,
     reactiveAnalytics,
-    limitChecker,
     reactiveWorkspace,
     limitCheckerView,
     reactiveTraderFxLiveRatesView,

--- a/src/workspace/src/dock.ts
+++ b/src/workspace/src/dock.ts
@@ -1,4 +1,8 @@
-import { limitChecker, reactiveAnalytics, reactiveTraderCredit } from "@/apps"
+import {
+  limitCheckerView,
+  reactiveAnalytics,
+  reactiveTraderCredit,
+} from "@/apps"
 import { reactiveTraderFx } from "@/apps"
 import { BASE_URL } from "@/consts"
 import { ADAPTIVE_LOGO } from "@/home/utils"
@@ -70,7 +74,7 @@ export const dockCustomActions = {
   },
   [DockAction.OpenLimitChecker]: () => {
     platform.launchApp({
-      app: limitChecker,
+      app: limitCheckerView,
     })
   },
 }


### PR DESCRIPTION
the standard stand alone limit checker has stopped working in workspace, seems to be because of the switch to standard fdc3. I have removed references to the standard app from workspace and replaced them with the workspace View version which is working.