### PR TITLE
chore: update hydra-platform to 4.57.0, rework connection

### DIFF
--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "reactive-trader-cloud",
       "dependencies": {
-        "@adaptive/hydra-platform": "4.12.0",
+        "@adaptive/hydra-platform": "4.57.0",
         "@finos/fdc3": "^1.2.0",
         "@openfin/core": "31.75.4",
         "@openfin/workspace": "13.0.7",
@@ -34,6 +34,7 @@
         "styled-components": "5.3.9"
       },
       "devDependencies": {
+        "@adaptive/hydra-web-codegen": "4.57.0",
         "@google-cloud/dialogflow": "^4.7.0",
         "@openfin/automation-cli": "1.2.0",
         "@playwright/test": "1.39.0",
@@ -85,10 +86,14 @@
         "node": "> 20.5.0"
       }
     },
-    "node_modules/@adaptive/hydra-codecs": {
-      "version": "4.12.0",
-      "resolved": "https://weareadaptive.jfrog.io/artifactory/api/npm/hydra-web/@adaptive/hydra-codecs/-/@adaptive/hydra-codecs-4.12.0.tgz",
-      "integrity": "sha512-FBtk604bJU3Np8y3p25Oc2JMURG0SdaEmXu6q9dwOL1PwQFXmdeNBZ4sc6z+Y2nzQjgtI1BIXmCFT7cAMcGmyg==",
+    "../../../../hydra/hydra1/web-proj/packages/hydra-codecs": {
+      "extraneous": true
+    },
+    "../../../../hydra/hydra1/web-proj/packages/hydra-web-codecs": {
+      "name": "@adaptive/hydra-codecs",
+      "version": "4.34.0-SNAPSHOT",
+      "extraneous": true,
+      "license": "COMMERCIAL",
       "dependencies": {
         "commander": "^7.1.0",
         "jsbi": "4.1.0",
@@ -96,20 +101,49 @@
       },
       "bin": {
         "hydra-web-codegen": "cli/hydra-web-codegen"
+      },
+      "devDependencies": {
+        "@types/text-encoding": "^0.0.35",
+        "@typescript-eslint/eslint-plugin": "^6.13.1",
+        "@typescript-eslint/parser": "^6.13.1",
+        "eslint": "^7.10.0",
+        "lint-staged": "^12.3.4",
+        "prettier": "^2.1.2",
+        "rimraf": "^3.0.2",
+        "typescript": "^5.2.0"
+      }
+    },
+    "node_modules/@adaptive/hydra-codecs": {
+      "version": "4.57.0",
+      "resolved": "https://weareadaptive.jfrog.io/artifactory/api/npm/hydra-web/@adaptive/hydra-codecs/-/@adaptive/hydra-codecs-4.57.0.tgz",
+      "integrity": "sha512-4L1+tJ8/KqZ4M4whEN21InEZwfgp0wldQTdzmdrcD9hvGqTV7UoBwY2oIE0XOL3Uq2pnQ2yaZTKRTmR1uj6qCg==",
+      "dependencies": {
+        "jsbi": "4.1.0"
       }
     },
     "node_modules/@adaptive/hydra-platform": {
-      "version": "4.12.0",
-      "resolved": "https://weareadaptive.jfrog.io/artifactory/api/npm/hydra-web/@adaptive/hydra-platform/-/@adaptive/hydra-platform-4.12.0.tgz",
-      "integrity": "sha512-yYhzG+A55VpjWlbwP3fJm9bFksflFkydfIG1UUc14w5uEPKsBMFlrFceq6Zfvuy8ExDP3sAWXjUgUMeH0tkskg==",
+      "version": "4.57.0",
+      "resolved": "https://weareadaptive.jfrog.io/artifactory/api/npm/hydra-web/@adaptive/hydra-platform/-/@adaptive/hydra-platform-4.57.0.tgz",
+      "integrity": "sha512-5M5GlnjC6lC1ryrEC+ZdtMQ0T0wgunrFZE2xCY7fkBCb/voFet5tg55seiUSe9be4jCP96Fjj+QM5Em30a4J7Q==",
       "dependencies": {
-        "@adaptive/hydra-codecs": "4.12.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "@adaptive/hydra-codecs": "4.57.0"
       },
       "peerDependencies": {
         "rxjs": "^7.0.0"
+      }
+    },
+    "node_modules/@adaptive/hydra-web-codegen": {
+      "version": "4.57.0",
+      "resolved": "https://weareadaptive.jfrog.io/artifactory/api/npm/hydra-web/@adaptive/hydra-web-codegen/-/@adaptive/hydra-web-codegen-4.57.0.tgz",
+      "integrity": "sha512-jFq+3ZMvQ+JFeIePS5fnnT73jIjS6wVtG5+xK5en0DCaeBqd7BxYZYleG6QplpP5j4kdLUzANmAHT1RXhXcCzQ==",
+      "dev": true,
+      "dependencies": {
+        "@adaptive/hydra-codecs": "4.57.0",
+        "commander": "^7.1.0",
+        "ts-morph": "^10.0.1"
+      },
+      "bin": {
+        "hydra-web-codegen": "cli/hydra-web-codegen"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4101,6 +4135,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -4112,6 +4147,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4119,6 +4155,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -8085,6 +8122,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.9.2.tgz",
       "integrity": "sha512-IPyg+c3Am0EBoa63W0f/AKeLrJhvzMzQ4BIvD1baxLopmiHOj1HFTXYxC6e8iTZ+UYtN+/WFM9UyGRnoA20b8g==",
+      "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.5",
         "minimatch": "^3.0.4",
@@ -10494,6 +10532,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -11016,7 +11055,8 @@
     "node_modules/code-block-writer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
-      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw=="
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
@@ -11069,6 +11109,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -14008,6 +14049,7 @@
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -14038,6 +14080,7 @@
     },
     "node_modules/fastq": {
       "version": "1.11.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -14141,6 +14184,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -15044,6 +15088,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -15953,6 +15998,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15992,6 +16038,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -16061,6 +16108,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -19719,6 +19767,7 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -19735,6 +19784,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.1",
@@ -19876,6 +19926,7 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -21278,7 +21329,8 @@
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -21970,6 +22022,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22986,6 +23039,7 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -23347,6 +23401,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24600,6 +24655,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -24773,6 +24829,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.1.0.tgz",
       "integrity": "sha512-hfskRPAbc+N1+2QvPLvJ0MOrhcwxJuBlCbX+D+9T7UnrZZqsdbmWb6FfywQ7sghyqwok6Pc8ZPwzaumlOJ8OBA==",
+      "dev": true,
       "dependencies": {
         "@ts-morph/common": "~0.9.2",
         "code-block-writer": "^10.1.1"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,17 +58,17 @@
     "workspace:start:preview": "npm:openfin:build && concurrently \"npm:serve\" \"npm:workspace:run\"",
     "finsemble:dev": "cross-env TARGET=finsemble vite",
     "finsemble:build": "cross-env TARGET=finsemble vite build",
-    "generateCod": "hydra-web-codegen -i trading-gateway.hyer -o src/generated",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "cross-env STORYBOOK=true storybook build -o ./dist/storybook",
     "_e2e:openfin:run": "cross-env-shell of-automation $npm_config_manifest_url ./e2e/openfin.spec.js --chromeDriverOverride=122 --devToolsPort=9091 --closeRuntime=never",
     "e2e:openfin": "playwright test --project=openfin",
     "e2e:openfin:smoke": "playwright test --project=openfin --grep @smoke",
     "e2e:web": "playwright test --project=chrome",
-    "e2e:web:smoke": "playwright test --project=chrome --grep @smoke"
+    "e2e:web:smoke": "playwright test --project=chrome --grep @smoke",
+    "generateCod": "hydra-web-codegen -i ../../trading-gateway.hyer -o src/generated"
   },
   "dependencies": {
-    "@adaptive/hydra-platform": "4.12.0",
+    "@adaptive/hydra-platform": "4.57.0",
     "@finos/fdc3": "^1.2.0",
     "@openfin/core": "31.75.4",
     "@openfin/workspace": "13.0.7",
@@ -96,6 +96,7 @@
     "styled-components": "5.3.9"
   },
   "devDependencies": {
+    "@adaptive/hydra-web-codegen": "4.57.0",
     "@google-cloud/dialogflow": "^4.7.0",
     "@openfin/automation-cli": "1.2.0",
     "@playwright/test": "1.39.0",

--- a/packages/client/src/client/OpenFin/apps/Launcher/NlpSuggestions/intents/index.tsx
+++ b/packages/client/src/client/OpenFin/apps/Launcher/NlpSuggestions/intents/index.tsx
@@ -1,4 +1,4 @@
-import { BASE_URL, ROUTES_CONFIG } from "@/client/constants"
+import { ROUTES_CONFIG } from "@/client/constants"
 import { constructUrl } from "@/client/utils/constructUrl"
 import { openWindow } from "@/client/utils/window/openWindow"
 import { NlpIntent, NlpIntentType } from "@/services/nlp"

--- a/packages/client/src/workspace/provider.ts
+++ b/packages/client/src/workspace/provider.ts
@@ -58,7 +58,7 @@ async function init() {
 
   const simulatedDealersSubscription = registerSimulatedDealerResponses()
 
-  await initConnection()
+  initConnection()
 
   const providerWindow = fin.Window.getCurrentSync()
   providerWindow.once("close-requested", async () => {


### PR DESCRIPTION
- Update to latest hydra web libs
- Use direct Hydra address (wss://...) rather than Nginx or local proxy - that part of deployment to be retired soon
- Separate codegen as dev dependency
- re-run codegen
- re-work connection to use new connectToTradingGateway
See web deployment [here](https://web.env.reactivetrader.com/branch/chore_update-hydra)
