### PR TITLE
fix: credit start sow, restore reset on re-connect

### DIFF
--- a/packages/client/src/services/connection.ts
+++ b/packages/client/src/services/connection.ts
@@ -68,7 +68,7 @@ const connectionMapper = (input: HConnectionStatus): ConnectionStatus =>
 // Stream of mapped (Hydra - RT) connection status
 const mappedConnectionStatus$ = hConnectionStatus$().pipe(map(connectionMapper))
 
-const IDLE_TIMEOUT = 15 * 60000
+const IDLE_TIMEOUT_MINUTES = 15
 
 // Dispose of connection and emit when idle for IDLE_TIMEOUT ms
 const idleDisconnect$: Observable<ConnectionStatus> = combineLatest([
@@ -84,9 +84,11 @@ const idleDisconnect$: Observable<ConnectionStatus> = combineLatest([
     // Only when we are connecting/ed and there is a disposable
     connectionExists(status, dispose),
   ),
-  debounceTime(IDLE_TIMEOUT),
+  debounceTime(IDLE_TIMEOUT_MINUTES * 60000),
   map(([[, dispose]]) => {
-    console.log(`User was idle for ${IDLE_TIMEOUT}, disconnecting`)
+    console.log(
+      `User was idle for ${IDLE_TIMEOUT_MINUTES} minutes .. disconnecting`,
+    )
     dispose()
     connectionDisposable$.next(() => undefined)
     return ConnectionStatus.IDLE_DISCONNECTED

--- a/packages/client/src/services/credit/creditRfqs.ts
+++ b/packages/client/src/services/credit/creditRfqs.ts
@@ -79,7 +79,7 @@ export const creditRfqsById$ = creditRfqUpdates$.pipe(
       switch (update.type) {
         case START_OF_STATE_OF_THE_WORLD_RFQ_UPDATE:
           // init state of scan is correct for start of SoW
-          return acc
+          return [false, {}]
         case END_OF_STATE_OF_THE_WORLD_RFQ_UPDATE:
           return [true, rfqs]
         case RFQ_CREATED_RFQ_UPDATE:


### PR DESCRIPTION
"cleanup" during blotter highlighting work introduced a subtle but lethal bug in the reconnect flow, where the RFQ store was not reset ... this has been restored
(for future ref, this hit us in an Error thrown in `useQuoteState` .. might want to make this a bit more lenient in future)