### PR TITLE
test(playwright): replace static wait with a dynamic one and added html reporter

### DIFF
--- a/src/client/e2e/credit.spec.ts
+++ b/src/client/e2e/credit.spec.ts
@@ -36,12 +36,9 @@ test.describe("Credit", () => {
       test.setTimeout(120000)
 
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
-      await newRfqPage
-        .locator("[data-testid='search-result-item']")
-        .nth(5)
-        .click()
+      await newRfqPage.getByTestId("search-result-item").nth(5).click()
 
-      const quantity = newRfqPage.locator("[data-testid='quantity']")
+      const quantity = newRfqPage.getByTestId("quantity")
       await quantity.type("2")
       await quantity.blur()
 
@@ -59,27 +56,28 @@ test.describe("Credit", () => {
 
       // Navigate to Live
       await rfqsPage.getByText(/Live/).click()
-      await rfqsPage.waitForTimeout(15000)
 
-      await rfqsPage
-        .locator("[data-testid='quotes']")
+      const firstquote = await rfqsPage
+        .getByTestId("quotes")
+        .first()
         .locator("div")
         .first()
-        .hover()
+      // Wait for first quote response
+      await expect(firstquote).not.toContainText("Awaiting response", {
+        timeout: 20000,
+      })
 
-      await rfqsPage
-        .getByTestId("quotes")
-        .getByText(/Accept/)
-        .first()
-        .click()
+      await firstquote.hover()
+
+      await firstquote.getByText(/Accept/).click()
 
       await rfqsPage.locator("li").getByText(/All/).nth(0).click()
       const btnTxt = await rfqsPage
-        .locator("[data-testid='view-trade']")
+        .getByTestId("view-trade")
         .first()
         .innerText()
 
-      await rfqsPage.locator("[data-testid='view-trade']").first().click()
+      await rfqsPage.getByTestId("view-trade").first().click()
 
       const tradeId = btnTxt.split(" ")[2]
       const blotterId = await rfqBlotterPage
@@ -95,12 +93,9 @@ test.describe("Credit", () => {
   test.describe("Sell side", () => {
     test("Sell side ticket", async ({ context }) => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
-      await newRfqPage
-        .locator("[data-testid='search-result-item']")
-        .nth(5)
-        .click()
+      await newRfqPage.getByTestId("search-result-item").nth(5).click()
 
-      const quantity = newRfqPage.locator("[data-testid='quantity']")
+      const quantity = newRfqPage.getByTestId("quantity")
       await quantity.type("2")
 
       await newRfqPage

--- a/src/client/e2e/credit.spec.ts
+++ b/src/client/e2e/credit.spec.ts
@@ -57,19 +57,19 @@ test.describe("Credit", () => {
       // Navigate to Live
       await rfqsPage.getByText(/Live/).click()
 
-      const firstquote = await rfqsPage
+      const firstQuote = await rfqsPage
         .getByTestId("quotes")
         .first()
         .locator("div")
         .first()
       // Wait for first quote response
-      await expect(firstquote).not.toContainText("Awaiting response", {
+      await expect(firstQuote).not.toContainText("Awaiting response", {
         timeout: 20000,
       })
 
-      await firstquote.hover()
+      await firstQuote.hover()
 
-      await firstquote.getByText(/Accept/).click()
+      await firstQuote.getByText(/Accept/).click()
 
       await rfqsPage.locator("li").getByText(/All/).nth(0).click()
       const btnTxt = await rfqsPage

--- a/src/client/playwright.config.ts
+++ b/src/client/playwright.config.ts
@@ -1,5 +1,5 @@
-import type { PlaywrightTestConfig } from "@playwright/test"
-import { devices } from "@playwright/test"
+import type {PlaywrightTestConfig} from "@playwright/test"
+import {devices} from "@playwright/test"
 
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
@@ -11,11 +11,24 @@ const config: PlaywrightTestConfig = {
       name: "chrome",
       use: {
         ...devices["Desktop Chrome"],
+        //Artifacts
+      screenshot: `only-on-failure`,
+      video: `retain-on-failure`,
+      trace: `retain-on-failure`,
+      headless: true,
       },
     },
     {
       name: "openfin",
     },
+  ],
+  reporter: [
+    [
+      `html`,
+      {
+        outputFolder: "html-report",
+      },
+    ],
   ],
   // use: {
   //   launchOptions: {


### PR DESCRIPTION
1. Replaced existing static wait `rfqsPage.waitForTimeout(15000)` with a dynamic one that will resume test execution only once a first quote response is received. This is speeding up test execution substantially
2. Optimised the use of `getByTestId`
3. Added html reporter to playwright.config

Ran both `e2e:web` and `e2e:web:smoke` multiple times to validate stability ✅