### PR TITLE
feat: formatting and shortcuts on limit checker inputs

### DIFF
--- a/src/client/public-openfin/limit-checker.json
+++ b/src/client/public-openfin/limit-checker.json
@@ -21,7 +21,7 @@
         "icon": "<BASE_URL>/static/media/limit-checker.svg",
         "autoShow": true,
         "defaultWidth": 900,
-        "defaultHeight": 820,
+        "defaultHeight": 700,
         "defaultCentered": true,
         "resizable": true,
         "maximizable": true,

--- a/src/client/src/App/LiveRates/Tile/Notional/Notional.tsx
+++ b/src/client/src/App/LiveRates/Tile/Notional/Notional.tsx
@@ -4,12 +4,7 @@ import { concat, merge, Observable, OperatorFunction, pipe } from "rxjs"
 import { filter, map, take } from "rxjs/operators"
 
 import { currencyPairs$ } from "@/services/currencyPairs"
-import {
-  createApplyCharacterMultiplier,
-  customNumberFormatter,
-  DECIMAL_SEPARATOR,
-  parseQuantity,
-} from "@/utils/formatNumber"
+import { formatNotional } from "@/utils/formatNotional"
 
 import { QuoteStateStage, useRfqState } from "../Rfq"
 import { symbolBind, useTileCurrencyPair } from "../Tile.context"
@@ -26,27 +21,6 @@ const [rawNotional$, onChangeNotionalValue] = createKeyedSignal(
   (symbol: string, rawVal: string) => ({ symbol, rawVal }),
 )
 export { onChangeNotionalValue }
-
-export const formatNotional = (
-  rawVal: string,
-  characterMultipliers: ("k" | "m" | "b" | "t")[],
-  formatterOptions?: Intl.NumberFormatOptions,
-): [number, string] => {
-  const applyCharacterMultiplier =
-    createApplyCharacterMultiplier(characterMultipliers)
-
-  const formatter = customNumberFormatter(formatterOptions)
-
-  const numValue = Math.abs(parseQuantity(rawVal))
-  const lastChar = rawVal.slice(-1).toLowerCase()
-  const value = applyCharacterMultiplier(numValue, lastChar)
-
-  return [
-    value,
-    formatter(value) +
-      (lastChar === DECIMAL_SEPARATOR ? DECIMAL_SEPARATOR : ""),
-  ]
-}
 
 export const [useNotional, getNotional$] = symbolBind((symbol) =>
   concat(

--- a/src/client/src/OpenFin/apps/LimitChecker/LimitCheckResults.tsx
+++ b/src/client/src/OpenFin/apps/LimitChecker/LimitCheckResults.tsx
@@ -1,3 +1,4 @@
+import { scan, share } from "rxjs"
 import styled from "styled-components"
 
 import { TradesGrid } from "@/App/Trades/TradesGrid"
@@ -5,8 +6,27 @@ import {
   limitCheckerColDef,
   limitCheckerColFields,
 } from "@/App/Trades/TradesState/colConfig"
+import { LimitCheckStatus, LimitCheckTrade } from "@/services/trades/types"
 
-import { tableRows$ } from "./state"
+import { limitResult$ } from "./state"
+
+let tradeId = 0
+
+const tableRows$ = limitResult$.pipe(
+  scan((acc, { notional, request, result }) => {
+    return [
+      {
+        status: result ? LimitCheckStatus.Success : LimitCheckStatus.Failure,
+        tradeId: tradeId++,
+        symbol: request.tradedCurrencyPair,
+        notional,
+        spotRate: request.rate,
+      },
+      ...acc,
+    ]
+  }, [] as LimitCheckTrade[]),
+  share(),
+)
 
 const Container = styled.div`
   display: flex;

--- a/src/client/src/OpenFin/apps/LimitChecker/LimitChecker.tsx
+++ b/src/client/src/OpenFin/apps/LimitChecker/LimitChecker.tsx
@@ -1,4 +1,5 @@
 import { Context, joinChannel } from "@finos/fdc3"
+import { Subscribe } from "@react-rxjs/core"
 import { useEffect } from "react"
 import styled from "styled-components"
 
@@ -31,8 +32,10 @@ const LimitChecker = () => {
 
   return (
     <Container>
-      <LimitInputs />
-      <LimitCheckResultsTable />
+      <Subscribe>
+        <LimitInputs />
+        <LimitCheckResultsTable />
+      </Subscribe>
     </Container>
   )
 }

--- a/src/client/src/OpenFin/apps/LimitChecker/LimitInput.tsx
+++ b/src/client/src/OpenFin/apps/LimitChecker/LimitInput.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components"
 
 import { CurrencyPair } from "@/services/currencyPairs/types"
 
-import { setLimit, useLimit } from "./state"
+import { onChangeLimitValue, useLimit } from "./state"
 
 const Container = styled.div`
   background-color: ${({ theme }) => theme.core.lightBackground};
@@ -37,7 +37,7 @@ const Input = styled.input`
   padding: 2px 0;
   color: ${({ theme }) => theme.core.textColor};
   border-bottom: 1.5px solid ${({ theme }) => theme.primary[5]};
-  caret-color: ${({ theme }) => theme.primary.base};
+  caret-color: ${({ theme }) => theme.accents.primary.base};
   &:focus {
     border-color: ${({ theme }) => theme.accents.primary.base};
   }
@@ -48,17 +48,17 @@ export const LimitInput = ({
 }: {
   currencyPair: CurrencyPair
 }) => {
-  const limit = useLimit(currencyPair.symbol)
+  const [, inputValue] = useLimit(currencyPair.symbol)
 
   const handleLimitChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLimit({ [currencyPair.symbol]: Number(e.target.value) })
+    onChangeLimitValue(currencyPair.symbol, e.target.value)
   }
 
   return (
     <Container>
       <Symbol>{currencyPair.base + "/" + currencyPair.terms}</Symbol>
       <Label>{currencyPair.base}</Label>
-      <Input value={limit} onChange={handleLimitChange} />
+      <Input value={inputValue} onChange={handleLimitChange} />
     </Container>
   )
 }

--- a/src/client/src/OpenFin/apps/LimitChecker/state.ts
+++ b/src/client/src/OpenFin/apps/LimitChecker/state.ts
@@ -2,8 +2,8 @@ import { bind } from "@react-rxjs/core"
 import { createKeyedSignal, createSignal } from "@react-rxjs/utils"
 import { concat, filter, map, switchMap, take } from "rxjs"
 
-import { formatNotional } from "@/App/LiveRates/Tile/Notional"
 import { currencyPairs$ } from "@/services/currencyPairs"
+import { formatNotional } from "@/utils/formatNotional"
 
 export interface LimitCheckerRequest {
   id: string

--- a/src/client/src/OpenFin/apps/LimitChecker/state.ts
+++ b/src/client/src/OpenFin/apps/LimitChecker/state.ts
@@ -1,8 +1,8 @@
 import { bind } from "@react-rxjs/core"
 import { createKeyedSignal, createSignal } from "@react-rxjs/utils"
-import { concat, map, switchMap, take } from "rxjs"
+import { concat, filter, map, switchMap, take } from "rxjs"
 
-import { mapToFormattedNotional } from "@/App/LiveRates/Tile/Notional"
+import { formatNotional } from "@/App/LiveRates/Tile/Notional"
 import { currencyPairs$ } from "@/services/currencyPairs"
 
 export interface LimitCheckerRequest {
@@ -28,7 +28,10 @@ const [useLimit, limitBySymbol$] = bind((symbol: string) =>
       })),
     ),
     limitInputValue$(symbol),
-  ).pipe(mapToFormattedNotional(({ value }) => value, ["k", "m"])),
+  ).pipe(
+    map(({ value }) => formatNotional(value, ["k", "m"])),
+    filter(([value]) => !Number.isNaN(value)),
+  ),
 )
 
 const [limitCheckRequest$, checkLimit] = createSignal<LimitCheckerRequest>()

--- a/src/client/src/services/trades/types.ts
+++ b/src/client/src/services/trades/types.ts
@@ -55,8 +55,8 @@ export enum LimitCheckStatus {
 export interface LimitCheckTrade extends Trade {
   status: LimitCheckStatus
   symbol: string
-  notional: number
-  spotRate: number
+  notional: string
+  spotRate: string
 }
 
 export interface Trade {

--- a/src/client/src/utils/formatNotional.ts
+++ b/src/client/src/utils/formatNotional.ts
@@ -1,0 +1,27 @@
+import {
+  createApplyCharacterMultiplier,
+  customNumberFormatter,
+  DECIMAL_SEPARATOR,
+  parseQuantity,
+} from "./formatNumber"
+
+export const formatNotional = (
+  rawVal: string,
+  characterMultipliers: ("k" | "m")[],
+  formatterOptions?: Intl.NumberFormatOptions,
+): [number, string] => {
+  const applyCharacterMultiplier =
+    createApplyCharacterMultiplier(characterMultipliers)
+
+  const formatter = customNumberFormatter(formatterOptions)
+
+  const numValue = Math.abs(parseQuantity(rawVal))
+  const lastChar = rawVal.slice(-1).toLowerCase()
+  const value = applyCharacterMultiplier(numValue, lastChar)
+
+  return [
+    value,
+    formatter(value) +
+      (lastChar === DECIMAL_SEPARATOR ? DECIMAL_SEPARATOR : ""),
+  ]
+}


### PR DESCRIPTION

![image](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/67154337/e46c48c9-3d22-468d-80da-f32674e724cb)

https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/67154337/40738151-c06b-420a-a7f1-82fa5d303ed9

Notional in table is also formatted now
![image](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/67154337/3327092c-66c4-4843-925d-633a7d31bf32)
