### PR TITLE
fix: force dark theme for launcher and limit checker

### DIFF
--- a/src/client/OpenFin/Window/WindowHeader.tsx
+++ b/src/client/OpenFin/Window/WindowHeader.tsx
@@ -1,5 +1,4 @@
 import Header from "client/App/Header"
-import { LimitCheckerHeader } from "client/App/Header/LimitCheckerHeader"
 import LoginControls from "client/App/Header/LoginControls"
 import ThemeSwitcher from "client/App/Header/theme-switcher"
 

--- a/src/client/OpenFin/apps/LimitChecker/LimitCheckResults.tsx
+++ b/src/client/OpenFin/apps/LimitChecker/LimitCheckResults.tsx
@@ -28,6 +28,7 @@ const tableRows$ = limitResult$.pipe(
 )
 
 const Container = styled.div`
+  background-color: ${({ theme }) => theme.core.darkBackground};
   display: flex;
   flex: 1;
   padding: 0 10px 20px 10px;

--- a/src/client/OpenFin/index.tsx
+++ b/src/client/OpenFin/index.tsx
@@ -4,8 +4,10 @@ import { DocTitle } from "client/components/DocTitle"
 import { Loader } from "client/components/Loader"
 import { BASE_PATH, ROUTES_CONFIG } from "client/constants"
 import { OpenFinContactDisplay } from "client/OpenFin/Footer/ContactUsButton"
+import { ThemeName, themes } from "client/theme"
 import { lazy, Suspense } from "react"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
+import { ThemeProvider } from "styled-components"
 
 import { Snapshots } from "./Snapshots/Snapshots"
 import { ChildWindowFrame } from "./Window/ChildWindowFrame"
@@ -33,9 +35,11 @@ export const OpenFinApp = () => (
       <Route
         path={ROUTES_CONFIG.launcher}
         element={
-          <Suspense fallback={<Loader />}>
-            <Launcher />
-          </Suspense>
+          <ThemeProvider theme={themes[ThemeName.Dark]}>
+            <Suspense fallback={<Loader opacity={1} />}>
+              <Launcher />
+            </Suspense>
+          </ThemeProvider>
         }
       />
 
@@ -114,17 +118,23 @@ export const OpenFinApp = () => (
       <Route
         path={ROUTES_CONFIG.limitChecker}
         element={
-          <DocTitle title="Limit Checker">
-            <LimitChecker />
-            <DisconnectionOverlay />
-          </DocTitle>
+          <ThemeProvider theme={themes[ThemeName.Dark]}>
+            <DocTitle title="Limit Checker">
+              <LimitChecker />
+              <DisconnectionOverlay />
+            </DocTitle>
+          </ThemeProvider>
         }
       />
 
       <Route path="/openfin-window-frame" element={<WindowFrame />} />
       <Route
         path="/openfin-admin-window-frame"
-        element={<LimitCheckerWindowFrame />}
+        element={
+          <ThemeProvider theme={themes[ThemeName.Dark]}>
+            <LimitCheckerWindowFrame />
+          </ThemeProvider>
+        }
       />
       <Route path="/openfin-sub-window-frame" element={<ChildWindowFrame />} />
       <Route path={ROUTES_CONFIG.contact} element={<OpenFinContactDisplay />} />


### PR DESCRIPTION
I've also been looking at [5038](https://adaptive.kanbanize.com/ctrl_board/18/cards/5038/details/) and it looks like the white screen isn't caused by the `backgroundColor` option in `defaultWindowOptions`/`defaultViewOptions`. When I set backgroundColor to red for example and start the FX app (video attached below), the app is red for a second, before it becomes white, and then it loads the app as usual. The views inside the app load in the same way. From inspection, this looks like it's because nothing has been loaded so the view is blank (white). Going to just submit this PR for [5041](https://adaptive.kanbanize.com/ctrl_board/18/cards/5041/details/) now and look at alternative solutions to 5038 separately.

https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/10549511/6c9a8ecc-3275-4f1c-9b7f-8c30091ea8df

