### PR TITLE
chore: run E2E from Prod code against Prod deployment

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "current-prod"
 
       - name: Set Node version
         uses: actions/setup-node@v4


### PR DESCRIPTION
use static tag to identify Prod current commit - and check this code out in the Prod E2E workflow