### PR TITLE
fix: stop bubble graph duplicating on reconnect

### DIFF
--- a/packages/client/src/client/App/Analytics/Positions/BubbleChart.tsx
+++ b/packages/client/src/client/App/Analytics/Positions/BubbleChart.tsx
@@ -176,7 +176,10 @@ const d3Effect = (chartDiv: HTMLDivElement) => {
     force.restart().alpha(0.5).nodes(nodes)
   })
 
-  return () => subscription.unsubscribe()
+  return () => {
+    select(chartDiv).select("svg").remove()
+    subscription.unsubscribe()
+  }
 }
 
 export const BubbleChart = () => {


### PR DESCRIPTION
Seemed to just need tear down logic for deleting the graph