### PR TITLE
New functions for getting newest TradeId and Status from the blotter

### DIFF
--- a/packages/client/playwright/components/blotter.component.ts
+++ b/packages/client/playwright/components/blotter.component.ts
@@ -21,34 +21,36 @@ export default class BlotterComponent extends BaseComponent {
     super(page.locator("[aria-labelledby='trades-table-heading']"), page)
   }
 
-  public async clickHeaderColumn (blotterColumnValue: BlotterColumnValue) {
-    await this.host.locator('[role="grid"] > div').first().locator("div").nth(blotterColumnValue).click()
+  public async clickHeaderColumn(blotterColumnValue: BlotterColumnValue) {
+    await this.host.locator("[role=\"grid\"] > div").first().locator("div").nth(blotterColumnValue).click()
   }
 
-  public async filterColumnByText (blotterColumnValue: BlotterColumnValue, text: string, isopen = false)  {
-    const header = this.host.locator('[role="grid"] > div').first().locator("div").nth(blotterColumnValue)
+  public async filterColumnByText(blotterColumnValue: BlotterColumnValue, text: string, isopen = false) {
+    const header = this.host.locator("[role=\"grid\"] > div").first().locator("div").nth(blotterColumnValue)
     await header.hover()
-    if(!isopen) {
-    await header.getByRole("button").click() }
+    if (!isopen) {
+      await header.getByRole("button").click()
+    }
     await header.getByRole("textbox").type(text)
   }
 
-  public async clearFilterColumn (blotterColumnValue: BlotterColumnValue, isopen = false)  {
-    const header = this.host.locator('[role="grid"] > div').first().locator("div").nth(blotterColumnValue)
+  public async clearFilterColumn(blotterColumnValue: BlotterColumnValue, isopen = false) {
+    const header = this.host.locator("[role=\"grid\"] > div").first().locator("div").nth(blotterColumnValue)
     await header.hover()
-    if(!isopen) {
-    await header.getByRole("button").click() }
+    if (!isopen) {
+      await header.getByRole("button").click()
+    }
     await header.getByRole("textbox").clear()
   }
 
-  public async getTradeCount () {
-    const rows = await this.host.locator('[role="grid"] > div').count()
+  public async getTradeCount() {
+    const rows = await this.host.locator("[role=\"grid\"] > div").count()
     // substract 1 for header row
     return rows - 1
   }
 
-  public async clickDownload (){
-    await this.host.locator('[aria-label="Export to CSV"]').click()
+  public async clickDownload() {
+    await this.host.locator("[aria-label=\"Export to CSV\"]").click()
   }
 
   public getTradeIDFromCSV = (csvRows: string | string[]): string => {
@@ -57,26 +59,40 @@ export default class BlotterComponent extends BaseComponent {
     const tradeField = firstRowFields[0]
     return tradeField
   }
-  
+
+  public async getlatestTradeId() {
+
+    const firstRow = await this.getTradeEntry(1)
+    const tradeId = firstRow.getValueByColumn(BlotterColumnValue.TRADEID)
+    return tradeId
+  }
+
+  public async getLatestStatus() {
+
+
+    const firstRow = await this.getTradeEntry(1)
+    const status = firstRow.getValueByColumn(BlotterColumnValue.STATUS)
+    return status
+  }
 
   public async getTradeEntry(rank: number) {
-    const tradeEntry = this.page.locator('[role="grid"] > div').nth(rank)
+    const tradeEntry = this.page.locator("[role=\"grid\"] > div").nth(rank)
 
     const backgroundColor = await tradeEntry.evaluate((element) => {
       return window
-       .getComputedStyle(element)
-       .getPropertyValue("background-color")
-   }) 
+        .getComputedStyle(element)
+        .getPropertyValue("background-color")
+    })
 
-   const animation = await tradeEntry.evaluate((element) => {
-    return window
-     .getComputedStyle(element)
-     .getPropertyValue("animation")
- })
-    
-   async function getValueByColumn(column: BlotterColumnValue) {
-    return await tradeEntry.locator("div").nth(column).textContent()
-  }
+    const animation = await tradeEntry.evaluate((element) => {
+      return window
+        .getComputedStyle(element)
+        .getPropertyValue("animation")
+    })
+
+    async function getValueByColumn(column: BlotterColumnValue) {
+      return await tradeEntry.locator("div").nth(column).textContent()
+    }
 
     async function hover() {
       await tradeEntry.hover()
@@ -84,4 +100,6 @@ export default class BlotterComponent extends BaseComponent {
 
     return { getValueByColumn, hover, backgroundColor, animation }
   }
+
+
 }

--- a/packages/client/playwright/components/blotter.component.ts
+++ b/packages/client/playwright/components/blotter.component.ts
@@ -67,7 +67,7 @@ export default class BlotterComponent extends BaseComponent {
     return tradeId
   }
 
-  public async getLatestStatus() {
+  public async getLatestTradeStatus() {
 
 
     const firstRow = await this.getTradeEntry(1)

--- a/packages/client/playwright/tests/spot-tile.spec.ts
+++ b/packages/client/playwright/tests/spot-tile.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-empty-pattern */
-import { BlotterColumnValue } from "../components/Blotter.component"
 import { CurrencyPair, Side } from "../components/SpotTile.component"
 import { expect, test } from "../pageFixture"
 import FxPage from "../pages/fx.page"
@@ -22,13 +21,11 @@ test.describe("FX purchase", () => {
 
       await expect(eurusdTile.confirmationDialogGreen).toBeVisible()
       const tileTradeId = await eurusdTile.getTradeId()
-
-      const firstRow = await page.blotterComponent.getTradeEntry(1)
-      const blotterTradeId = await firstRow.getValueByColumn(
-        BlotterColumnValue.TRADEID,
-      )
+      const blotterTradeId = await page.blotterComponent.getlatestTradeId()
+      const blotterStatus = await page.blotterComponent.getLatestStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
+      expect(blotterStatus).toBe("Done")
     })
 
     test("When I buy USD/JPY then a tile displays in green with confirmation message", async ({}) => {
@@ -54,12 +51,11 @@ test.describe("FX purchase", () => {
       await expect(gbpjpyTile.confirmationDialogRed).toBeVisible()
       const tileTradeId = await gbpjpyTile.getTradeId()
 
-      const firstRow = await page.blotterComponent.getTradeEntry(1)
-      const blotterTradeId = await firstRow.getValueByColumn(
-        BlotterColumnValue.TRADEID,
-      )
+      const blotterTradeId = await page.blotterComponent.getlatestTradeId()
+      const blotterStatus = await page.blotterComponent.getLatestStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
+      expect(blotterStatus).toBe("Rejected")
     })
   })
 
@@ -76,12 +72,11 @@ test.describe("FX purchase", () => {
       await expect(eurjpyTile.confirmationDialogGreen).toBeVisible()
       const tileTradeId = await eurjpyTile.getTradeId()
 
-      const firstRow = await page.blotterComponent.getTradeEntry(1)
-      const blotterTradeId = await firstRow.getValueByColumn(
-        BlotterColumnValue.TRADEID,
-      )
+      const blotterTradeId = await page.blotterComponent.getlatestTradeId()
+      const blotterStatus = await page.blotterComponent.getLatestStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
+      expect(blotterStatus).toBe("Done")
     })
   })
 

--- a/packages/client/playwright/tests/spot-tile.spec.ts
+++ b/packages/client/playwright/tests/spot-tile.spec.ts
@@ -22,7 +22,7 @@ test.describe("FX purchase", () => {
       await expect(eurusdTile.confirmationDialogGreen).toBeVisible()
       const tileTradeId = await eurusdTile.getTradeId()
       const blotterTradeId = await page.blotterComponent.getlatestTradeId()
-      const blotterStatus = await page.blotterComponent.getLatestStatus()
+      const blotterStatus = await page.blotterComponent.getLatestTradeStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
       expect(blotterStatus).toBe("Done")
@@ -52,7 +52,7 @@ test.describe("FX purchase", () => {
       const tileTradeId = await gbpjpyTile.getTradeId()
 
       const blotterTradeId = await page.blotterComponent.getlatestTradeId()
-      const blotterStatus = await page.blotterComponent.getLatestStatus()
+      const blotterStatus = await page.blotterComponent.getLatestTradeStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
       expect(blotterStatus).toBe("Rejected")
@@ -73,7 +73,7 @@ test.describe("FX purchase", () => {
       const tileTradeId = await eurjpyTile.getTradeId()
 
       const blotterTradeId = await page.blotterComponent.getlatestTradeId()
-      const blotterStatus = await page.blotterComponent.getLatestStatus()
+      const blotterStatus = await page.blotterComponent.getLatestTradeStatus()
 
       expect(tileTradeId).toBe(blotterTradeId)
       expect(blotterStatus).toBe("Done")


### PR DESCRIPTION
Removed the code to retrieve the latest TradeId from the Spec file and moved it to the blotter Component. Also created a similar function to retrieve the newly created Trade Status (to verify specially the rejected Trades). 