### PR TITLE
Rt 5578: Fix credit.spec test failure on openfin

### DIFF
--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -34,6 +34,20 @@ test.describe("Credit", () => {
     }
   })
 
+  test.afterEach(async ({ context }, testInfo) => {
+    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+      const subWindowFrame = context
+        .pages()
+        .find((page) => page.url().includes("openfin-sub-window-frame"))
+      await subWindowFrame?.close()
+    } else {
+      const sellSidePage = context
+        .pages()
+        .find((page) => page.url().includes("credit-sellside"))
+      await sellSidePage?.close()
+    }
+  })
+
   test.describe("New RFQ", () => {
     test("Create RFQ for GOOGL @smoke", async () => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
@@ -74,7 +88,7 @@ test.describe("Credit", () => {
 
       await firstQuote.hover()
 
-      await firstQuote.getByText(/Accept/).click()
+      await firstQuote.getByText(/Accept/).click({ force: true })
 
       await rfqsPage.locator("li").getByText(/All/).nth(0).click()
       const btnTxt = await rfqsPage
@@ -96,7 +110,7 @@ test.describe("Credit", () => {
   })
 
   test.describe("Sell side", () => {
-    test("Sell side ticket", async ({ context }, testInfo) => {
+    test("Sell side ticket", async ({ context }) => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
       await newRfqPage
         .getByTestId("search-result-item")
@@ -112,7 +126,7 @@ test.describe("Credit", () => {
         .getByText(/Adaptive Bank/)
         .click()
 
-      const sellSidePromise = context.waitForEvent("page", {
+      const pagePromise = context.waitForEvent("page", {
         predicate: (page) => page.url().includes("credit-sellside"),
       })
 
@@ -121,7 +135,7 @@ test.describe("Credit", () => {
         .getByText(/Send RFQ/)
         .click()
 
-      const sellSidePage = await sellSidePromise
+      const sellSidePage = await pagePromise
 
       await sellSidePage.waitForSelector("text=New RFQ")
 
@@ -133,20 +147,11 @@ test.describe("Credit", () => {
         "$100",
         { timeout: 5000 },
       )
-
-      if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
-        const subWindowFrame = context
-          .pages()
-          .find((page) => page.url().includes("openfin-sub-window-frame"))
-        await subWindowFrame?.close()
-      } else {
-        await sellSidePage.close()
-      }
     })
   })
 
-  test.describe("Passing a new RFQ", () => {
-    test("pass a newly created RFQ ", async ({ context }, testInfo) => {
+  test.describe("Passing RFQ", () => {
+    test("pass a newly created RFQ ", async ({ context }) => {
       await newRfqPage.getByPlaceholder(/Enter a CUSIP/).click()
       await newRfqPage.getByTestId("search-result-item").nth(5).click()
 
@@ -169,7 +174,7 @@ test.describe("Credit", () => {
 
       const sellSidePage = await pagePromise
 
-      await sellSidePage.waitForSelector("text=New RFQ", { timeout: 10000 })
+      await sellSidePage.waitForSelector("text=New RFQ")
 
       await sellSidePage.getByRole("button", { name: "Pass" }).click()
 
@@ -177,14 +182,6 @@ test.describe("Credit", () => {
         "Passed",
         { timeout: 5000 },
       )
-      if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
-        const subWindowFrame = context
-          .pages()
-          .find((page) => page.url().includes("openfin-sub-window-frame"))
-        await subWindowFrame?.close()
-      } else {
-        await sellSidePage.close()
-      }
     })
   })
 })


### PR DESCRIPTION
Added an `afterEach` step to close all residual sell-side window for both openfin and web context. 

Tested both web and openfin ✅ 

