### PR TITLE
Test: 5581 Improve "New RFQ/Create RFQ for GOOGL @smoke" test resiliency

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -9,7 +9,7 @@ defaults:
 
 jobs:
   e2e:
-    name: End-to-end test against uat
+    name: End-to-end test against dev
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Run tests
         env:
           E2E_RTC_WEB_ROOT_URL: https://openfin.env.reactivetrader.com/pull/${{ github.event.number }}
-        run: npm run e2e:openfin credit.
+        run: npm run e2e:openfin credit.spec
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/packages/client/e2e/blotter.spec.ts
+++ b/packages/client/e2e/blotter.spec.ts
@@ -4,7 +4,7 @@ import { expect, Page } from "@playwright/test"
 import fs from "fs"
 
 import { test } from "./fixtures"
-import { OPENFIN_PROJECT_NAME } from "./utils"
+import { isOpenFin } from "./utils"
 
 const getTradeIDColIndex = () => {
   // const tradeIndex = fxColFields.indexOf(
@@ -38,8 +38,8 @@ test.describe("Trade Blotter", () => {
   let tilePage: Page
   let blotterPage: Page
 
-  test.beforeAll(async ({ context, fxPagesRec }, testInfo) => {
-    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+  test.beforeAll(async ({ context, fxPagesRec }, workerInfo) => {
+    if (isOpenFin(workerInfo)) {
       tilePage = fxPagesRec["fx-tiles"]
       blotterPage = fxPagesRec["fx-blotter"]
     } else {
@@ -54,8 +54,8 @@ test.describe("Trade Blotter", () => {
   })
 
   // eslint-disable-next-line no-empty-pattern
-  test.afterAll(async ({}, testInfo) => {
-    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+  test.afterAll(async ({}, workerInfo) => {
+    if (isOpenFin(workerInfo)) {
       await blotterPage.getByTestId("filter-button").click()
     }
   })
@@ -72,12 +72,13 @@ test.describe("Trade Blotter", () => {
   })
 
   test("when user buys a currency, the new row should flash briefly ", async () => {
-
     await tilePage.locator("input[id='notional-input-EURUSD']").clear()
-    await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
+    await tilePage
+      .locator("input[id='notional-input-EURUSD']")
+      .pressSequentially("1m")
 
     await tilePage.locator('[data-testid="Buy-EURUSD"]').nth(0).click()
-  
+
     const tradeID = await tilePage
       .locator("[data-testid='trade-id']")
       .innerText()
@@ -117,7 +118,7 @@ test.describe("Trade Blotter", () => {
     await filterButton.click()
     const searchInput = blotterPage.locator('[aria-label*="Primary filter"]')
     const tradeIDToSearch = "1"
-    await searchInput.type(tradeIDToSearch, { delay: 100 })
+    await searchInput.pressSequentially(tradeIDToSearch, { delay: 100 })
     const rows = blotterPage.locator(`[role="grid"] > div`)
     expect(await rows.count()).toBe(2)
     const firstRowTradeID = await getTradeIDCellContent(blotterPage, 1)
@@ -161,7 +162,7 @@ test.describe("Trade Blotter", () => {
     const searchInput = blotterPage.locator('[aria-label*="Primary filter"]')
 
     const tradeIDToSearch = "1"
-    await searchInput.type(tradeIDToSearch, { delay: 100 })
+    await searchInput.pressSequentially(tradeIDToSearch, { delay: 100 })
 
     const downloadPromise = blotterPage.waitForEvent("download")
 

--- a/packages/client/e2e/fixtures.ts
+++ b/packages/client/e2e/fixtures.ts
@@ -1,7 +1,7 @@
 import { chromium, Page, test as base } from "@playwright/test"
 import * as dotenv from "dotenv"
 
-import { OPENFIN_PROJECT_NAME } from "./utils"
+import { isOpenFin } from "./utils"
 
 dotenv.config({ path: ".env.development" })
 dotenv.config()
@@ -62,8 +62,9 @@ const urlPathToCreditPage = (path: string): CreditPage => {
 }
 
 export const test = base.extend<IPlaywrightFixtures>({
+  // eslint-disable-next-line no-empty-pattern
   browser: async ({}, use, workerInfo) => {
-    if (workerInfo.project.name === OPENFIN_PROJECT_NAME) {
+    if (isOpenFin(workerInfo)) {
       const runtimeConnection = await chromium.connectOverCDP(RUNTIME_ADDRESS)
       await use(runtimeConnection)
     } else {
@@ -87,7 +88,7 @@ export const test = base.extend<IPlaywrightFixtures>({
   },
   fxPagesRec: async ({ context }, use, workerInfo) => {
     const contextPages = context.pages()
-    if (workerInfo.project.name === OPENFIN_PROJECT_NAME) {
+    if (isOpenFin(workerInfo)) {
       const pages = fxOpenfinUrlPaths.reduce((rec, urlPath) => {
         const page = contextPages.find(
           (p) => p.url() === `${process.env.E2E_RTC_WEB_ROOT_URL}/${urlPath}`,
@@ -109,7 +110,7 @@ export const test = base.extend<IPlaywrightFixtures>({
   },
   creditPagesRec: async ({ context }, use, workerInfo) => {
     const contextPages = context.pages()
-    if (workerInfo.project.name === OPENFIN_PROJECT_NAME) {
+    if (isOpenFin(workerInfo)) {
       const pages = creditOpenfinUrlPaths.reduce((rec, urlPath) => {
         const page = contextPages.find(
           (p) => p.url() === `${process.env.E2E_RTC_WEB_ROOT_URL}/${urlPath}`,
@@ -131,7 +132,7 @@ export const test = base.extend<IPlaywrightFixtures>({
   },
   limitCheckerPageRec: async ({ context }, use, workerInfo) => {
     const contextPages = context.pages()
-    if (workerInfo.project.name === OPENFIN_PROJECT_NAME) {
+    if (isOpenFin(workerInfo)) {
       const page = contextPages.find(
         (p) =>
           p.url() ===

--- a/packages/client/e2e/fx.spec.ts
+++ b/packages/client/e2e/fx.spec.ts
@@ -1,15 +1,15 @@
 import { expect, Page, selectors } from "@playwright/test"
 
 import { test } from "./fixtures"
-import { OPENFIN_PROJECT_NAME } from "./utils"
+import { isOpenFin } from "./utils"
 
 test.describe("Fx App", () => {
   let mainWindow: Page
   let tilePage: Page
   let blotterPage: Page
 
-  test.beforeAll(async ({ context, fxPagesRec }, testInfo) => {
-    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+  test.beforeAll(async ({ context, fxPagesRec }, workerInfo) => {
+    if (isOpenFin(workerInfo)) {
       mainWindow = fxPagesRec["mainWindow"]
       tilePage = fxPagesRec["fx-tiles"]
       blotterPage = fxPagesRec["fx-blotter"]
@@ -27,11 +27,11 @@ test.describe("Fx App", () => {
 
   test.skip("Views should open new windows when popped out, and reattach to main window when closed", async ({
     context,
-  }, testInfo) => {
+  }, workerInfo) => {
     //TODO either adapt this test for web tear out or write a companion test
     //TODO Test is failing intermittently due to issue documented in RT-5538. Skipping the test until resolved
 
-    test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME)
+    test.skip(!isOpenFin(workerInfo), "openfin only")
 
     const popOutButtons = mainWindow.getByTitle("open in new window")
     const toggleLock = mainWindow.getByTitle("toggle layout lock")

--- a/packages/client/e2e/limit-checker.spec.ts
+++ b/packages/client/e2e/limit-checker.spec.ts
@@ -1,15 +1,20 @@
 import { Page } from "@playwright/test"
 
 import { test } from "./fixtures"
-import { assertGridCell, assertGridRow, OPENFIN_PROJECT_NAME, Timeout } from "./utils"
+import {
+  assertGridCell,
+  assertGridRow,
+  ElementTimeout,
+  isOpenFin,
+} from "./utils"
 
 test.describe("Limit Checker", () => {
   let tilePage: Page
   let blotterPage: Page
   let limitCheckerPage: Page
 
-  test.beforeAll(async ({ fxPagesRec, limitCheckerPageRec }, testInfo) => {
-    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+  test.beforeAll(async ({ fxPagesRec, limitCheckerPageRec }, workerInfo) => {
+    if (isOpenFin(workerInfo)) {
       tilePage = fxPagesRec["fx-tiles"]
       blotterPage = fxPagesRec["fx-blotter"]
       limitCheckerPage = limitCheckerPageRec
@@ -17,8 +22,8 @@ test.describe("Limit Checker", () => {
   })
 
   // eslint-disable-next-line no-empty-pattern
-  test("Trade is checked and allowed if notional is under set limit", async ({}, testInfo) => {
-    test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME, "Openfin Only")
+  test("Trade is checked and allowed if notional is under set limit", async ({}, workerInfo) => {
+    test.skip(!isOpenFin(workerInfo), "Openfin Only")
 
     const limitTableFirstRowCells = limitCheckerPage
       .locator(`[role="grid"] > div`)
@@ -55,7 +60,7 @@ test.describe("Limit Checker", () => {
     await tradeBlotterFirstRowCells
       .nth(1)
       .getByText(lastTradeId + 1 + "")
-      .waitFor({ state: "visible", timeout: Timeout.AGGRESSIVE })
+      .waitFor({ state: "visible", timeout: ElementTimeout.AGGRESSIVE })
 
     await assertGridRow({
       row: limitTableFirstRowCells,
@@ -78,8 +83,9 @@ test.describe("Limit Checker", () => {
     })
   })
 
-  test("Trade is blocked if notional is above limit", async ({}, testInfo) => {
-    test.skip(testInfo.project.name !== OPENFIN_PROJECT_NAME, "Openfin Only")
+  // eslint-disable-next-line no-empty-pattern
+  test("Trade is blocked if notional is above limit", async ({}, workerInfo) => {
+    test.skip(!isOpenFin(workerInfo), "Openfin Only")
 
     const limitTableFirstRowCells = limitCheckerPage
       .locator(`[role="grid"] > div`)

--- a/packages/client/e2e/spot-tile.spec.ts
+++ b/packages/client/e2e/spot-tile.spec.ts
@@ -1,14 +1,14 @@
 import { expect, Page } from "@playwright/test"
 
 import { test } from "./fixtures"
-import { OPENFIN_PROJECT_NAME } from "./utils"
+import { ElementTimeout, isOpenFin } from "./utils"
 
 test.describe("Spot Tile", () => {
   let tilePage: Page
   let blotterPage: Page
 
-  test.beforeAll(async ({ context, fxPagesRec }, testInfo) => {
-    if (testInfo.project.name === OPENFIN_PROJECT_NAME) {
+  test.beforeAll(async ({ context, fxPagesRec }, workerInfo) => {
+    if (isOpenFin(workerInfo)) {
       tilePage = fxPagesRec["fx-tiles"]
       blotterPage = fxPagesRec["fx-blotter"]
       tilePage.setViewportSize({ width: 1280, height: 1024 })
@@ -29,7 +29,9 @@ test.describe("Spot Tile", () => {
       await tilePage.locator("[data-testid='menuButton-EUR']").click()
 
       await tilePage.locator("input[id='notional-input-EURUSD']").clear()
-      await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
+      await tilePage
+        .locator("input[id='notional-input-EURUSD']")
+        .pressSequentially("1m")
 
       await tilePage.locator("[data-testid='Sell-EURUSD']").click()
 
@@ -85,16 +87,20 @@ test.describe("Spot Tile", () => {
       await tilePage.locator("[data-testid='rfqButton']").click()
 
       await expect(tilePage.getByTestId("rfqTimer")).toBeVisible()
-      await tilePage.getByTestId("rfqTimer").waitFor({state: "hidden", timeout: 10500})
+      await tilePage
+        .getByTestId("rfqTimer")
+        .waitFor({ state: "hidden", timeout: ElementTimeout.RFQTIMEOUT })
       const requoteBtn = tilePage.getByText(/Requote/)
-      await expect (requoteBtn).toBeVisible({timeout: 100})
+      await expect(requoteBtn).toBeVisible({ timeout: 100 })
     })
   })
 
   test.describe("Notional value", () => {
     test("When I type 1k as notional value to EUR/USD then notional value should be 1000", async () => {
       await tilePage.locator("input[id='notional-input-EURUSD']").clear()
-      await tilePage.locator("input[id='notional-input-EURUSD']").type("1k")
+      await tilePage
+        .locator("input[id='notional-input-EURUSD']")
+        .pressSequentially("1k")
       const notionalValue = await tilePage
         .locator("input[id='notional-input-EURUSD']")
         .inputValue()
@@ -103,7 +109,9 @@ test.describe("Spot Tile", () => {
 
     test("When I type 1m as notional value to EUR/USD then notional value should be 1,000,000", async () => {
       await tilePage.locator("input[id='notional-input-EURUSD']").clear()
-      await tilePage.locator("input[id='notional-input-EURUSD']").type("1m")
+      await tilePage
+        .locator("input[id='notional-input-EURUSD']")
+        .pressSequentially("1m")
       const notionalValue = await tilePage
         .locator("input[id='notional-input-EURUSD']")
         .inputValue()
@@ -114,13 +122,13 @@ test.describe("Spot Tile", () => {
       await tilePage.locator("input[id='notional-input-EURUSD']").clear()
       await tilePage
         .locator("input[id='notional-input-EURUSD']")
-        .type("1200000000")
+        .pressSequentially("1200000000")
       await expect(tilePage.getByText(/Max exceeded/)).toBeVisible()
 
       await tilePage.locator("input[id='notional-input-EURUSD']").clear()
       await tilePage
         .locator("input[id='notional-input-EURUSD']")
-        .type("1m")
+        .pressSequentially("1m")
       await expect(tilePage.getByText(/Max exceeded/)).not.toBeVisible()
     })
   })

--- a/packages/client/e2e/utils.ts
+++ b/packages/client/e2e/utils.ts
@@ -6,6 +6,10 @@ export enum Timeout {
   NORMAL = 10000,
   LONG = 20000,
 }
+export enum TestTimeout {
+  NORMAL = 30000,
+  EXTENDED = 60000
+}
 
 export const assertGridRow = async ({
   row,

--- a/packages/client/e2e/utils.ts
+++ b/packages/client/e2e/utils.ts
@@ -1,15 +1,17 @@
-import { expect, Locator } from "@playwright/test"
+import { expect, Locator, WorkerInfo } from "@playwright/test"
 
-export const OPENFIN_PROJECT_NAME = "openfin"
+export const isOpenFin = (workerInfo: WorkerInfo) =>
+  workerInfo.project.name === "openfin"
 
 export enum ElementTimeout {
   AGGRESSIVE = 5000,
   NORMAL = 15000,
-  LONG = 30000
+  LONG = 30000,
+  RFQTIMEOUT = 10500,
 }
 export enum TestTimeout {
   NORMAL = 60000,
-  EXTENDED = 90000
+  EXTENDED = 90000,
 }
 
 export const assertGridRow = async ({

--- a/packages/client/e2e/utils.ts
+++ b/packages/client/e2e/utils.ts
@@ -1,14 +1,15 @@
 import { expect, Locator } from "@playwright/test"
 
 export const OPENFIN_PROJECT_NAME = "openfin"
-export enum Timeout {
+
+export enum ElementTimeout {
   AGGRESSIVE = 5000,
-  NORMAL = 10000,
-  LONG = 20000,
+  NORMAL = 15000,
+  LONG = 30000
 }
 export enum TestTimeout {
-  NORMAL = 30000,
-  EXTENDED = 60000
+  NORMAL = 60000,
+  EXTENDED = 90000
 }
 
 export const assertGridRow = async ({

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --max-warnings 0",
     "lint:fix": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --max-warnings 0 --fix",
     "lint:cache": "npm run lint -- --cache",
-    "_format": "prettier README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
+    "_format": "prettier README.md \"src/**/*.{js,jsx,ts,tsx,json,md}\" \"e2e/**/*.ts\"",
     "format": "npm run _format -- --write",
     "format:check": "npm run _format -- --check",
     "test": "vitest",

--- a/packages/client/playwright.config.ts
+++ b/packages/client/playwright.config.ts
@@ -1,10 +1,12 @@
 import type { PlaywrightTestConfig } from "@playwright/test"
 import { devices } from "@playwright/test"
 
+import { TestTimeout } from "./e2e/utils"
+
 const config: PlaywrightTestConfig = {
   testDir: "./e2e",
   /* Maximum time one test can run for. */
-  timeout: 60_000,
+  timeout: TestTimeout.NORMAL,
   workers: 1,
   projects: [
     {


### PR DESCRIPTION
Latest investigated  PR and scheduled e2e test failure show high failure occurrences in regards to `New RFQ/Create RFQ for GOOGL @smoke` test case. 

**Facts**
1. Failures are happening more frequently on CI, while it was rarely happening when test being ran on local
2. Playwright report output is frequently about test timing out after default 30 seconds. No specific step causing the failure are reported
3. Screenshots are showing some quotes being available, but the test didn't select one for execution
4. At the moment of interacting with the UI, it may have other quotes rendering as selectable, potentially causing erratic behaviour with hoving and clicking on accept button

**Troubleshooting**
1. I've set the test to run in loop 10 times to find a frequency and to have few occurrences to better troubleshoot
2. I've temporary set a test workflow file to run the test in loop on CI for both web and openfin

**Observations**
1. Test flakiness is observable on CI with an average ratio of 1/5 (~20%)
2. Test flakiness ratio is lower on local (~5%)
4. test execution time is higher on ci than when ran locally. On CI it get > than 30 seconds on many failures
5. Locally test execution time average is around 25 seconds

**Action taken**
1. Since the total test execution time is close to 30 sec, then I increased test timeout to 60 seconds
2. To avoid lengthy failure in case it fail to click on the accept button, I added a 5 seconds timeout on quote click action. It should be there as the previous step wait for the button to be visible
3. Added retry logic in case the test failed to click on the  `accept` button. 
