### PR TITLE
test(playwright): remove always() condition from workflow

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           npm run e2e:web
       - uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           npm run e2e:web:smoke
       - uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()  
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
           npm run e2e:web
       - uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
           name: playwright-report
           path: playwright-report/


### PR DESCRIPTION
Changes done to upload html report artifact ONLY when e2e tests fail. Previous condition was set to `always()` in order to force uploading artifact step to be executed on both e2e success and failure. without this condition the default behaviour is to execute only if previous step was successful 

https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
> You can use the following status check functions as expressions in if conditionals. A default status check of success() is applied unless you include one of these functions.
sucess()
always()
cancelled()
failure()
