### PR TITLE
fix: showing last trades instead of first trade in ws nlp

### DIFF
--- a/packages/client/src/workspace/home/respondWithIntent.ts
+++ b/packages/client/src/workspace/home/respondWithIntent.ts
@@ -145,7 +145,6 @@ export const respondWithIntent = (
 
     case NlpIntentType.TradeInfo: {
       const sub = trades$.subscribe((trades) => {
-        trades.reverse()
         const trimmedTrades = (intent as TradesInfoIntent).payload.count
           ? trades.splice(0, (intent as TradesInfoIntent).payload.count)
           : trades


### PR DESCRIPTION
Broken state, showing first trades:
![image](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/67154337/3274befc-10a5-4a88-9703-294d486d5a5e)

Fixed state, showing last trades:
![Screenshot 2023-08-30 at 16 23 32](https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/67154337/b56165b0-a74b-4aba-a531-f75cd239cbc1)
