### PR TITLE
Google Analytics upgrade

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,42 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no"
-    />
-    <meta id="themeColor" name="theme-color" content="#2e3543" />
-    <meta
-      name="description"
-      content="Reactive Trader® - Cloud edition. Example reactive currency pair trading app"
-    />
-    <link rel="apple-touch-icon" href="/touch-icon-iphone.png" />
-    <link rel="manifest" href="/manifest.json" />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"
-    />
-    <title>Reactive Trader®</title>
-    <%- injectScript %>
-  </head>
 
-  <body>
-    <div id="root"></div>
-    <noscript> You need to enable JavaScript to run this app. </noscript>
-    <!-- Google Analytics -->
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no" />
+  <meta id="themeColor" name="theme-color" content="#2e3543" />
+  <meta name="description" content="Reactive Trader® - Cloud edition. Example reactive currency pair trading app" />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/touch-icon-iphone.png" />
+  <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" />
+
+  <title>Reactive Trader®</title>
+
+  <%- injectScript %>
+    <!-- Google Analytics tag - (gtag.js) -->
     <script>
-      window.ga =
-        window.ga ||
-        function () {
-          ;(ga.q = ga.q || []).push(arguments)
-        }
-      ga.l = +new Date()
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
     </script>
-    <script async src="https://www.google-analytics.com/analytics.js"></script>
     <!-- End Google Analytics -->
-    <script type="module" src="/src/index.tsx"></script>
-  </body>
+</head>
+
+<body>
+  <div id="root"></div>
+  <noscript> You need to enable JavaScript to run this app. </noscript>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+
 </html>

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -56,7 +56,7 @@
     "e2e:web:smoke": "playwright test --project=chrome --grep @smoke"
   },
   "dependencies": {
-    "@adaptive/hydra-platform": "^3.120.0",
+    "@adaptive/hydra-platform": "3.120.0",
     "@finos/fdc3": "^1.2.0",
     "@openfin/core": "31.75.4",
     "@openfin/workspace": "13.0.7",
@@ -66,7 +66,7 @@
     "d3": "^6.6.2",
     "date-fns": "^2.19.0",
     "downshift": "^6.1.9",
-    "lodash": "^4.17.21",
+    "lodash": "4.17.21",
     "openfin-notifications": "1.23.0",
     "polished": "^4.1.1",
     "query-string": "^7.1.3",

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,11 +1,11 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 
+import { ENVIRONMENT } from "@/constants"
 import { GlobalScrollbarStyle, ThemeProvider } from "@/theme"
 import GlobalStyle from "@/theme/globals"
 
-import { GA_TRACKING_ID } from "./constants"
-import { gaDimension, getMainApp } from "./main"
+import { getMainApp } from "./main"
 import {
   registerCreditAcceptedNotifications,
   registerFxNotifications,
@@ -38,19 +38,9 @@ export async function initApp() {
     </StrictMode>,
   )
 
-  const { ga } = window
-
-  ga("create", {
-    trackingId: GA_TRACKING_ID,
-    transport: "beacon",
-  })
-
-  ga("set", {
-    dimension1: gaDimension,
-    dimension2: gaDimension,
-    dimension3: import.meta.env,
-    page: window.location.pathname,
-  })
-
-  ga("send", "pageview")
+  window.gtag("js", new Date())
+  window.gtag(
+    "config",
+    ENVIRONMENT === "prod" ? "G-Z3PC9MRCH9" : "G-Y28QSEPEC8",
+  )
 }

--- a/src/client/src/App/Footer/ContactUsButton/ContactUs.tsx
+++ b/src/client/src/App/Footer/ContactUsButton/ContactUs.tsx
@@ -1,7 +1,6 @@
-import { ContactUsContentResolver, Link } from "./styled"
+import { EMAIL, WEBSITE } from "@/constants"
 
-const WEBSITE = "https://weareadaptive.com"
-const EMAIL = "sales@weareadaptive.com"
+import { ContactUsContentResolver, Link } from "./styled"
 
 export const ContactUs = () => (
   <ContactUsContentResolver>
@@ -25,7 +24,9 @@ export const ContactUs = () => (
 
     <Link
       onClick={() => {
-        window.ga("send", "event", "RT - Outbound", "click", WEBSITE)
+        window.gtag("event", "outbound_click", {
+          destination: WEBSITE,
+        })
         window.open(WEBSITE)
       }}
     >

--- a/src/client/src/App/Footer/ContactUsButton/FollowUs.tsx
+++ b/src/client/src/App/Footer/ContactUsButton/FollowUs.tsx
@@ -1,16 +1,13 @@
+import { SOCIAL_ADDRESSES, SocialPlatform } from "@/constants"
+
 import { ContactUsContentResolver, Link } from "./styled"
 
-type Social = "Twitter" | "LinkedIn" | "Github"
-const config: Record<Social, string> = {
-  Twitter: "https://twitter.com/WeAreAdaptive",
-  LinkedIn: "https://www.linkedin.com/company/adaptive-consulting-ltd/",
-  Github: "https://github.com/adaptiveConsulting/",
-}
-
 export const FollowUs = () => {
-  const onClick = (social: Social) => () => {
-    window.ga("send", "event", "RT - Social", "click", `${social} (url)`)
-    window.open(config[social])
+  const onClick = (social: SocialPlatform) => () => {
+    window.gtag("event", "outbound_click", {
+      destination: SOCIAL_ADDRESSES[social],
+    })
+    window.open(SOCIAL_ADDRESSES[social])
   }
 
   return (

--- a/src/client/src/App/Header/Header.tsx
+++ b/src/client/src/App/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from "react"
 
 import Logo from "@/components/Logo"
+import { WEBSITE } from "@/constants"
 
 import {
   AppHeaderRoot,
@@ -27,14 +28,10 @@ export const defaultLogo = (
       size={1.75}
       role="button"
       onClick={() => {
-        window.ga(
-          "send",
-          "event",
-          "RT - Outbound",
-          "click",
-          "https://weareadaptive.com",
-        )
-        window.open("https://weareadaptive.com/")
+        window.gtag("event", "outbound_click", {
+          destination: WEBSITE,
+        })
+        window.open(WEBSITE)
       }}
       data-qa="header__root-logo"
     />

--- a/src/client/src/App/LiveRates/Tile/Tile.state.ts
+++ b/src/client/src/App/LiveRates/Tile/Tile.state.ts
@@ -91,14 +91,12 @@ export const [useTileState, getTileState$] = bind(
         spotRate: direction === Direction.Buy ? price.ask : price.bid,
       })),
       tap(({ direction, currencyPair, spotRate, notional }) => {
-        window.ga(
-          "send",
-          "event",
-          "RT - Trade Attempt",
+        window.gtag("event", "fx_trade_attempt", {
           direction,
-          `${currencyPair} - ${spotRate}`,
+          currencyPair,
+          spotRate,
           notional,
-        )
+        })
       }),
       exhaustMap((request) =>
         concat(

--- a/src/client/src/constants.ts
+++ b/src/client/src/constants.ts
@@ -1,6 +1,5 @@
 type Environment = "local" | "env" | "dev" | "uat" | "prod"
 
-export const GA_TRACKING_ID = "UA-46320965-5"
 // Comes from vite.config - base
 // Will be / for vite development mode (local),
 // otherwise the full domain / path of the deployment e.g. https://web.env.reactivetrader.com/pull/2064
@@ -42,3 +41,13 @@ export const CREDIT_RFQ_EXPIRY_SECONDS = 120
 export const CREDIT_SELL_SIDE_TICKET_HEIGHT = 262
 
 export const HIGHLIGHT_ROW_FLASH_TIME = 3000
+
+export const WEBSITE = "https://weareadaptive.com"
+export const EMAIL = "sales@weareadaptive.com"
+
+export type SocialPlatform = "Twitter" | "LinkedIn" | "Github"
+export const SOCIAL_ADDRESSES: Record<SocialPlatform, string> = {
+  Twitter: "https://twitter.com/WeAreAdaptive",
+  LinkedIn: "https://www.linkedin.com/company/adaptive-consulting-ltd/",
+  Github: "https://github.com/adaptiveConsulting/",
+}

--- a/src/client/src/dom.d.ts
+++ b/src/client/src/dom.d.ts
@@ -8,6 +8,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     FSBL: any // Finsemble
     ga: ga
+    gtag: gtag
   }
 
   interface WindowEventMap {

--- a/src/client/src/setupTests.ts
+++ b/src/client/src/setupTests.ts
@@ -1,3 +1,3 @@
 import { styleSheetSerializer } from "jest-styled-components/serializer"
-window.ga = Function.prototype
+window.gtag = Function.prototype
 expect.addSnapshotSerializer(styleSheetSerializer)


### PR DESCRIPTION
Upgraded from UA to GA4, which for RT just means getting the Google Analytics source from a different address, including the G-xxxxx "tag" in the URL along with slightly modified script logic using conditional HTML insertion in the Vite build.
Then doing the same in the GA config setup in the main app in code.

Demonstrates switch to using a "dev" property for all but Prod, to keep stuff like local testing out of the reports that can track external usage of RT + friends

_Tested locally and on the PR deploy, per std bot comment below - if you have GA access, can be tracked in GA realtime report [here](https://analytics.google.com/analytics/web/#/p383903600/realtime/overview)_

_Deferring E2E against Prod to follow on - plan at the moment is to use a query param or something .._

<img width="788" alt="rtc-4822-GA-UI--fx-trade-attempt-custom-event" src="https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/8402485/a7b3287d-15ee-4ba2-ab3f-73000c49fcb3">
