### PR TITLE
Test(maintenance): Update Playwright scripts for openfin 

### DIFF
--- a/packages/client/e2e/blotter.spec.ts
+++ b/packages/client/e2e/blotter.spec.ts
@@ -72,6 +72,10 @@ test.describe("Trade Blotter", () => {
   })
 
   test("when user buys a currency, the new row should flash briefly ", async () => {
+
+    await tilePage.locator("input[id='notional-input-EURUSD']").clear()
+    await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
+
     const tile = tilePage.locator('[data-testid="Buy-EURUSD"]').nth(0)
     await tile.click()
 
@@ -157,7 +161,7 @@ test.describe("Trade Blotter", () => {
 
     const searchInput = blotterPage.locator('[aria-label*="Primary filter"]')
 
-    const tradeIDToSearch = "2"
+    const tradeIDToSearch = "1"
     await searchInput.type(tradeIDToSearch, { delay: 100 })
 
     const downloadPromise = blotterPage.waitForEvent("download")

--- a/packages/client/e2e/blotter.spec.ts
+++ b/packages/client/e2e/blotter.spec.ts
@@ -76,9 +76,8 @@ test.describe("Trade Blotter", () => {
     await tilePage.locator("input[id='notional-input-EURUSD']").clear()
     await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
 
-    const tile = tilePage.locator('[data-testid="Buy-EURUSD"]').nth(0)
-    await tile.click()
-
+    await tilePage.locator('[data-testid="Buy-EURUSD"]').nth(0).click()
+  
     const tradeID = await tilePage
       .locator("[data-testid='trade-id']")
       .innerText()

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -55,7 +55,7 @@ test.describe("Credit", () => {
       // Navigate to Live
       await rfqsPage.getByText(/Live/).first().click()
 
-      const firstQuote = await rfqsPage
+      const firstQuote = rfqsPage
         .getByTestId("quotes")
         .first()
         .locator("div")
@@ -101,21 +101,22 @@ test.describe("Credit", () => {
         .getByText(/Adaptive Bank/)
         .click()
 
+      const pagePromise = context.waitForEvent("page", {
+        predicate: page => page.url().includes("credit-sellside"),
+      })
+
       await newRfqPage
         .locator("button")
         .getByText(/Send RFQ/)
         .click()
 
-      context.on("page", async (sellSidePage) => {
-        await sellSidePage.waitForURL("**/credit-sellside?**")
+      const sellSidePage = await pagePromise
 
-        await sellSidePage.waitForSelector("text=New RFQ")
+      await sellSidePage.waitForSelector("text=New RFQ")
 
-        await sellSidePage.getByTestId("price-input").fill("100")
+      await sellSidePage.getByTestId("price-input").fill("100")
 
-        await sellSidePage.keyboard.press("Enter")
-
-      })
+      await sellSidePage.keyboard.press("Enter")
 
       await expect(rfqsPage.getByTestId("quotes").first()).toContainText("$100", {timeout: 10000})
     })

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -107,7 +107,7 @@ test.describe("Credit", () => {
         .click()
 
       context.on("page", async (sellSidePage) => {
-        await sellSidePage.waitForURL("**/credit-sellside?**")
+        await sellSidePage.waitForURL(`${process.env.E2E_RTC_WEB_ROOT_URL}/credit-sellside?**`)
 
         await sellSidePage.waitForSelector("text=New RFQ")
 

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -34,7 +34,7 @@ test.describe("Credit", () => {
   test.describe("New RFQ", () => {
     test("Create RFQ for GOOGL @smoke", async () => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
-      await newRfqPage.getByTestId("search-result-item").nth(5).click()
+      await newRfqPage.getByTestId("search-result-item").getByText("GOOGL").first().click()
 
       const quantity = newRfqPage.getByTestId("quantity")
       await quantity.type("2")
@@ -91,7 +91,7 @@ test.describe("Credit", () => {
   test.describe("Sell side", () => {
     test("Sell side ticket", async ({ context }) => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
-      await newRfqPage.getByTestId("search-result-item").nth(5).click()
+      await newRfqPage.getByTestId("search-result-item").getByText("GOOGL").first().click()
 
       const quantity = newRfqPage.getByTestId("quantity")
       await quantity.type("2")
@@ -101,21 +101,20 @@ test.describe("Credit", () => {
         .getByText(/Adaptive Bank/)
         .click()
 
+      const pagePromise = context.waitForEvent("page")
+
       await newRfqPage
         .locator("button")
         .getByText(/Send RFQ/)
         .click()
 
-      context.on("page", async (sellSidePage) => {
-        await sellSidePage.waitForURL(`${process.env.E2E_RTC_WEB_ROOT_URL}/credit-sellside?**`)
+      const sellSidePage = await pagePromise
 
-        await sellSidePage.waitForSelector("text=New RFQ")
+      await sellSidePage.waitForSelector("text=New RFQ")
 
-        await sellSidePage.getByTestId("price-input").fill("100")
+      await sellSidePage.getByTestId("price-input").fill("100")
 
-        await sellSidePage.keyboard.press("Enter")
-
-      })
+      await sellSidePage.keyboard.press("Enter")
 
       await expect(rfqsPage.getByTestId("quotes").first()).toContainText("$100", {timeout: 10000})
     })

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -53,7 +53,7 @@ test.describe("Credit", () => {
         .click()
 
       // Navigate to Live
-      await rfqsPage.getByText(/Live/).click()
+      await rfqsPage.getByText(/Live/).first().click()
 
       const firstQuote = await rfqsPage
         .getByTestId("quotes")
@@ -101,20 +101,21 @@ test.describe("Credit", () => {
         .getByText(/Adaptive Bank/)
         .click()
 
-      const pagePromise = context.waitForEvent("page")
-
       await newRfqPage
         .locator("button")
         .getByText(/Send RFQ/)
         .click()
 
-      const sellSidePage = await pagePromise
+      context.on("page", async (sellSidePage) => {
+        await sellSidePage.waitForURL("**/credit-sellside?**")
 
-      await sellSidePage.waitForSelector("text=New RFQ")
+        await sellSidePage.waitForSelector("text=New RFQ")
 
-      await sellSidePage.getByTestId("price-input").fill("100")
+        await sellSidePage.getByTestId("price-input").fill("100")
 
-      await sellSidePage.keyboard.press("Enter")
+        await sellSidePage.keyboard.press("Enter")
+
+      })
 
       await expect(rfqsPage.getByTestId("quotes").first()).toContainText("$100", {timeout: 10000})
     })

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -33,7 +33,7 @@ test.describe("Credit", () => {
 
   test.describe("New RFQ", () => {
     test("Create RFQ for GOOGL @smoke", async () => {
-      test.setTimeout(120000)
+      test.setTimeout(30000)
 
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
       await newRfqPage.getByTestId("search-result-item").nth(5).click()
@@ -103,22 +103,23 @@ test.describe("Credit", () => {
         .getByText(/Adaptive Bank/)
         .click()
 
-      const pagePromise = context.waitForEvent("page")
-
       await newRfqPage
         .locator("button")
         .getByText(/Send RFQ/)
         .click()
 
-      const sellSidePage = await pagePromise
+      context.on("page", async (sellSidePage) => {
+        await sellSidePage.waitForURL("**/credit-sellside?**")
 
-      await sellSidePage.waitForSelector("text=New RFQ")
+        await sellSidePage.waitForSelector("text=New RFQ")
 
-      await sellSidePage.getByTestId("price-input").fill("100")
+        await sellSidePage.getByTestId("price-input").fill("100")
 
-      await sellSidePage.keyboard.press("Enter")
+        await sellSidePage.keyboard.press("Enter")
 
-      await expect(rfqsPage.getByTestId("quotes").first()).toContainText("$100")
+      })
+
+      await expect(rfqsPage.getByTestId("quotes").first()).toContainText("$100", {timeout: 10000})
     })
   })
 })

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -33,8 +33,6 @@ test.describe("Credit", () => {
 
   test.describe("New RFQ", () => {
     test("Create RFQ for GOOGL @smoke", async () => {
-      test.setTimeout(30000)
-
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
       await newRfqPage.getByTestId("search-result-item").nth(5).click()
 

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -30,6 +30,7 @@ test.describe("Fx App", () => {
     context,
   }, testInfo) => {
     //TODO either adapt this test for web tear out or write a companion test
+    //TODO remove skip once https://adaptive.kanbanize.com/ctrl_board/18/cards/5498/details/ is resolved. Skipping as it fail to reattach to main window
 
     test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME)
 

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -38,6 +38,7 @@ test.describe("Fx App", () => {
     const popOutButtons = mainWindow.getByTitle("open in new window")
     const toggleLock = mainWindow.getByTitle("toggle layout lock")
 
+    await expect(popOutButtons).toHaveCount(3)
     await expect(popOutButtons.nth(0)).not.toBeVisible()
 
     await toggleLock.hover()
@@ -46,13 +47,11 @@ test.describe("Fx App", () => {
     const liveRatesPagePromise = context.waitForEvent("page")
     await popOutButtons.nth(0).click()
     const poppedOutLiveRatesPage = await liveRatesPagePromise
-
     await poppedOutLiveRatesPage.waitForSelector("text=Live Rates")
 
     const blotterPagePromise = context.waitForEvent("page")
     await popOutButtons.nth(0).click()
     const poppedOutBlotterPage = await blotterPagePromise
-
     await poppedOutBlotterPage.waitForSelector("text=Trades")
 
     await poppedOutLiveRatesPage
@@ -74,6 +73,7 @@ test.describe("Fx App", () => {
     await toggleLock.hover()
     await toggleLock.click()
 
+    await expect(popOutButtons).toHaveCount(3)
     await expect(popOutButtons.nth(0)).not.toBeVisible()
   })
 })

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -30,18 +30,18 @@ test.describe("Fx App", () => {
     context,
   }, testInfo) => {
     //TODO either adapt this test for web tear out or write a companion test
-    //TODO remove skip once https://adaptive.kanbanize.com/ctrl_board/18/cards/5498/details/ is resolved. Skipping as it fail to reattach to main window
+    //TODO Test is failing intermittently due to issue documented in RT-5538. Skipping the test until resolved
 
     test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME)
 
-    const popOutTitle = "open in new window"
+ 
+    const popOutButtons = mainWindow.getByTitle("open in new window")
+    const toggleLock = mainWindow.getByTitle("toggle layout lock")
 
-    await expect(mainWindow.getByTitle(popOutTitle).nth(0)).not.toBeVisible()
+    await expect(popOutButtons.nth(0)).not.toBeVisible()
 
-    await mainWindow.getByTitle("toggle layout lock").hover()
-    await mainWindow.getByTitle("toggle layout lock").click()
-
-    const popOutButtons = mainWindow.getByTitle(popOutTitle)
+    await toggleLock.hover()
+    await toggleLock.click()
 
     const liveRatesPagePromise = context.waitForEvent("page")
     await popOutButtons.nth(0).click()
@@ -59,21 +59,20 @@ test.describe("Fx App", () => {
       .locator("[data-qa='openfin-chrome__close']")
       .click()
 
-    await expect(poppedOutLiveRatesPage.isClosed()).toBeTruthy()
-    await expect(poppedOutBlotterPage.isClosed()).toBeFalsy()
     await expect(mainWindow.locator("text=Live Rates")).toBeVisible()
+    expect(poppedOutLiveRatesPage.isClosed()).toBeTruthy()
     
     await poppedOutBlotterPage
       .locator("[data-qa='openfin-chrome__close']")
       .click()
-    
-    await expect(poppedOutBlotterPage.isClosed()).toBeTruthy()
 
     await expect(mainWindow.locator("text=Trades")).toBeVisible()
+    expect(poppedOutBlotterPage.isClosed()).toBeTruthy()
+
     await expect(mainWindow.locator("text=Analytics")).toBeVisible()
 
-    await mainWindow.getByTitle("toggle layout lock").hover()
-    await mainWindow.getByTitle("toggle layout lock").click()
+    await toggleLock.hover()
+    await toggleLock.click()
 
     await expect(popOutButtons.nth(0)).not.toBeVisible()
   })

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -26,7 +26,7 @@ test.describe("Fx App", () => {
     selectors.setTestIdAttribute("data-qa")
   })
 
-  test("Views should open new windows when popped out, and reattach to main window when closed", async ({
+  test.skip("Views should open new windows when popped out, and reattach to main window when closed", async ({
     context,
   }, testInfo) => {
     //TODO either adapt this test for web tear out or write a companion test

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -33,9 +33,13 @@ test.describe("Fx App", () => {
 
     test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME)
 
+    const popOutTitle = "open in new window"
+
+    await expect(mainWindow.getByTitle(popOutTitle).nth(0)).not.toBeVisible()
+
+    await mainWindow.getByTitle("toggle layout lock").hover()
     await mainWindow.getByTitle("toggle layout lock").click()
 
-    const popOutTitle = "open in new window"
     const popOutButtons = mainWindow.getByTitle(popOutTitle)
 
     const liveRatesPagePromise = context.waitForEvent("page")
@@ -50,13 +54,26 @@ test.describe("Fx App", () => {
 
     await poppedOutBlotterPage.waitForSelector("text=Trades")
 
-    await poppedOutLiveRatesPage.getByTestId("openfin-chrome__close").click()
+    await poppedOutLiveRatesPage
+      .locator("[data-qa='openfin-chrome__close']")
+      .click()
 
-    expect(await mainWindow.waitForSelector("text=Live Rates")).toBeTruthy()
+    await expect(poppedOutLiveRatesPage.isClosed()).toBeTruthy()
+    await expect(poppedOutBlotterPage.isClosed()).toBeFalsy()
+    await expect(mainWindow.locator("text=Live Rates")).toBeVisible()
+    
+    await poppedOutBlotterPage
+      .locator("[data-qa='openfin-chrome__close']")
+      .click()
+    
+    await expect(poppedOutBlotterPage.isClosed()).toBeTruthy()
 
-    await poppedOutBlotterPage.getByTestId("openfin-chrome__close").click()
+    await expect(mainWindow.locator("text=Trades")).toBeVisible()
+    await expect(mainWindow.locator("text=Analytics")).toBeVisible()
 
-    expect(await mainWindow.waitForSelector("text=Trades")).toBeTruthy()
-    expect(await mainWindow.waitForSelector("text=Analytics")).toBeTruthy()
+    await mainWindow.getByTitle("toggle layout lock").hover()
+    await mainWindow.getByTitle("toggle layout lock").click()
+
+    await expect(popOutButtons.nth(0)).not.toBeVisible()
   })
 })

--- a/packages/client/e2e/limit-checker.spec.ts
+++ b/packages/client/e2e/limit-checker.spec.ts
@@ -30,39 +30,44 @@ test.describe("Limit Checker", () => {
       .nth(1)
       .locator("div")
 
-    const limitCheckInput = limitCheckerPage.getByLabel("EUR/USD")
+    const limitCheckInput = limitCheckerPage
+      .locator("div", {
+        has: limitCheckerPage.locator("div", { hasText: /^EUR\/USD$/ }),
+      })
+      .last()
+      .locator("input")
+
+    const lastTradeIdString = await tradeBlotterFirstRowCells.nth(1).innerText()
+    const lastTradeId = isNaN(Number(lastTradeIdString)) ? 0 : Number(lastTradeIdString)
 
     const limitIdString = await limitTableFirstRowCells.nth(1).innerText()
+    const limitId = isNaN(Number(limitIdString)) ? -1 : Number(limitIdString)
 
-    const limitId = Number(limitIdString) ? Number(limitIdString) : -1
-
-    await limitCheckInput.fill("1000000")
+    await limitCheckInput.fill("2000000")
 
     const tileInput = tilePage.getByLabel("EUR").nth(0)
-    await tileInput.fill("12345")
+    await tileInput.fill("999999")
 
     await tilePage.locator("[data-testid='Buy-EURUSD']").click()
 
+    await tradeBlotterFirstRowCells.nth(1).getByText(lastTradeId + 1 + "").waitFor({state: "visible"})
+    
     await assertGridRow(
       limitTableFirstRowCells,
-      [limitId + 1 + "", "Success", "EURUSD", "12,345"],
+      [limitId + 1 + "", "Success", "EURUSD", "2,000,000"],
       1,
-      5,
     )
-
-    await assertGridCell(tradeBlotterFirstRowCells, 2, "Done")
 
     await assertGridRow(
       tradeBlotterFirstRowCells,
-      ["Buy", "EURUSD", "EUR", "12,345"],
+      ["Buy", "EURUSD", "EUR", "999,999"],
       4,
-      8,
     )
   })
 
   test("Trade is blocked if notional is above limit", async ({}, testInfo) => {
     test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME, "Openfin Only")
-
+  
     const limitTableFirstRowCells = limitCheckerPage
       .locator(`[role="grid"] > div`)
       .nth(1)
@@ -75,21 +80,27 @@ test.describe("Limit Checker", () => {
 
     const tradeId = await tradeBlotterFirstRowCells.nth(1).innerText()
 
-    const limitCheckInput = limitCheckerPage.getByLabel("EUR/USD")
+    const limitCheckInput = limitCheckerPage
+      .locator("div", {
+        has: limitCheckerPage.locator("div", { hasText: /^EUR\/USD$/ }),
+      })
+      .last()
+      .locator("input")
+
     const tileInput = tilePage.getByLabel("EUR").nth(0)
 
     const limitIdString = await limitTableFirstRowCells.nth(1).innerText()
-    const limitId = Number(limitIdString) ? Number(limitIdString) : -1
+    const limitId = !isNaN(Number(limitIdString)) ? Number(limitIdString) : -1
 
-    await limitCheckInput.fill("1000")
+    await limitCheckInput.fill("1000000")
 
-    await tileInput.fill("100000")
+    await tileInput.fill("1000001")
 
     await tilePage.locator("[data-testid='Buy-EURUSD']").click()
 
     await assertGridRow(
       limitTableFirstRowCells,
-      [limitId + 2 + "", "Failure", "EURUSD", "100,000"],
+      [limitId + 1 + "", "Failure", "EURUSD", "1,000,000"],
       1,
       5,
     )

--- a/packages/client/e2e/limit-checker.spec.ts
+++ b/packages/client/e2e/limit-checker.spec.ts
@@ -50,7 +50,7 @@ test.describe("Limit Checker", () => {
 
     await tilePage.locator("[data-testid='Buy-EURUSD']").click()
 
-    await tradeBlotterFirstRowCells.nth(1).getByText(lastTradeId + 1 + "").waitFor({state: "visible"})
+    await tradeBlotterFirstRowCells.nth(1).getByText(lastTradeId + 1 + "").waitFor({state: "visible", timeout:5000})
     
     await assertGridRow(
       limitTableFirstRowCells,

--- a/packages/client/e2e/limit-checker.spec.ts
+++ b/packages/client/e2e/limit-checker.spec.ts
@@ -82,13 +82,13 @@ test.describe("Limit Checker", () => {
 
     const tradeId = await tradeBlotterFirstRowCells.nth(1).innerText()
 
-    const limitCheckInput = limitCheckerPage
+   const limitCheckInput = limitCheckerPage
       .locator("div", {
         has: limitCheckerPage.locator("div", { hasText: /^EUR\/USD$/ }),
       })
       .last()
       .locator("input")
-
+  
     const tileInput = tilePage.getByLabel("EUR").nth(0)
 
     const limitIdString = await limitTableFirstRowCells.nth(1).innerText()

--- a/packages/client/e2e/limit-checker.spec.ts
+++ b/packages/client/e2e/limit-checker.spec.ts
@@ -46,7 +46,7 @@ test.describe("Limit Checker", () => {
     await limitCheckInput.fill("2000000")
 
     const tileInput = tilePage.getByLabel("EUR").nth(0)
-    await tileInput.fill("999999")
+    await tileInput.fill("1999999")
 
     await tilePage.locator("[data-testid='Buy-EURUSD']").click()
 
@@ -56,12 +56,14 @@ test.describe("Limit Checker", () => {
       limitTableFirstRowCells,
       [limitId + 1 + "", "Success", "EURUSD", "2,000,000"],
       1,
+      5,
     )
 
     await assertGridRow(
       tradeBlotterFirstRowCells,
-      ["Buy", "EURUSD", "EUR", "999,999"],
+      ["Buy", "EURUSD", "EUR", "1,999,999"],
       4,
+      8,
     )
   })
 

--- a/packages/client/e2e/spot-tile.spec.ts
+++ b/packages/client/e2e/spot-tile.spec.ts
@@ -65,7 +65,6 @@ test.describe("Spot Tile", () => {
   })
 
   test.describe("Timed out transaction", () => {
-    test.setTimeout(10000)
     test("When I sell EUR/JPY then an execution animation appears until a timed out tile displays in orange with message 'Trade taking longer than expected'", async () => {
       await tilePage.locator("[data-testid='Sell-EURJPY']").click()
 
@@ -80,7 +79,6 @@ test.describe("Spot Tile", () => {
   })
 
   test.describe("High notional RFQ", () => {
-    test.setTimeout(15000)
     test("When I initiate RFQ on NZD/USD then it should display fixed prices for buy/sell and after 10 secs, and a requote button appears", async () => {
       await tilePage.locator("[data-testid='rfqButton']").click()
 

--- a/packages/client/e2e/spot-tile.spec.ts
+++ b/packages/client/e2e/spot-tile.spec.ts
@@ -26,6 +26,9 @@ test.describe("Spot Tile", () => {
     test("When I sell EUR to USD then trade Id shown in tile should match trade Id shown in blotter @smoke", async () => {
       await tilePage.locator("[data-testid='menuButton-EUR']").click()
 
+      await tilePage.locator("input[id='notional-input-EURUSD']").clear()
+      await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
+
       await tilePage.locator("[data-testid='Sell-EURUSD']").click()
 
       const tradeId = await tilePage
@@ -62,7 +65,7 @@ test.describe("Spot Tile", () => {
   })
 
   test.describe("Timed out transaction", () => {
-    test.setTimeout(60000)
+    test.setTimeout(10000)
     test("When I sell EUR/JPY then an execution animation appears until a timed out tile displays in orange with message 'Trade taking longer than expected'", async () => {
       await tilePage.locator("[data-testid='Sell-EURJPY']").click()
 
@@ -77,6 +80,7 @@ test.describe("Spot Tile", () => {
   })
 
   test.describe("High notional RFQ", () => {
+    test.setTimeout(15000)
     test("When I initiate RFQ on NZD/USD then it should display fixed prices for buy/sell and after 10 secs, and a requote button appears", async () => {
       await tilePage.locator("[data-testid='rfqButton']").click()
 

--- a/packages/client/e2e/utils.ts
+++ b/packages/client/e2e/utils.ts
@@ -15,7 +15,7 @@ export const assertGridRow = async (
     i < (endIndex ? endIndex : assertions.length);
     i++
   ) {
-    assertGridCell(row, i, assertions[j])
+    await assertGridCell(row, i, assertions[j])
     j++
   }
 }

--- a/packages/client/playwright.config.ts
+++ b/packages/client/playwright.config.ts
@@ -4,7 +4,7 @@ import {devices} from "@playwright/test"
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
   /* Maximum time one test can run for. */
-  timeout: 50 * 1000,
+  timeout: 30 * 1000,
   workers: 1,
   projects: [
     {

--- a/packages/client/playwright.config.ts
+++ b/packages/client/playwright.config.ts
@@ -4,7 +4,7 @@ import {devices} from "@playwright/test"
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
   /* Maximum time one test can run for. */
-  timeout: 30000,
+  timeout: 30_000,
   workers: 1,
   projects: [
     {
@@ -20,6 +20,11 @@ const config: PlaywrightTestConfig = {
     },
     {
       name: "openfin",
+      use: {
+      screenshot: "only-on-failure",
+      video: "retain-on-failure",
+      trace: "retain-on-failure",
+      },
     },
   ],
   reporter: [

--- a/packages/client/playwright.config.ts
+++ b/packages/client/playwright.config.ts
@@ -4,7 +4,7 @@ import {devices} from "@playwright/test"
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 30000,
   workers: 1,
   projects: [
     {


### PR DESCRIPTION
Performed scripts maintenance to allow existing scripts to run successfully against both web and openfin 

1. changed `credit.spec` strategy to interact with credit-sellside openfin window
2. did `fx.spec` maintenance (openfin specific).  test is now stable but it will fail when run while credit window is open at the same time (and make subsequent tests fail too). I will address this issue with the team.  Meanwhile I made it skipped until a resolution is found
3. few minor tweaks to improve suite resiliency 
4. removed unnecessary test timeout and set default to 30 seconds. This will prevent long hanging time in case of test case failure.  Current tests take less 20 seconds to run at the most

Ran whole suite against both openfin and web ✅ 