### PR TITLE
Test(playwright): Added Playwright html reporter to github actions

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -27,3 +27,9 @@ jobs:
           E2E_RTC_WEB_ROOT_URL: https://web.uat.reactivetrader.com
         run: |
           npm run e2e:web
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -27,3 +27,9 @@ jobs:
           E2E_RTC_WEB_ROOT_URL: https://web.prod.reactivetrader.com
         run: |
           npm run e2e:web:smoke
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -165,3 +165,9 @@ jobs:
           E2E_RTC_WEB_ROOT_URL: https://web.env.reactivetrader.com/pull/${{ github.event.number }}
         run: |
           npm run e2e:web
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,9 +12,9 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices["Desktop Chrome"],
         //Artifacts
-      screenshot: `only-on-failure`,
-      video: `retain-on-failure`,
-      trace: `retain-on-failure`,
+      screenshot: "only-on-failure",
+      video: "retain-on-failure",
+      trace: "retain-on-failure",
       headless: true,
       },
     },
@@ -23,10 +23,12 @@ const config: PlaywrightTestConfig = {
     },
   ],
   reporter: [
+    ["list"],
     [
-      `html`,
+      "html",
       {
-        outputFolder: "html-report",
+        outputFolder: "playwright-report",
+        open: "never",
       },
     ],
   ],


### PR DESCRIPTION
updated yml workflow files to include html reporter as an artifact to github actions with 7 retention days . This allows to download playwright html report to help in troubleshooting failing tests

Output example -> https://github.com/AdaptiveConsulting/ReactiveTraderCloud/actions/runs/5881522557 

html outcome in case of failure:
<img width="505" alt="Screenshot 2023-08-16 at 15 07 34" src="https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/103059406/a9554c98-803b-4394-9c5e-0470f00c2ccb">

Also added `list` reporter for more verbose console output
![Screenshot 2023-08-16 at 15 10 03](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/103059406/6af8c4ed-44b5-47e7-aa53-8a0407a47e38)
