### PR TITLE
chore: Serialise web and openfin e2e tests execution

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -173,7 +173,7 @@ jobs:
 
   openfin-end-to-end-test-fx:
     name: Openfin e2e test - FX
-    needs: build
+    needs: web-end-to-end-test
     runs-on: windows-latest
 
     steps:
@@ -203,7 +203,7 @@ jobs:
 
   openfin-end-to-end-test-credit:
     name: Openfin e2e test - Credit
-    needs: build
+    needs: web-end-to-end-test
     runs-on: windows-latest
 
     steps:

--- a/packages/client/e2e/credit.spec.ts
+++ b/packages/client/e2e/credit.spec.ts
@@ -148,7 +148,7 @@ test.describe("Credit", () => {
 
       await sellSidePage.waitForSelector("text=New RFQ")
 
-      await sellSidePage.getByTestId("price-input").fill("100")
+      await sellSidePage.getByTestId("price-input").pressSequentially("100")
 
       await sellSidePage.keyboard.press("Enter")
 


### PR DESCRIPTION
Serializing `web` -> `openfin` e2e tests on a PR basis to prevent intermittent concurrency issues that cause false negative results

<img width="1169" alt="Screenshot 2023-10-17 at 14 44 58" src="https://github.com/AdaptiveConsulting/ReactiveTraderCloud/assets/103059406/4b4e6877-0146-450b-8acd-9c5792127dbb">
